### PR TITLE
[material-ui] Change React.ReactElement type from `any` to `unknown`

### DIFF
--- a/packages/mui-material/src/Chip/Chip.d.ts
+++ b/packages/mui-material/src/Chip/Chip.d.ts
@@ -15,7 +15,7 @@ export interface ChipOwnProps {
   /**
    * The Avatar element to display.
    */
-  avatar?: React.ReactElement<any>;
+  avatar?: React.ReactElement<unknown>;
   /**
    * This prop isn't supported.
    * Use the `component` prop if you need to change the children structure.
@@ -47,7 +47,7 @@ export interface ChipOwnProps {
   /**
    * Override the default delete icon element. Shown only if `onDelete` is set.
    */
-  deleteIcon?: React.ReactElement<any>;
+  deleteIcon?: React.ReactElement<unknown>;
   /**
    * If `true`, the component is disabled.
    * @default false
@@ -56,7 +56,7 @@ export interface ChipOwnProps {
   /**
    * Icon element.
    */
-  icon?: React.ReactElement<any>;
+  icon?: React.ReactElement<unknown>;
   /**
    * The content of the component.
    */

--- a/packages/mui-material/src/GlobalStyles/GlobalStyles.d.ts
+++ b/packages/mui-material/src/GlobalStyles/GlobalStyles.d.ts
@@ -18,4 +18,4 @@ export interface GlobalStylesProps {
  *
  * - [GlobalStyles API](https://mui.com/material-ui/api/global-styles/)
  */
-export default function GlobalStyles(props: GlobalStylesProps): React.ReactElement<any>;
+export default function GlobalStyles(props: GlobalStylesProps): React.ReactElement<unknown>;

--- a/packages/mui-material/src/Modal/Modal.d.ts
+++ b/packages/mui-material/src/Modal/Modal.d.ts
@@ -50,7 +50,7 @@ export interface ModalOwnProps {
   /**
    * A single child content element.
    */
-  children: React.ReactElement<any>;
+  children: React.ReactElement<unknown>;
   /**
    * Override or extend the styles applied to the component.
    */

--- a/packages/mui-material/src/Slider/Slider.d.ts
+++ b/packages/mui-material/src/Slider/Slider.d.ts
@@ -281,7 +281,7 @@ export interface SliderTypeMap<
 }
 
 export interface SliderValueLabelProps extends React.HTMLAttributes<HTMLSpanElement> {
-  children: React.ReactElement<any>;
+  children: React.ReactElement<unknown>;
   index: number;
   open: boolean;
   value: number;

--- a/packages/mui-material/src/StepConnector/StepConnector.d.ts
+++ b/packages/mui-material/src/StepConnector/StepConnector.d.ts
@@ -4,7 +4,7 @@ import { InternalStandardProps as StandardProps } from '..';
 import { Theme } from '../styles';
 import { StepConnectorClasses } from './stepConnectorClasses';
 
-export type StepConnectorIcon = React.ReactElement<any> | string | number;
+export type StepConnectorIcon = React.ReactElement<unknown> | string | number;
 
 export interface StepConnectorProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, 'children'> {

--- a/packages/mui-material/src/Tab/Tab.d.ts
+++ b/packages/mui-material/src/Tab/Tab.d.ts
@@ -28,7 +28,7 @@ export interface TabOwnProps {
   /**
    * The icon to display.
    */
-  icon?: string | React.ReactElement<any>;
+  icon?: string | React.ReactElement<unknown>;
   /**
    * The position of the icon relative to the label.
    * @default 'top'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

part of https://github.com/mui/material-ui/issues/42380

since there was no activity in the issue, i went ahead and changed instances of `React.ReactElement<any>` to `React.ReactElement<unknown>`, There still 15+ instances of `React.ReactElement<any,any>` to be changed. i'll leave that up to other contributors 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
