### PR TITLE
[core] Disable eslint-plugin-react-compiler for Base

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -475,6 +475,7 @@ module.exports = {
       rules: {
         'import/no-default-export': 'error',
         'import/prefer-default-export': 'off',
+        ...(ENABLE_REACT_COMPILER_PLUGIN ? { 'react-compiler/react-compiler': 'off' } : {}),
       },
     },
     {


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/42548

Disabling the `eslint-plugin-react-compiler` rules in the `mui-base` folder because we don't want to invest time in fixing issues relative to Base UI because Base UI is moving to https://github.com/mui/base-ui in the future.