### PR TITLE
[material-ui][docs] Shorten useMediaQuery subheading

### DIFF
--- a/docs/data/material/components/use-media-query/use-media-query.md
+++ b/docs/data/material/components/use-media-query/use-media-query.md
@@ -25,7 +25,7 @@ The media query string can be any valid CSS media query, for example [`'(prefers
 
 ⚠️ You can't use `'print'` per browsers limitation, for example [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=774398).
 
-## Using Material UI's breakpoint helpers
+## Using breakpoint helpers
 
 You can use Material UI's [breakpoint helpers](/material-ui/customization/breakpoints/) as follows:
 


### PR DESCRIPTION
It's kinda redundant to see "Material UI" in the heading when we're in the Material UI docs.

Preview link: https://deploy-preview-42561--material-ui.netlify.app/material-ui/react-use-media-query/

|before|after|
|---|---|
|<img width="216" alt="Screenshot 2024-06-07 at 13 02 24" src="https://github.com/mui/material-ui/assets/7225802/8189fdc8-8dab-4463-a6e4-908c987cefb0">|<img width="196" alt="Screenshot 2024-06-07 at 13 02 34" src="https://github.com/mui/material-ui/assets/7225802/4477faa6-e560-4dad-9bd5-567af628f8ad">|