### PR TITLE
[material-ui][pigment-css] Integrate `extendSxProp` adapter

### DIFF
--- a/packages/mui-material/src/Typography/Typography.js
+++ b/packages/mui-material/src/Typography/Typography.js
@@ -2,13 +2,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { extendSxProp } from '@mui/system/styleFunctionSx';
 import composeClasses from '@mui/utils/composeClasses';
-import { styled, createUseThemeProps } from '../zero-styled';
+import { styled, createUseThemeProps, internal_createExtendSxProp } from '../zero-styled';
 import capitalize from '../utils/capitalize';
 import { getTypographyUtilityClass } from './typographyClasses';
 
 const useThemeProps = createUseThemeProps('MuiTypography');
+const extendSxProp = internal_createExtendSxProp();
 
 const useUtilityClasses = (ownerState) => {
   const { align, gutterBottom, noWrap, paragraph, variant, classes } = ownerState;

--- a/packages/mui-material/src/zero-styled/index.ts
+++ b/packages/mui-material/src/zero-styled/index.ts
@@ -10,6 +10,7 @@ export function createUseThemeProps(name: string) {
   return useThemeProps;
 }
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export function internal_createExtendSxProp() {
   return extendSxProp;
 }

--- a/packages/mui-material/src/zero-styled/index.ts
+++ b/packages/mui-material/src/zero-styled/index.ts
@@ -1,3 +1,4 @@
+import { extendSxProp } from '@mui/system/styleFunctionSx';
 import useThemeProps from '../styles/useThemeProps';
 
 export { css, keyframes } from '@mui/system';
@@ -7,4 +8,8 @@ export { default as styled } from '../styles/styled';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function createUseThemeProps(name: string) {
   return useThemeProps;
+}
+
+export function internal_createExtendSxProp() {
+  return extendSxProp;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #42261

This PR makes the `extendSxProp` replaceable by Pigment CSS. The [`extendSxProp`](https://github.com/mui/pigment-css/pull/112/files) from Pigment CSS is just a placeholder to remove the connection between Material UI and MUI System, thus reducing bundle size of the application.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
