### PR TITLE
[codemod] Support more cases for sx-prop transformation

### DIFF
--- a/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.js
@@ -165,10 +165,24 @@ export default function sxV6(file, api, options) {
         if (data.node.type === 'ArrowFunctionExpression') {
           const returnExpression = getReturnExpression(data.node);
           if (returnExpression) {
-            recurseObjectExpression({
-              ...data,
-              node: returnExpression,
-            });
+            if (
+              returnExpression.type === 'MemberExpression' &&
+              returnExpression.property?.type === 'ConditionalExpression'
+            ) {
+              recurseObjectExpression({
+                ...data,
+                node: j.conditionalExpression(
+                  returnExpression.property.test,
+                  { ...returnExpression, property: returnExpression.property.consequent },
+                  { ...returnExpression, property: returnExpression.property.alternate },
+                ),
+              });
+            } else {
+              recurseObjectExpression({
+                ...data,
+                node: returnExpression,
+              });
+            }
           }
         }
         if (data.node.type === 'ObjectExpression') {

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.js
@@ -478,7 +478,7 @@ export default function sxV6(file, api, options) {
         }
         lines.push(line);
       }
-      if (line.includes('sx=') && !line.match(/sx=\{\{[^\}]+\}\}/)) {
+      if (line.includes('sx=') && !line.match(/sx=\{\{[^}]+\}\}/)) {
         isInStyled = true;
         spaceMatch = line.match(/^\s+/);
       }

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.js
@@ -436,7 +436,12 @@ export default function sxV6(file, api, options) {
             }
           }
           if (
-            data.node.expressions?.some((expression) => getObjectKey(expression)?.name === 'theme')
+            data.node.expressions?.some(
+              (expression) =>
+                getObjectKey(expression)?.name === 'theme' ||
+                (expression.type === 'CallExpression' &&
+                  getObjectKey(expression.callee)?.name === 'theme'),
+            )
           ) {
             if (data.root.type === 'ObjectExpression') {
               data.replaceRoot?.(buildArrowFunctionAST([j.identifier('theme')], data.root));

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.js
@@ -219,8 +219,10 @@ export default function sxV6(file, api, options) {
                 });
               }
             } else if (
-              returnExpression.type === 'CallExpression' &&
-              getObjectKey(returnExpression.callee)?.name === 'theme'
+              (returnExpression.type === 'CallExpression' &&
+                getObjectKey(returnExpression.callee)?.name === 'theme') ||
+              (returnExpression.type === 'MemberExpression' &&
+                getObjectKey(returnExpression)?.name === 'theme')
             ) {
               data.replaceValue?.(returnExpression);
               rootThemeCallback(data);

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.js
@@ -414,7 +414,7 @@ export default function sxV6(file, api, options) {
         }
         lines.push(line);
       }
