### PR TITLE
[lab][LoadingButton] Prevent React crash with Google Translate

### DIFF
--- a/docs/data/material/components/buttons/LoadingButtonsTransition.js
+++ b/docs/data/material/components/buttons/LoadingButtonsTransition.js
@@ -34,7 +34,7 @@ export default function LoadingButtonsTransition() {
           variant="outlined"
           disabled
         >
-          <span>disabled</span>
+          Disabled
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -43,7 +43,7 @@ export default function LoadingButtonsTransition() {
           loadingIndicator="Loading…"
           variant="outlined"
         >
-          <span>Fetch data</span>
+          Fetch data
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -53,7 +53,7 @@ export default function LoadingButtonsTransition() {
           loadingPosition="end"
           variant="contained"
         >
-          <span>Send</span>
+          Send
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -64,7 +64,7 @@ export default function LoadingButtonsTransition() {
           startIcon={<SaveIcon />}
           variant="contained"
         >
-          <span>Save</span>
+          Save
         </LoadingButton>
       </Box>
       <Box sx={{ '& > button': { m: 1 } }}>
@@ -74,7 +74,7 @@ export default function LoadingButtonsTransition() {
           variant="outlined"
           disabled
         >
-          <span>disabled</span>
+          Disabled
         </LoadingButton>
         <LoadingButton
           onClick={handleClick}
@@ -82,7 +82,7 @@ export default function LoadingButtonsTransition() {
           loadingIndicator="Loading…"
           variant="outlined"
         >
-          <span>Fetch data</span>
+          Fetch data
         </LoadingButton>
         <LoadingButton
           onClick={handleClick}
@@ -91,7 +91,7 @@ export default function LoadingButtonsTransition() {
           loadingPosition="end"
           variant="contained"
         >
-          <span>Send</span>
+          Send
         </LoadingButton>
         <LoadingButton
           color="secondary"
@@ -101,7 +101,7 @@ export default function LoadingButtonsTransition() {
           startIcon={<SaveIcon />}
           variant="contained"
         >
-          <span>Save</span>
+          Save
         </LoadingButton>
       </Box>
     </div>

--- a/docs/data/material/components/buttons/LoadingButtonsTransition.tsx
+++ b/docs/data/material/components/buttons/LoadingButtonsTransition.tsx
@@ -34,7 +34,7 @@ export default function LoadingButtonsTransition() {
           variant="outlined"
           disabled
         >
-          <span>disabled</span>
+          Disabled
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -43,7 +43,7 @@ export default function LoadingButtonsTransition() {
           loadingIndicator="Loading…"
           variant="outlined"
         >
-          <span>Fetch data</span>
+          Fetch data
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -53,7 +53,7 @@ export default function LoadingButtonsTransition() {
           loadingPosition="end"
           variant="contained"
         >
-          <span>Send</span>
+          Send
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -64,7 +64,7 @@ export default function LoadingButtonsTransition() {
           startIcon={<SaveIcon />}
           variant="contained"
         >
-          <span>Save</span>
+          Save
         </LoadingButton>
       </Box>
       <Box sx={{ '& > button': { m: 1 } }}>
@@ -74,7 +74,7 @@ export default function LoadingButtonsTransition() {
           variant="outlined"
           disabled
         >
-          <span>disabled</span>
+          Disabled
         </LoadingButton>
         <LoadingButton
           onClick={handleClick}
@@ -82,7 +82,7 @@ export default function LoadingButtonsTransition() {
           loadingIndicator="Loading…"
           variant="outlined"
         >
-          <span>Fetch data</span>
+          Fetch data
         </LoadingButton>
         <LoadingButton
           onClick={handleClick}
@@ -91,7 +91,7 @@ export default function LoadingButtonsTransition() {
           loadingPosition="end"
           variant="contained"
         >
-          <span>Send</span>
+          Send
         </LoadingButton>
         <LoadingButton
           color="secondary"
@@ -101,7 +101,7 @@ export default function LoadingButtonsTransition() {
           startIcon={<SaveIcon />}
           variant="contained"
         >
-          <span>Save</span>
+          Save
         </LoadingButton>
       </Box>
     </div>

--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -185,14 +185,3 @@ This has the advantage of supporting any element, for instance, a link `<a>` ele
 Toggle the loading switch to see the transition between the different states.
 
 {{"demo": "LoadingButtonsTransition.js"}}
-
-:::warning
-There is a [known issue](https://github.com/mui/material-ui/issues/27853) with translating a page using Chrome tools when a Loading Button is present.
-After the page is translated, the application crashes when the loading state of a Button changes.
-To prevent this, ensure that the contents of the Loading Button are nested inside any HTML element, such as a `<span>`:
-
-```jsx
-<LoadingButton loading variant="outlined">
-  <span>Submit</span>
-</LoadingButton>
-```

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -34,10 +34,6 @@ const useUtilityClasses = (ownerState) => {
   };
 };
 
-const contentDivStyles = {
-  display: 'contents',
-};
-
 // TODO use `import rootShouldForwardProp from '../styles/rootShouldForwardProp';` once move to core
 const rootShouldForwardProp = (prop) =>
   prop !== 'ownerState' && prop !== 'theme' && prop !== 'sx' && prop !== 'as' && prop !== 'classes';
@@ -247,14 +243,15 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
       ownerState={ownerState}
     >
       {ownerState.loadingPosition === 'end' ? (
-        <div style={contentDivStyles}>{children}</div>
+        <span>{children}</span>
       ) : (
         loadingButtonLoadingIndicator
       )}
+
       {ownerState.loadingPosition === 'end' ? (
         loadingButtonLoadingIndicator
       ) : (
-        <div style={contentDivStyles}>{children}</div>
+        <span>{children}</span>
       )}
     </LoadingButtonRoot>
   );

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -34,6 +34,10 @@ const useUtilityClasses = (ownerState) => {
   };
 };
 
+const contentDivStyles = {
+  display: 'contents',
+};
+
 // TODO use `import rootShouldForwardProp from '../styles/rootShouldForwardProp';` once move to core
 const rootShouldForwardProp = (prop) =>
   prop !== 'ownerState' && prop !== 'theme' && prop !== 'sx' && prop !== 'as' && prop !== 'classes';
@@ -242,8 +246,16 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
       classes={classes}
       ownerState={ownerState}
     >
-      {ownerState.loadingPosition === 'end' ? children : loadingButtonLoadingIndicator}
-      {ownerState.loadingPosition === 'end' ? loadingButtonLoadingIndicator : children}
+      {ownerState.loadingPosition === 'end' ? (
+        <div style={contentDivStyles}>{children}</div>
+      ) : (
+        loadingButtonLoadingIndicator
+      )}
+      {ownerState.loadingPosition === 'end' ? (
+        loadingButtonLoadingIndicator
+      ) : (
+        <div style={contentDivStyles}>{children}</div>
+      )}
     </LoadingButtonRoot>
   );
 });


### PR DESCRIPTION
Resolves https://github.com/mui/material-ui/issues/27853. Based on a previous attempt https://github.com/mui/material-ui/pull/35198.

---

_Original PR description:_

### Use case summary:
Using the LoadingButton while have Google translation (chrome feature) active on your site. 
Problem: Google modifies the button contents and React can't figure out its bindings anymore. Causes crash 💥

### How to reproduce: 
https://codesandbox.io/s/dry-water-eig2e7?file=/demo.tsx

**Steps:**
- Open sandbox in external browser
- Use google chrome's translate feature (see screenshot)
- Click the loading button 
- Notice crash 💥
![image](https://user-images.githubusercontent.com/4742816/202733890-b27c584a-861e-4433-a23f-2446c4a60db9.png)

---

_Additional description:_

I introduced two changes from the original PR:
1. Use a `<span>` instead of a `<div>` to wrap `children`.
2. Remove `display: contents`.

Regarding number 2, `display: contents` suffered from deep accessibility issues, the most important one causing elements with the property applied to be removed from the accessibility tree. Most of these issues have been solved over the years, but it's still unclear if it's 100% reliable, especially on Safari. I'm wary of using this property if we're not 100% sure about it'll have the expected behavior. Let me know your thoughts. Some literature about the topic:
- https://adrianroselli.com/2018/05/display-contents-is-not-a-css-reset.html
- https://adrianroselli.com/2022/07/its-mid-2022-and-browsers-mostly-safari-still-break-accessibility-via-display-properties.html
- https://hidde.blog/more-accessible-markup-with-display-contents/