### PR TITLE
[material-ui][docs] Fix ESLint error in Stepper demo

### DIFF
--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
@@ -47,9 +47,10 @@ export default function HorizontalNonLinearStepper() {
   };
 
   const handleComplete = () => {
-    const newCompleted = { ...completed };
-    newCompleted[activeStep] = true;
-    setCompleted(newCompleted);
+    setCompleted({
+      ...completed,
+      [activeStep]: true,
+    });
     handleNext();
   };
 

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
@@ -47,7 +47,7 @@ export default function HorizontalNonLinearStepper() {
   };
 
   const handleComplete = () => {
-    const newCompleted = completed;
+    const newCompleted = { ...completed };
     newCompleted[activeStep] = true;
     setCompleted(newCompleted);
     handleNext();

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
@@ -49,9 +49,10 @@ export default function HorizontalNonLinearStepper() {
   };
 
   const handleComplete = () => {
-    const newCompleted = { ...completed };
-    newCompleted[activeStep] = true;
-    setCompleted(newCompleted);
+    setCompleted({
+      ...completed,
+      [activeStep]: true,
+    });
     handleNext();
   };
 

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
@@ -49,7 +49,7 @@ export default function HorizontalNonLinearStepper() {
   };
 
   const handleComplete = () => {
-    const newCompleted = completed;
+    const newCompleted = { ...completed };
     newCompleted[activeStep] = true;
     setCompleted(newCompleted);
     handleNext();


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/42548

Fixing an error reported by `eslint-plugin-react-compiler` in a Stepper [demo](https://mui.com/material-ui/react-stepper/#non-linear):

```
/material-ui/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
  51:5  error  This mutates a variable that React considers immutable  react-compiler/react-compiler

/material-ui/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
  53:5  error  This mutates a variable that React considers immutable  react-compiler/react-compiler
```

### How to test

- ESLint shouldn't report the error anymore (you need to set `ENABLE_REACT_COMPILER_PLUGIN` to `true` in `.eslintrc.js` locally)
- The demo should work as expected:
  - Original: https://mui.com/material-ui/react-stepper/#non-linear
  - PR: https://deploy-preview-42559--material-ui.netlify.app/material-ui/react-use-media-query/#migrating-from-withwidth