-      if (line.includes('sx=')) {
+      if (line.includes('sx=') && !line.match(/sx=\{\{[^\}]+\}\}/)) {
         isInStyled = true;
         spaceMatch = line.match(/^\s+/);
       }

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.js
@@ -222,7 +222,10 @@ export default function sxV6(file, api, options) {
               (returnExpression.type === 'CallExpression' &&
                 getObjectKey(returnExpression.callee)?.name === 'theme') ||
               (returnExpression.type === 'MemberExpression' &&
-                getObjectKey(returnExpression)?.name === 'theme')
+                getObjectKey(returnExpression)?.name === 'theme') ||
+              (returnExpression.type === 'BinaryExpression' &&
+                (getObjectKey(returnExpression.left)?.name === 'theme' ||
+                  getObjectKey(returnExpression.right)?.name === 'theme'))
             ) {
               data.replaceValue?.(returnExpression);
               rootThemeCallback(data);

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.test.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.test.js
@@ -105,5 +105,29 @@ describe('@mui/codemod', () => {
         expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
+
+    describe('should not delete line breaks', () => {
+      it('transforms props as needed', () => {
+        const actual = transform(
+          { source: read('./test-cases/sx-line-break.actual.js') },
+          { jscodeshift },
+          {},
+        );
+
+        const expected = read('./test-cases/sx-line-break.expected.js');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+
+      it('should be idempotent', () => {
+        const actual = transform(
+          { source: read('./test-cases/sx-line-break.expected.js') },
+          { jscodeshift },
+          {},
+        );
+
+        const expected = read('./test-cases/sx-line-break.expected.js');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+    });
   });
 });

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-line-break.actual.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-line-break.actual.js
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Stack from '@mui/material/Stack';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+function appBarLabel(label) {
+  return (
+    <Toolbar>
+      <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
+        <MenuIcon />
+      </IconButton>
+      <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
+        {label}
+      </Typography>
+    </Toolbar>
+  );
+}
+
+const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#1976d2',
+    },
+  },
+});
+
+export default function EnableColorOnDarkAppBar() {
+  return (
+    <Stack spacing={2} sx={{ flexGrow: 1 }}>
+      <ThemeProvider theme={darkTheme}>
+        <AppBar position="static" color="primary" enableColorOnDark>
+          {appBarLabel('enableColorOnDark')}
+        </AppBar>
+        <AppBar position="static" color="primary">
+          {appBarLabel('default')}
+        </AppBar>
+      </ThemeProvider>
+    </Stack>
+  );
+}

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-line-break.expected.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-line-break.expected.js
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Stack from '@mui/material/Stack';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+function appBarLabel(label) {
+  return (
+    <Toolbar>
+      <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
+        <MenuIcon />
+      </IconButton>
+      <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
+        {label}
+      </Typography>
+    </Toolbar>
+  );
+}
+
+const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#1976d2',
+    },
+  },
+});
+
+export default function EnableColorOnDarkAppBar() {
+  return (
+    <Stack spacing={2} sx={{ flexGrow: 1 }}>
+      <ThemeProvider theme={darkTheme}>
+        <AppBar position="static" color="primary" enableColorOnDark>
+          {appBarLabel('enableColorOnDark')}
+        </AppBar>
+        <AppBar position="static" color="primary">
+          {appBarLabel('default')}
+        </AppBar>
+      </ThemeProvider>
+    </Stack>
+  );
+}

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.actual.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.actual.js
@@ -87,3 +87,11 @@ function FacebookCircularProgress(props) {
     p: 4,
   }}
 ></Box>;
+
+<Backdrop
+  sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }}
+  open={open}
+  onClick={handleClose}
+>
+  <CircularProgress color="inherit" />
+</Backdrop>;

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.actual.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.actual.js
@@ -1,14 +1,11 @@
 function FacebookCircularProgress(props) {
   return (
-    (<Box sx={{ position: 'relative' }}>
+    <Box sx={{ position: 'relative' }}>
       <CircularProgress
         variant="determinate"
-        sx={theme => ({
-          color: theme.palette.grey[800],
-          ...theme.applyStyles("light", {
-            color: theme.palette.grey[200]
-          })
-        })}
+        sx={{
+          color: (theme) => theme.palette.grey[theme.palette.mode === 'light' ? 200 : 800],
+        }}
         size={40}
         thickness={4}
         {...props}
@@ -17,55 +14,65 @@ function FacebookCircularProgress(props) {
       <CircularProgress
         variant="indeterminate"
         disableShrink
-        sx={theme => ({
-          color: '#308fe8',
+        sx={{
+          color: (theme) => (theme.palette.mode === 'light' ? '#1a90ff' : '#308fe8'),
           animationDuration: '550ms',
           position: 'absolute',
           left: 0,
           [`& .${circularProgressClasses.circle}`]: {
             strokeLinecap: 'round',
           },
-          ...theme.applyStyles("light", {
-            color: '#1a90ff'
-          })
-        })}
+        }}
         size={40}
         thickness={4}
         {...props}
       />
-    </Box>)
+    </Box>
   );
 }
 
 <Paper
   elevation={0}
-  sx={theme => ({
+  sx={{
     display: 'flex',
-    border: `1px solid ${theme.palette.divider}`,
-    flexWrap: 'wrap'
-  })}
+    border: (theme) => `1px solid ${theme.palette.divider}`,
+    flexWrap: 'wrap',
+  }}
 ></Paper>;
 
 <Divider
-  sx={theme => ({
-    border: `1px solid ${'#000'}`,
-    ...theme.applyStyles("dark", {
-      border: `1px solid ${'#fff'}`
-    })
-  })}
+  sx={{ border: (theme) => `1px solid ${theme.palette.mode === 'dark' ? '#fff' : '#000'}` }}
 />;
 
 <Typography
   component="span"
   variant="subtitle1"
   color="inherit"
-  sx={theme => ({
+  sx={{
     position: 'relative',
     p: 4,
     pt: 2,
-    pb: `calc(${theme.spacing(1)} + 6px)`
-  })}
+    pb: (theme) => `calc(${theme.spacing(1)} + 6px)`,
+  }}
 >
   {image.title}
   <ImageMarked className="MuiImageMarked-root" />
 </Typography>;
+
+<Autocomplete
+  sx={{
+    display: 'inline-block',
+    '& input': {
+      width: 200,
+      bgcolor: 'background.paper',
+      color: (theme) => theme.palette.getContrastText(theme.palette.background.paper),
+    },
+  }}
+  id="custom-input-demo"
+  options={options}
+  renderInput={(params) => (
+    <div ref={params.InputProps.ref}>
+      <input type="text" {...params.inputProps} />
+    </div>
+  )}
+/>;

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.actual.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.actual.js
@@ -1,0 +1,32 @@
+function FacebookCircularProgress(props) {
+  return (
+    <Box sx={{ position: 'relative' }}>
+      <CircularProgress
+        variant="determinate"
+        sx={{
+          color: (theme) => theme.palette.grey[theme.palette.mode === 'light' ? 200 : 800],
+        }}
+        size={40}
+        thickness={4}
+        {...props}
+        value={100}
+      />
+      <CircularProgress
+        variant="indeterminate"
+        disableShrink
+        sx={{
+          color: (theme) => (theme.palette.mode === 'light' ? '#1a90ff' : '#308fe8'),
+          animationDuration: '550ms',
+          position: 'absolute',
+          left: 0,
+          [`& .${circularProgressClasses.circle}`]: {
+            strokeLinecap: 'round',
+          },
+        }}
+        size={40}
+        thickness={4}
+        {...props}
+      />
+    </Box>
+  );
+}

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.actual.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.actual.js
@@ -30,3 +30,16 @@ function FacebookCircularProgress(props) {
     </Box>
   );
 }
