### PR TITLE
[system][useMediaQuery] Drop Safari < 14 support

### DIFF
--- a/packages/mui-material/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/mui-material/src/useMediaQuery/useMediaQuery.test.js
@@ -22,11 +22,10 @@ function createMatchMedia(width, ref) {
       matches: mediaQuery.match(query, {
         width,
       }),
-      // Mocking matchMedia in Safari < 14 where MediaQueryList doesn't inherit from EventTarget
-      addListener: (listener) => {
+      addEventListener: (eventType, listener) => {
         listeners.push(listener);
       },
-      removeListener: (listener) => {
+      removeEventListener: (eventType, listener) => {
         const index = listeners.indexOf(listener);
         if (index > -1) {
           listeners.splice(index, 1);

--- a/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
@@ -72,27 +72,20 @@ function useMediaQueryOld(
   });
 
   useEnhancedEffect(() => {
-    let active = true;
-
     if (!matchMedia) {
       return undefined;
     }
 
     const queryList = matchMedia!(query);
     const updateMatch = () => {
-      // Workaround Safari wrong implementation of matchMedia
-      // TODO can we remove it?
-      // https://github.com/mui/material-ui/pull/17315#issuecomment-528286677
-      if (active) {
-        setMatch(queryList.matches);
-      }
+      setMatch(queryList.matches);
     };
+
     updateMatch();
-    // TODO: Use `addEventListener` once support for Safari < 14 is dropped
-    queryList.addListener(updateMatch);
+    queryList.addEventListener('change', updateMatch);
+
     return () => {
-      active = false;
-      queryList.removeListener(updateMatch);
+      queryList.removeEventListener('change', updateMatch);
     };
   }, [query, matchMedia]);
 
@@ -131,10 +124,9 @@ function useMediaQueryNew(
     return [
       () => mediaQueryList.matches,
       (notify: () => void) => {
-        // TODO: Use `addEventListener` once support for Safari < 14 is dropped
-        mediaQueryList.addListener(notify);
+        mediaQueryList.addEventListener('change', notify);
         return () => {
-          mediaQueryList.removeListener(notify);
+          mediaQueryList.removeEventListener('change', notify);
         };
       },
     ];


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/42459

This PR stops using deprecated browser APIs:
- https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener
- https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/removeListener

These were needed to support Safari 13 but we no longer support it so it's fine to use the recommended browser APIs.