### PR TITLE
[system][useMediaQuery] Remove deprecated types

### DIFF
--- a/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
+++ b/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
@@ -1673,3 +1673,13 @@ The SpeedDial's `TransitionProps` prop was deprecated in favor of `slotProps.tra
 +  slotProps={{ transition: { unmountOnExit: true } }}
  />
 ```
+
+## useMediaQuery
+
+### Removed types
+
+The following deprecated types were removed:
+
+- `MuiMediaQueryList`: use `MediaQueryList` (from lib.dom.d.ts) instead.
+- `MuiMediaQueryListEvent`: use `MediaQueryListEvent` (from lib.dom.d.ts) instead.
+- `MuiMediaQueryListListener`: use `(event: MediaQueryListEvent) => void` instead.

--- a/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
+++ b/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
@@ -1673,13 +1673,3 @@ The SpeedDial's `TransitionProps` prop was deprecated in favor of `slotProps.tra
 +  slotProps={{ transition: { unmountOnExit: true } }}
  />
 ```
-
-## useMediaQuery
-
-### Removed types
-
-The following deprecated types were removed:
-
-- `MuiMediaQueryList`: use `MediaQueryList` (from lib.dom.d.ts) instead.
-- `MuiMediaQueryListEvent`: use `MediaQueryListEvent` (from lib.dom.d.ts) instead.
-- `MuiMediaQueryListListener`: use `(event: MediaQueryListEvent) => void` instead.

--- a/docs/data/material/migration/migration-v5/migration-v5.md
+++ b/docs/data/material/migration/migration-v5/migration-v5.md
@@ -123,3 +123,13 @@ We recommend adopting this new behavior and **not trying to replicate the old on
 #### Contents wrapped in a <span>
 
 The `children` passed to the LoadingButton component is now wrapped in a `<span>` tag to avoid [issues](https://github.com/mui/material-ui/issues/27853) when using tools to translate websites.
+
+### useMediaQuery
+
+#### Removed types
+
+The following deprecated types were removed:
+
+- `MuiMediaQueryList`: use `MediaQueryList` (from lib.dom.d.ts) instead.
+- `MuiMediaQueryListEvent`: use `MediaQueryListEvent` (from lib.dom.d.ts) instead.
+- `MuiMediaQueryListListener`: use `(event: MediaQueryListEvent) => void` instead.

--- a/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
@@ -4,27 +4,6 @@ import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import { getThemeProps } from '../useThemeProps';
 import useTheme from '../useThemeWithoutDefault';
 
-/**
- * @deprecated Not used internally. Use `MediaQueryListEvent` from lib.dom.d.ts instead.
- */
-export interface MuiMediaQueryListEvent {
-  matches: boolean;
-}
-
-/**
- * @deprecated Not used internally. Use `MediaQueryList` from lib.dom.d.ts instead.
- */
-export interface MuiMediaQueryList {
-  matches: boolean;
-  addListener: (listener: MuiMediaQueryListListener) => void;
-  removeListener: (listener: MuiMediaQueryListListener) => void;
-}
-
-/**
- * @deprecated Not used internally. Use `(event: MediaQueryListEvent) => void` instead.
- */
-export type MuiMediaQueryListListener = (event: MuiMediaQueryListEvent) => void;
-
 export interface UseMediaQueryOptions {
   /**
    * As `window.matchMedia()` is unavailable on the server,


### PR DESCRIPTION
The types being removed were deprecated 3 years ago: https://github.com/mui/material-ui/pull/28413. It's a good opportunity to get rid of them for v6.