+
+<Paper
+  elevation={0}
+  sx={{
+    display: 'flex',
+    border: (theme) => `1px solid ${theme.palette.divider}`,
+    flexWrap: 'wrap',
+  }}
+></Paper>;
+
+<Divider
+  sx={{ border: (theme) => `1px solid ${theme.palette.mode === 'dark' ? '#fff' : '#000'}` }}
+/>;

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.actual.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.actual.js
@@ -1,11 +1,14 @@
 function FacebookCircularProgress(props) {
   return (
-    <Box sx={{ position: 'relative' }}>
+    (<Box sx={{ position: 'relative' }}>
       <CircularProgress
         variant="determinate"
-        sx={{
-          color: (theme) => theme.palette.grey[theme.palette.mode === 'light' ? 200 : 800],
-        }}
+        sx={theme => ({
+          color: theme.palette.grey[800],
+          ...theme.applyStyles("light", {
+            color: theme.palette.grey[200]
+          })
+        })}
         size={40}
         thickness={4}
         {...props}
@@ -14,32 +17,55 @@ function FacebookCircularProgress(props) {
       <CircularProgress
         variant="indeterminate"
         disableShrink
-        sx={{
-          color: (theme) => (theme.palette.mode === 'light' ? '#1a90ff' : '#308fe8'),
+        sx={theme => ({
+          color: '#308fe8',
           animationDuration: '550ms',
           position: 'absolute',
           left: 0,
           [`& .${circularProgressClasses.circle}`]: {
             strokeLinecap: 'round',
           },
-        }}
+          ...theme.applyStyles("light", {
+            color: '#1a90ff'
+          })
+        })}
         size={40}
         thickness={4}
         {...props}
       />
-    </Box>
+    </Box>)
   );
 }
 
 <Paper
   elevation={0}
-  sx={{
+  sx={theme => ({
     display: 'flex',
-    border: (theme) => `1px solid ${theme.palette.divider}`,
-    flexWrap: 'wrap',
-  }}
+    border: `1px solid ${theme.palette.divider}`,
+    flexWrap: 'wrap'
+  })}
 ></Paper>;
 
 <Divider
-  sx={{ border: (theme) => `1px solid ${theme.palette.mode === 'dark' ? '#fff' : '#000'}` }}
+  sx={theme => ({
+    border: `1px solid ${'#000'}`,
+    ...theme.applyStyles("dark", {
+      border: `1px solid ${'#fff'}`
+    })
+  })}
 />;
+
+<Typography
+  component="span"
+  variant="subtitle1"
+  color="inherit"
+  sx={theme => ({
+    position: 'relative',
+    p: 4,
+    pt: 2,
+    pb: `calc(${theme.spacing(1)} + 6px)`
+  })}
+>
+  {image.title}
+  <ImageMarked className="MuiImageMarked-root" />
+</Typography>;

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.actual.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.actual.js
@@ -76,3 +76,14 @@ function FacebookCircularProgress(props) {
     </div>
   )}
 />;
