### PR TITLE
[docs-infra] Add small design polish

### DIFF
--- a/docs/pages/experiments/website/branding-theme-test.tsx
+++ b/docs/pages/experiments/website/branding-theme-test.tsx
@@ -52,6 +52,9 @@ export default function BrandingThemeTest() {
             <IconButton color="info">
               <GitHubIcon fontSize="small" />
             </IconButton>
+            <IconButton>
+              <GitHubIcon fontSize="small" />
+            </IconButton>
           </Stack>
         </Section>
         <Divider />

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-restricted-globals */
+/* eslint-disable material-ui/no-hardcoded-labels */
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { useTheme } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
 // Components
 import DialogActions from '@mui/material/DialogActions';
 import TextField from '@mui/material/TextField';
@@ -20,12 +21,35 @@ import ThumbDownAltRoundedIcon from '@mui/icons-material/ThumbDownAltRounded';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import PanToolRoundedIcon from '@mui/icons-material/PanToolRounded';
+import ArrowOutwardRoundedIcon from '@mui/icons-material/ArrowOutwardRounded';
+import XIcon from '@mui/icons-material/X';
+import YouTubeIcon from '@mui/icons-material/YouTube';
+import RssFeedIcon from '@mui/icons-material/RssFeed';
+import DiscordIcon from 'docs/src/icons/DiscordIcon';
 // Other imports
 import { Link } from '@mui/docs/Link';
 import PageContext from 'docs/src/modules/components/PageContext';
+import SvgMuiLogotype from 'docs/src/icons/SvgMuiLogotype';
 import EditPage from 'docs/src/modules/components/EditPage';
 import { useUserLanguage, useTranslate } from '@mui/docs/i18n';
 import { getCookie, pageToTitleI18n } from 'docs/src/modules/utils/helpers';
+
+const FooterLink = styled(Link)(({ theme }) => {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 2,
+    fontFamily: (theme.vars || theme).typography.fontFamily,
+    fontSize: (theme.vars || theme).typography.pxToRem(13),
+    fontWeight: (theme.vars || theme).typography.fontWeightMedium,
+    color: (theme.vars || theme).palette.primary[600],
+    '& > svg': { fontSize: '13px', transition: '0.2s' },
+    '&:hover > svg': { transform: 'translateX(2px)' },
+    ...theme.applyDarkStyles({
+      color: (theme.vars || theme).palette.primary[300],
+    }),
+  };
+});
 
 /**
  * @typedef {import('docs/src/pages').MuiPage} MuiPage
@@ -231,6 +255,8 @@ const EMPTY_SECTION = { hash: '', text: '' };
 // This dead code is here to simplify the creation of special feedback channel
 const SPEACIAL_FEEDBACK_HASH = [{ hash: 'new-docs-api-feedback', text: 'New API content design' }];
 
+const iconColor = 'grey.500';
+
 export default function AppLayoutDocsFooter(props) {
   const { tableOfContents = [], location } = props;
 
@@ -368,40 +394,6 @@ export default function AppLayoutDocsFooter(props) {
   return (
     <React.Fragment>
       <Stack component="footer" direction="column" sx={{ my: 4 }}>
-        {hidePagePagination ? null : (
-          <Stack direction="row" justifyContent="space-between">
-            {prevPage !== null ? (
-              <Button
-                size="small"
-                variant="text"
-                component={Link}
-                noLinkStyle
-                prefetch={false}
-                href={prevPage.pathname}
-                {...prevPage.linkProps}
-                startIcon={<ChevronLeftIcon />}
-              >
-                {pageToTitleI18n(prevPage, t)}
-              </Button>
-            ) : (
-              <div />
-            )}
-            {nextPage !== null ? (
-              <Button
-                size="small"
-                component={Link}
-                noLinkStyle
-                prefetch={false}
-                href={nextPage.pathname}
-                {...nextPage.linkProps}
-                endIcon={<ChevronRightIcon />}
-              >
-                {pageToTitleI18n(nextPage, t)}
-              </Button>
-            ) : null}
-          </Stack>
-        )}
-        <Divider sx={{ my: 2 }} />
         <Stack
           direction={{ xs: 'column', sm: 'row' }}
           alignItems="center"
@@ -409,12 +401,12 @@ export default function AppLayoutDocsFooter(props) {
           spacing={{ xs: 3, sm: 1 }}
         >
           <EditPage sourceLocation={location} />
-          <Stack direction="row" alignItems="center" spacing={1} useFlexGap>
+          <Stack direction="row" alignItems="center" spacing={0.5} useFlexGap>
             <Typography id="feedback-message" variant="body2" color="text.secondary">
               {t('feedbackMessage')}
             </Typography>
             <Tooltip title={t('feedbackYes')}>
-              <IconButton color="info" onClick={handleClickThumb(1)} aria-pressed={rating === 1}>
+              <IconButton onClick={handleClickThumb(1)} aria-pressed={rating === 1}>
                 <ThumbUpAltRoundedIcon
                   color={rating === 1 ? 'primary' : undefined}
                   sx={{ fontSize: 15 }}
@@ -422,7 +414,7 @@ export default function AppLayoutDocsFooter(props) {
               </IconButton>
             </Tooltip>
             <Tooltip title={t('feedbackNo')}>
-              <IconButton color="info" onClick={handleClickThumb(0)} aria-pressed={rating === 0}>
+              <IconButton onClick={handleClickThumb(0)} aria-pressed={rating === 0}>
                 <ThumbDownAltRoundedIcon
                   color={rating === 0 ? 'error' : undefined}
                   sx={{ fontSize: 15 }}
@@ -514,6 +506,106 @@ export default function AppLayoutDocsFooter(props) {
             </form>
           </Collapse>
         </div>
+        <Divider sx={{ my: 2 }} />
+        {hidePagePagination ? null : (
+          <Stack direction="row" justifyContent="space-between">
+            {prevPage !== null ? (
+              <Button
+                size="small"
+                variant="text"
+                component={Link}
+                noLinkStyle
+                prefetch={false}
+                href={prevPage.pathname}
+                {...prevPage.linkProps}
+                startIcon={<ChevronLeftIcon />}
+              >
+                {pageToTitleI18n(prevPage, t)}
+              </Button>
+            ) : (
+              <div />
+            )}
+            {nextPage !== null ? (
+              <Button
+                size="small"
+                component={Link}
+                noLinkStyle
+                prefetch={false}
+                href={nextPage.pathname}
+                {...nextPage.linkProps}
+                endIcon={<ChevronRightIcon />}
+              >
+                {pageToTitleI18n(nextPage, t)}
+              </Button>
+            ) : null}
+          </Stack>
+        )}
+        <Divider sx={{ my: 2 }} />
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          alignItems="center"
+          spacing={{ xs: 3, sm: 1 }}
+        >
+          <Stack direction="row" alignItems="center" spacing={1} useFlexGap sx={{ flexGrow: 1 }}>
+            <Link href="https://mui.com/" aria-label="Go to homepage">
+              <SvgMuiLogotype height={28} width={64} />
+            </Link>
+            <Typography color="grey.500" fontSize={13} sx={{ opacity: '70%' }}>
+              &bull;
+            </Typography>
+            <FooterLink href="https://mui.com/blog/" target="_blank" rel="noopener">
+              Blog <ArrowOutwardRoundedIcon />
+            </FooterLink>
+            <Typography color="grey.500" fontSize={13} sx={{ opacity: '70%' }}>
+              &bull;
+            </Typography>
+            <FooterLink href="https://mui.com/store/" target="_blank" rel="noopener">
+              Store <ArrowOutwardRoundedIcon />
+            </FooterLink>
+          </Stack>
+          <Stack spacing={1} direction="row" useFlexGap>
+            <IconButton
+              target="_blank"
+              rel="noopener"
+              href="https://twitter.com/MUI_hq"
+              aria-label="twitter"
+              title="X"
+              size="small"
+            >
+              <XIcon fontSize="small" sx={{ color: iconColor }} />
+            </IconButton>
+            <IconButton
+              target="_blank"
+              rel="noopener"
+              href="https://mui.com/r/discord/"
+              aria-label="Discord"
+              title="Discord"
+              size="small"
+            >
+              <DiscordIcon fontSize="small" sx={{ color: iconColor }} />
+            </IconButton>
+            <IconButton
+              target="_blank"
+              rel="noopener"
+              href="https://www.youtube.com/@MUI_hq"
+              aria-label="YouTube"
+              title="YouTube"
+              size="small"
+            >
+              <YouTubeIcon fontSize="small" sx={{ color: iconColor }} />
+            </IconButton>
+            <IconButton
+              target="_blank"
+              rel="noopener"
+              href="https://mui.com/feed/blog/rss.xml"
+              aria-label="RSS Feed"
+              title="RSS Feed"
+              size="small"
+            >
+              <RssFeedIcon fontSize="small" sx={{ color: iconColor }} />
+            </IconButton>
+          </Stack>
+        </Stack>
       </Stack>
       <Snackbar
         open={snackbarOpen}

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -2,7 +2,7 @@
 /* eslint-disable material-ui/no-hardcoded-labels */
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { styled, useTheme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
 // Components
 import DialogActions from '@mui/material/DialogActions';
 import TextField from '@mui/material/TextField';
@@ -21,34 +21,12 @@ import ThumbDownAltRoundedIcon from '@mui/icons-material/ThumbDownAltRounded';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import PanToolRoundedIcon from '@mui/icons-material/PanToolRounded';
-import XIcon from '@mui/icons-material/X';
-import YouTubeIcon from '@mui/icons-material/YouTube';
-import RssFeedIcon from '@mui/icons-material/RssFeed';
-import ArrowOutwardRoundedIcon from '@mui/icons-material/ArrowOutwardRounded';
-import DiscordIcon from 'docs/src/icons/DiscordIcon';
 // Other imports
 import { Link } from '@mui/docs/Link';
 import PageContext from 'docs/src/modules/components/PageContext';
 import EditPage from 'docs/src/modules/components/EditPage';
-import SvgMuiLogotype from 'docs/src/icons/SvgMuiLogotype';
 import { useUserLanguage, useTranslate } from '@mui/docs/i18n';
 import { getCookie, pageToTitleI18n } from 'docs/src/modules/utils/helpers';
-
-const FooterLink = styled(Typography)(({ theme }) => {
-  return {
-    ...theme.typography.body2,
-    display: 'flex',
-    alignItems: 'center',
-    gap: 4,
-    fontWeight: (theme.vars || theme).typography.fontWeightSemiBold,
-    color: (theme.vars || theme).palette.primary[600],
-    '& > svg': { transition: '0.2s' },
-    '&:hover > svg': { transform: 'translateX(2px)' },
-    ...theme.applyDarkStyles({
-      color: (theme.vars || theme).palette.primary[300],
-    }),
-  };
-});
 
 /**
  * @typedef {import('docs/src/pages').MuiPage} MuiPage
@@ -390,7 +368,41 @@ export default function AppLayoutDocsFooter(props) {
 
   return (
     <React.Fragment>
-      <Stack component="footer" direction="column" spacing={2.5} sx={{ my: 6 }}>
+      <Stack component="footer" direction="column" sx={{ my: 4 }}>
+        {hidePagePagination ? null : (
+          <Stack direction="row" justifyContent="space-between">
+            {prevPage !== null ? (
+              <Button
+                size="small"
+                variant="text"
+                component={Link}
+                noLinkStyle
+                prefetch={false}
+                href={prevPage.pathname}
+                {...prevPage.linkProps}
+                startIcon={<ChevronLeftIcon />}
+              >
+                {pageToTitleI18n(prevPage, t)}
+              </Button>
+            ) : (
+              <div />
+            )}
+            {nextPage !== null ? (
+              <Button
+                size="small"
+                component={Link}
+                noLinkStyle
+                prefetch={false}
+                href={nextPage.pathname}
+                {...nextPage.linkProps}
+                endIcon={<ChevronRightIcon />}
+              >
+                {pageToTitleI18n(nextPage, t)}
+              </Button>
+            ) : null}
+          </Stack>
+        )}
+        <Divider sx={{ my: 2 }} />
         <Stack
           direction={{ xs: 'column', sm: 'row' }}
           alignItems="center"
@@ -399,12 +411,7 @@ export default function AppLayoutDocsFooter(props) {
         >
           <EditPage sourceLocation={location} />
           <Stack direction="row" alignItems="center" spacing={1} useFlexGap>
-            <Typography
-              id="feedback-message"
-              variant="body2"
-              fontWeight="medium"
-              color="text.secondary"
-            >
+            <Typography id="feedback-message" variant="body2" color="text.secondary">
               {t('feedbackMessage')}
             </Typography>
             <Tooltip title={t('feedbackYes')}>
@@ -433,6 +440,7 @@ export default function AppLayoutDocsFooter(props) {
             onEntered={handleEntered}
             timeout={{ enter: 0, exit: theme.transitions.duration.standard }}
           >
+            <Divider sx={{ my: 2, borderStyle: 'dashed' }} />
             {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
             <form
               aria-labelledby="feedback-message"
@@ -454,7 +462,7 @@ export default function AppLayoutDocsFooter(props) {
                     }}
                   />
                 ) : (
-                  <Typography variant="body2" id="feedback-description" color="text.secondary">
+                  <Typography id="feedback-description" color="text.secondary">
                     {rating === 1 ? t('feedbackMessageUp') : t('feedbackMessageDown')}
                   </Typography>
                 )}
@@ -463,7 +471,7 @@ export default function AppLayoutDocsFooter(props) {
                   margin="dense"
                   name="comment"
                   fullWidth
-                  rows={4}
+                  rows={2}
                   value={comment}
                   onChange={handleChangeTextfield}
                   inputProps={{
@@ -507,110 +515,6 @@ export default function AppLayoutDocsFooter(props) {
             </form>
           </Collapse>
         </div>
-        <Divider />
-        {hidePagePagination ? null : (
-          <Stack direction="row" justifyContent="space-between" sx={{ my: 2 }}>
-            {prevPage !== null ? (
-              <Button
-                size="small"
-                variant="text"
-                component={Link}
-                noLinkStyle
-                prefetch={false}
-                href={prevPage.pathname}
-                {...prevPage.linkProps}
-                startIcon={<ChevronLeftIcon />}
-              >
-                {pageToTitleI18n(prevPage, t)}
-              </Button>
-            ) : (
-              <div />
-            )}
-            {nextPage !== null ? (
-              <Button
-                size="small"
-                component={Link}
-                noLinkStyle
-                prefetch={false}
-                href={nextPage.pathname}
-                {...nextPage.linkProps}
-                endIcon={<ChevronRightIcon />}
-              >
-                {pageToTitleI18n(nextPage, t)}
-              </Button>
-            ) : null}
-          </Stack>
-        )}
-        <Divider />
-        <Stack
-          direction={{ xs: 'column', sm: 'row' }}
-          alignItems="center"
-          spacing={{ xs: 3, sm: 1 }}
-        >
-          <Stack direction="row" alignItems="center" spacing={1.2} useFlexGap sx={{ flexGrow: 1 }}>
-            <Link href="https://mui.com/" aria-label="Go to homepage">
-              <SvgMuiLogotype height={24} width={72} />
-            </Link>
-            <Typography color="grey.500" fontSize={13} sx={{ opacity: '70%' }}>
-              &bull;
-            </Typography>
-            <Link href="https://mui.com/blog/" target="_blank" rel="noopener">
-              <FooterLink>
-                Blog <ArrowOutwardRoundedIcon sx={{ fontSize: 14 }} />
-              </FooterLink>
-            </Link>
-            <Typography color="grey.500" fontSize={13} sx={{ opacity: '70%' }}>
-              &bull;
-            </Typography>
-            <Link href="https://mui.com/store/" target="_blank" rel="noopener">
-              <FooterLink>
-                Store <ArrowOutwardRoundedIcon sx={{ fontSize: 14 }} />
-              </FooterLink>
-            </Link>
-          </Stack>
-          <Stack spacing={1} direction="row" useFlexGap>
-            <IconButton
-              target="_blank"
-              rel="noopener"
-              href="https://mui.com/feed/blog/rss.xml"
-              aria-label="RSS Feed"
-              title="RSS Feed"
-              size="small"
-            >
-              <RssFeedIcon fontSize="small" sx={{ color: 'grey.500' }} />
-            </IconButton>
-            <IconButton
-              target="_blank"
-              rel="noopener"
-              href="https://twitter.com/MUI_hq"
-              aria-label="twitter"
-              title="X"
-              size="small"
-            >
-              <XIcon fontSize="small" sx={{ color: 'grey.500' }} />
-            </IconButton>
-            <IconButton
-              target="_blank"
-              rel="noopener"
-              href="https://www.youtube.com/@MUI_hq"
-              aria-label="YouTube"
-              title="YouTube"
-              size="small"
-            >
-              <YouTubeIcon fontSize="small" sx={{ color: 'grey.500' }} />
-            </IconButton>
-            <IconButton
-              target="_blank"
-              rel="noopener"
-              href="https://mui.com/r/discord/"
-              aria-label="Discord"
-              title="Discord"
-              size="small"
-            >
-              <DiscordIcon fontSize="small" sx={{ color: 'grey.500' }} />
-            </IconButton>
-          </Stack>
-        </Stack>
       </Stack>
       <Snackbar
         open={snackbarOpen}

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-restricted-globals */
-/* eslint-disable material-ui/no-hardcoded-labels */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useTheme } from '@mui/material/styles';

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -63,7 +63,7 @@ const Item = styled(
         marginTop: theme.spacing(1),
         textTransform: 'uppercase',
         letterSpacing: '.1rem',
-        fontWeight: theme.typography.fontWeightBold,
+        fontWeight: theme.typography.fontWeightSemiBold,
         fontSize: theme.typography.pxToRem(11),
         '&::before': {
           content: '""',
@@ -144,7 +144,7 @@ const Item = styled(
     theme.applyDarkStyles({
       ...color,
       '&::before': {
-        background: alpha(theme.palette.primaryDark[500], 0.3),
+        background: (theme.vars || theme).palette.primaryDark[700],
       },
       '&.app-drawer-active': {
         color: (theme.vars || theme).palette.primary[300],
@@ -159,7 +159,7 @@ const Item = styled(
       },
       ...(subheader && {
         '&::before': {
-          background: alpha(theme.palette.primaryDark[700], 0.6),
+          background: (theme.vars || theme).palette.primaryDark[700],
         },
         '&::after': {
           background: alpha(theme.palette.primaryDark[700], 0.8),

--- a/docs/src/modules/components/AppSettingsDrawer.js
+++ b/docs/src/modules/components/AppSettingsDrawer.js
@@ -20,7 +20,7 @@ import { useTranslate } from '@mui/docs/i18n';
 
 const Heading = styled(Typography)(({ theme }) => ({
   margin: '16px 0 8px',
-  fontWeight: theme.typography.fontWeightBold,
+  fontWeight: theme.typography.fontWeightSemiBold,
   fontSize: theme.typography.pxToRem(11),
   textTransform: 'uppercase',
   letterSpacing: '.1rem',

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -32,7 +32,7 @@ const Nav = styled('nav')(({ theme }) => ({
 const NavLabel = styled(Typography)(({ theme }) => ({
   padding: theme.spacing(1, 0, 1, 1.4),
   fontSize: theme.typography.pxToRem(11),
-  fontWeight: theme.typography.fontWeightBold,
+  fontWeight: theme.typography.fontWeightSemiBold,
   textTransform: 'uppercase',
   letterSpacing: '.1rem',
   color: (theme.vars || theme).palette.text.tertiary,

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -31,7 +31,7 @@ const NativeLink = styled('a')(({ theme }) => ({
   ...theme.applyDarkStyles({
     boxShadow: `${alpha(theme.palette.primaryDark[600], 0.1)} 0 2px 0 inset, ${(theme.vars || theme).palette.common.black} 0 -2px 0 inset`,
     '&:hover': {
-      backgroundColor: (theme.vars || theme).palette.primaryDark[800],
+      backgroundColor: alpha(theme.palette.primary[800], 0.2),
       borderColor: (theme.vars || theme).palette.primary[900],
     },
   }),

--- a/docs/src/modules/components/EditPage.js
+++ b/docs/src/modules/components/EditPage.js
@@ -24,7 +24,7 @@ export default function EditPage(props) {
     <Button
       component="a"
       size="small"
-      variant="outlined"
+      variant="text"
       color="secondary"
       startIcon={<GitHubIcon sx={{ mr: 0.5 }} />}
       href={
@@ -40,7 +40,6 @@ export default function EditPage(props) {
       data-ga-event-category={userLanguage === 'en' ? undefined : 'l10n'}
       data-ga-event-action={userLanguage === 'en' ? undefined : 'edit-button'}
       data-ga-event-label={userLanguage === 'en' ? undefined : userLanguage}
-      sx={{ '&:hover > span': { transform: 'translateX(-2px)' } }}
     >
       {t('editPage')}
     </Button>

--- a/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
+++ b/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
@@ -549,7 +549,7 @@ const Root = styled('div')(
       border: '1px solid',
       borderColor: alpha(lightTheme.palette.primaryDark[600], 0.5),
       backgroundColor: alpha(lightTheme.palette.primaryDark[800], 0.5),
-      color: `var(--muidocs-palette-grey-200, ${lightTheme.palette.grey[200]})`,
+      color: `var(--muidocs-palette-grey-300, ${lightTheme.palette.grey[300]})`,
       transition: theme.transitions.create(['background', 'borderColor', 'display'], {
         duration: theme.transitions.duration.shortest,
       }),

--- a/packages/mui-docs/src/branding/brandingTheme.ts
+++ b/packages/mui-docs/src/branding/brandingTheme.ts
@@ -1284,14 +1284,17 @@ export function getThemedComponents(): ThemeOptions {
         },
       },
       MuiTooltip: {
+        defaultProps: {
+          arrow: true,
+        },
         styleOverrides: {
           tooltip: ({ theme }) => ({
             padding: '6px 8px',
             borderRadius: 6,
-            backgroundColor: (theme.vars || theme).palette.grey[400],
-            ...theme.applyDarkStyles({
-              backgroundColor: (theme.vars || theme).palette.grey[800],
-            }),
+            backgroundColor: (theme.vars || theme).palette.grey[800],
+            '& .MuiTooltip-arrow': {
+              color: (theme.vars || theme).palette.grey[800],
+            },
           }),
         },
       },

--- a/packages/mui-docs/src/branding/brandingTheme.ts
+++ b/packages/mui-docs/src/branding/brandingTheme.ts
@@ -530,7 +530,7 @@ export function getThemedComponents(): ThemeOptions {
               ...theme.typography.body1,
               lineHeight: 21 / 16,
               padding: theme.spacing('8px', '10px', '10px', '12px'),
-              fontWeight: theme.typography.fontWeightSemiBold,
+              fontWeight: theme.typography.fontWeightMedium,
               borderRadius: 10,
               '& > span': { transition: '0.2s', marginLeft: 4 },
               '&:hover > span': { transform: 'translateX(2px)' },
@@ -538,16 +538,16 @@ export function getThemedComponents(): ThemeOptions {
             ...(ownerState.size === 'medium' && {
               fontSize: defaultTheme.typography.pxToRem(15),
               padding: theme.spacing('8px', '12px', '8px', '14px'),
-              fontWeight: theme.typography.fontWeightSemiBold,
+              fontWeight: theme.typography.fontWeightMedium,
               borderRadius: 8,
               '& > span': { transition: '0.2s', marginLeft: 4 },
               '&:hover > span': { transform: 'translateX(2px)' },
             }),
             ...(ownerState.size === 'small' && {
-              padding: theme.spacing('6px', 1.5),
+              padding: '6px 8px',
               fontFamily: theme.typography.fontFamily,
               fontSize: defaultTheme.typography.pxToRem(13),
-              fontWeight: theme.typography.fontWeightSemiBold,
+              fontWeight: theme.typography.fontWeightMedium,
               borderRadius: 8,
               '& .MuiButton-startIcon': {
                 transition: '0.15s',
@@ -783,6 +783,15 @@ export function getThemedComponents(): ThemeOptions {
         styleOverrides: {
           root: ({ theme, ownerState }) => ({
             borderRadius: theme.shape.borderRadius,
+            transition: 'all 100ms ease-in',
+            '&:hover': {
+              borderColor: (theme.vars || theme).palette.grey[300],
+              background: (theme.vars || theme).palette.grey[50],
+              ...theme.applyDarkStyles({
+                borderColor: (theme.vars || theme).palette.primaryDark[600],
+                background: alpha(theme.palette.primaryDark[700], 0.8),
+              }),
+            },
             ...(ownerState.size === 'small' && {
               height: 32,
               width: 32,
@@ -797,11 +806,10 @@ export function getThemedComponents(): ThemeOptions {
             props: { color: 'primary' },
             style: ({ theme }) => [
               {
-                border: `1px solid`,
                 color: (theme.vars || theme).palette.primary.main,
                 backgroundColor: alpha(theme.palette.primaryDark[50], 0.1),
-                borderColor: (theme.vars || theme).palette.primaryDark[100],
-                boxShadow: `${alpha(theme.palette.grey[200], 0.5)} 0 1px 0 inset, ${alpha(theme.palette.grey[100], 0.4)} 0 -1px 0 inset, ${alpha(theme.palette.grey[200], 0.5)} 0 1px 2px 0`,
+                border: `1px solid ${(theme.vars || theme).palette.primaryDark[100]}`,
+                boxShadow: `#FFF 0 1px 0 inset, ${alpha(theme.palette.grey[200], 0.4)} 0 -1px 0 inset, ${alpha(theme.palette.grey[200], 0.5)} 0 1px 2px 0`,
                 '&:hover': {
                   borderColor: (theme.vars || theme).palette.grey[300],
                   background: (theme.vars || theme).palette.grey[50],
@@ -823,14 +831,12 @@ export function getThemedComponents(): ThemeOptions {
             props: { color: 'info' },
             style: ({ theme }) => [
               {
-                color: (theme.vars || theme).palette.text.tertiary,
-                borderRadius: theme.shape.borderRadius,
-                border: `1px solid`,
+                color: (theme.vars || theme).palette.text.secondary,
                 backgroundColor: alpha(theme.palette.primaryDark[50], 0.1),
-                borderColor: (theme.vars || theme).palette.primaryDark[100],
-                boxShadow: `${alpha(theme.palette.grey[50], 0.4)} 0 1px 0 inset, ${alpha(theme.palette.grey[100], 0.5)} 0 -1px 0 inset, ${alpha(theme.palette.grey[200], 0.5)} 0 1px 2px 0`,
+                border: `1px solid ${(theme.vars || theme).palette.primaryDark[100]}`,
+                boxShadow: `#FFF 0 1px 0 inset, ${alpha(theme.palette.grey[200], 0.4)} 0 -1px 0 inset, ${alpha(theme.palette.grey[200], 0.5)} 0 1px 2px 0`,
                 '&:hover': {
-                  color: (theme.vars || theme).palette.primary.main,
+                  color: (theme.vars || theme).palette.text.primary,
                   borderColor: (theme.vars || theme).palette.grey[300],
                   background: (theme.vars || theme).palette.grey[50],
                 },
@@ -838,11 +844,10 @@ export function getThemedComponents(): ThemeOptions {
               theme.applyDarkStyles({
                 borderColor: alpha(theme.palette.primaryDark[600], 0.5),
                 backgroundColor: alpha(theme.palette.primaryDark[700], 0.2),
-                boxShadow: `${alpha(theme.palette.primaryDark[600], 0.2)} 0 1px 0 inset, ${(theme.vars || theme).palette.common.black} 0 -1px 0 inset, ${(theme.vars || theme).palette.common.black} 0 1px 2px 0`,
+                boxShadow: `${alpha(theme.palette.primaryDark[600], 0.3)} 0 1px 0 inset, ${(theme.vars || theme).palette.common.black} 0 -1px 0 inset, ${(theme.vars || theme).palette.common.black} 0 1px 2px 0`,
                 '&:hover': {
-                  color: (theme.vars || theme).palette.primary[400],
-                  borderColor: (theme.vars || theme).palette.primaryDark[500],
-                  background: alpha(theme.palette.primaryDark[700], 0.4),
+                  borderColor: (theme.vars || theme).palette.primaryDark[600],
+                  background: alpha(theme.palette.primaryDark[700], 0.8),
                 },
               }),
             ],
@@ -1280,10 +1285,14 @@ export function getThemedComponents(): ThemeOptions {
       },
       MuiTooltip: {
         styleOverrides: {
-          tooltip: {
+          tooltip: ({ theme }) => ({
+            padding: '6px 8px',
             borderRadius: 6,
-            padding: '6px 12px',
-          },
+            backgroundColor: (theme.vars || theme).palette.grey[400],
+            ...theme.applyDarkStyles({
+              backgroundColor: (theme.vars || theme).palette.grey[800],
+            }),
+          }),
         },
       },
       MuiSwitch: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Some simple stuff on this PR — here's a run-down:

- Actually, maybe the most significant change of this PR is removing the logo and extra links from the docs footer. I had added that many months ago, but ultimately, I feel like they just clutter the docs without a great reason. Way cleaner without them!
- Swapping some semi-bold font-weight instances to medium to lighten things up a bit
- A bunch of color improvements, mostly on the icon button (improving shadows, border, and hover state styles)

Preview: https://deploy-preview-42455--material-ui.netlify.app/material-ui/migration/migration-v5/