### PR TITLE
[core] Skip charts animation for visual regression test

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2216,6 +2216,10 @@ importers:
   packages/waterfall: {}
 
   test:
+    dependencies:
+      '@react-spring/web':
+        specifier: ^9.7.3
+        version: 9.7.3(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@babel/runtime':
         specifier: ^7.24.6

--- a/test/package.json
+++ b/test/package.json
@@ -43,5 +43,8 @@
     "webfontloader": "^1.6.28",
     "webpack": "^5.91.0",
     "yargs": "^17.7.2"
+  },
+  "dependencies": {
+    "@react-spring/web": "^9.7.3"
   }
 }

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -3,7 +3,13 @@ import PropTypes from 'prop-types';
 import * as ReactDOMClient from 'react-dom/client';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import webfontloader from 'webfontloader';
+import { Globals } from '@react-spring/web';
 import TestViewer from './TestViewer';
+
+// Skip charts annimation for screen shots
+Globals.assign({
+  skipAnimation: true,
+});
 
 // Get all the fixtures specifically written for preventing visual regressions.
 const importRegressionFixtures = require.context('./fixtures', true, /\.(js|ts|tsx)$/, 'lazy');

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -33,7 +33,21 @@ importRegressionFixtures.keys().forEach((path) => {
 }, []);
 
 const blacklist = [
-  'docs-getting-started-templates-dashboard-components', // Already tested by /docs-getting-started-templates-dashboard/Dashboard
+  // Next components are tested by docs-getting-started-templates-dashboard-components/MainGrid.png
+  '/docs-getting-started-templates-dashboard/Dashboard.png',
+  '/docs-getting-started-templates-dashboard-components/ChartUserByCountry.png',
+  '/docs-getting-started-templates-dashboard-components/CustomDatePicker.png',
+  '/docs-getting-started-templates-dashboard-components/CustomizedDataGrid.png',
+  '/docs-getting-started-templates-dashboard-components/CustomizedTreeView.png',
+  '/docs-getting-started-templates-dashboard-components/Header.png',
+  '/docs-getting-started-templates-dashboard-components/HighlightedCard.png',
+  '/docs-getting-started-templates-dashboard-components/MenuButton.png',
+  '/docs-getting-started-templates-dashboard-components/Navbar.png',
+  '/docs-getting-started-templates-dashboard-components/NavbarBreadcrumbs.png',
+  '/docs-getting-started-templates-dashboard-components/OptionsMenu.png',
+  '/docs-getting-started-templates-dashboard-components/PageViewsChart.png',
+  '/docs-getting-started-templates-dashboard-components/Search.png',
+  '/docs-getting-started-templates-dashboard-components/ToggleColorMode.png',
   'docs-getting-started-templates-dashboard-internals-components', // No public components
   'docs-getting-started-templates-dashboard-components/SideNav.png', // No public components
   'docs-getting-started-templates-dashboard-components/PageViewsBarChart.png', // No public components

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -33,21 +33,21 @@ importRegressionFixtures.keys().forEach((path) => {
 }, []);
 
 const blacklist = [
-  // Next components are tested by docs-getting-started-templates-dashboard-components/MainGrid.png
-  '/docs-getting-started-templates-dashboard/Dashboard.png',
-  '/docs-getting-started-templates-dashboard-components/ChartUserByCountry.png',
-  '/docs-getting-started-templates-dashboard-components/CustomDatePicker.png',
-  '/docs-getting-started-templates-dashboard-components/CustomizedDataGrid.png',
-  '/docs-getting-started-templates-dashboard-components/CustomizedTreeView.png',
-  '/docs-getting-started-templates-dashboard-components/Header.png',
-  '/docs-getting-started-templates-dashboard-components/HighlightedCard.png',
-  '/docs-getting-started-templates-dashboard-components/MenuButton.png',
-  '/docs-getting-started-templates-dashboard-components/Navbar.png',
-  '/docs-getting-started-templates-dashboard-components/NavbarBreadcrumbs.png',
-  '/docs-getting-started-templates-dashboard-components/OptionsMenu.png',
-  '/docs-getting-started-templates-dashboard-components/PageViewsChart.png',
-  '/docs-getting-started-templates-dashboard-components/Search.png',
-  '/docs-getting-started-templates-dashboard-components/ToggleColorMode.png',
+  // The following components are tested by docs-getting-started-templates-dashboard-components/MainGrid.png
+  'docs-getting-started-templates-dashboard/Dashboard.png',
+  'docs-getting-started-templates-dashboard-components/ChartUserByCountry.png',
+  'docs-getting-started-templates-dashboard-components/CustomDatePicker.png',
+  'docs-getting-started-templates-dashboard-components/CustomizedDataGrid.png',
+  'docs-getting-started-templates-dashboard-components/CustomizedTreeView.png',
+  'docs-getting-started-templates-dashboard-components/Header.png',
+  'docs-getting-started-templates-dashboard-components/HighlightedCard.png',
+  'docs-getting-started-templates-dashboard-components/MenuButton.png',
+  'docs-getting-started-templates-dashboard-components/Navbar.png',
+  'docs-getting-started-templates-dashboard-components/NavbarBreadcrumbs.png',
+  'docs-getting-started-templates-dashboard-components/OptionsMenu.png',
+  'docs-getting-started-templates-dashboard-components/PageViewsChart.png',
+  'docs-getting-started-templates-dashboard-components/Search.png',
+  'docs-getting-started-templates-dashboard-components/ToggleColorMode.png',
   'docs-getting-started-templates-dashboard-internals-components', // No public components
   'docs-getting-started-templates-dashboard-components/SideNav.png', // No public components
   'docs-getting-started-templates-dashboard-components/PageViewsBarChart.png', // No public components

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -33,7 +33,8 @@ importRegressionFixtures.keys().forEach((path) => {
 }, []);
 
 const blacklist = [
-  'docs-getting-started-templates-dashboard-internals-components/CustomIcons.png', // No public components
+  'docs-getting-started-templates-dashboard-components', // Already tested by /docs-getting-started-templates-dashboard/Dashboard
+  'docs-getting-started-templates-dashboard-internals-components', // No public components
   'docs-getting-started-templates-dashboard-components/SideNav.png', // No public components
   'docs-getting-started-templates-dashboard-components/PageViewsBarChart.png', // No public components
   'docs-getting-started-templates-dashboard-components/StatCard.png', // No public components


### PR DESCRIPTION
Should prevent that type of false positiv

![image](https://github.com/mui/material-ui/assets/45398769/9934a891-0472-47fc-829f-7aff95c6a6f0)

I also noticed we do screenshot of the dashboard and each component individually. Which seems like waisting resources. So I only kept the dashboard screenshot and  remove all the subcomponents