+
+<Box
+  sx={{
+    position: 'relative',
+    width: 400,
+    bgcolor: 'background.paper',
+    border: '2px solid #000',
+    boxShadow: (theme) => theme.shadows[5],
+    p: 4,
+  }}
+></Box>;

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.expected.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.expected.js
@@ -54,3 +54,18 @@ function FacebookCircularProgress(props) {
     })
   })}
 />;
+
+<Typography
+  component="span"
+  variant="subtitle1"
+  color="inherit"
+  sx={theme => ({
+    position: 'relative',
+    p: 4,
+    pt: 2,
+    pb: `calc(${theme.spacing(1)} + 6px)`
+  })}
+>
+  {image.title}
+  <ImageMarked className="MuiImageMarked-root" />
+</Typography>;

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.expected.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.expected.js
@@ -36,3 +36,21 @@ function FacebookCircularProgress(props) {
     </Box>)
   );
 }
+
+<Paper
+  elevation={0}
+  sx={theme => ({
+    display: 'flex',
+    border: `1px solid ${theme.palette.divider}`,
+    flexWrap: 'wrap'
+  })}
+></Paper>;
+
+<Divider
+  sx={theme => ({
+    border: `1px solid ${'#000'}`,
+    ...theme.applyStyles("dark", {
+      border: `1px solid ${'#fff'}`
+    })
+  })}
+/>;

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.expected.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.expected.js
@@ -1,0 +1,38 @@
+function FacebookCircularProgress(props) {
+  return (
+    (<Box sx={{ position: 'relative' }}>
+      <CircularProgress
+        variant="determinate"
+        sx={theme => ({
+          color: theme.palette.grey[800],
+          ...theme.applyStyles("light", {
+            color: theme.palette.grey[200]
+          })
+        })}
+        size={40}
+        thickness={4}
+        {...props}
+        value={100}
+      />
+      <CircularProgress
+        variant="indeterminate"
+        disableShrink
+        sx={theme => ({
+          color: '#308fe8',
+          animationDuration: '550ms',
+          position: 'absolute',
+          left: 0,
+          [`& .${circularProgressClasses.circle}`]: {
+            strokeLinecap: 'round',
+          },
+          ...theme.applyStyles("light", {
+            color: '#1a90ff'
+          })
+        })}
+        size={40}
+        thickness={4}
+        {...props}
+      />
+    </Box>)
+  );
+}

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.expected.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.expected.js
@@ -69,3 +69,21 @@ function FacebookCircularProgress(props) {
   {image.title}
   <ImageMarked className="MuiImageMarked-root" />
 </Typography>;
+
+<Autocomplete
+  sx={theme => ({
+    display: 'inline-block',
+    '& input': {
+      width: 200,
+      bgcolor: 'background.paper',
+      color: theme.palette.getContrastText(theme.palette.background.paper),
+    }
+  })}
+  id="custom-input-demo"
+  options={options}
+  renderInput={(params) => (
+    <div ref={params.InputProps.ref}>
+      <input type="text" {...params.inputProps} />
+    </div>
+  )}
+/>;

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.expected.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.expected.js
@@ -87,3 +87,14 @@ function FacebookCircularProgress(props) {
     </div>
   )}
 />;
+
+<Box
+  sx={theme => ({
+    position: 'relative',
+    width: 400,
+    bgcolor: 'background.paper',
+    border: '2px solid #000',
+    boxShadow: theme.shadows[5],
+    p: 4
+  })}
+></Box>;

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.expected.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/test-cases/sx-value-callback.expected.js
@@ -98,3 +98,14 @@ function FacebookCircularProgress(props) {
     p: 4
   })}
 ></Box>;
+
+<Backdrop
+  sx={theme => ({
+    color: '#fff',
+    zIndex: theme.zIndex.drawer + 1
+  })}
+  open={open}
+  onClick={handleClose}
+>
+  <CircularProgress color="inherit" />
+</Backdrop>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Please review the test cases. Found the bugs from #42475.

**Summary of the fix is the support of**:
- Do remove line break that's not related to sx
- Hoist theme value callback to the top
  
  ```diff
  sx={
  - { color: theme => theme.palette.divider }  
  + theme => ({
  +    color: theme.palette.divider,
  + })
  }
  ```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
