### PR TITLE
[docs][Grid] Fix docs spacing

### DIFF
--- a/docs/data/material/components/grid2/grid2.md
+++ b/docs/data/material/components/grid2/grid2.md
@@ -9,10 +9,10 @@ materialDesign: https://m2.material.io/design/layout/understanding-layout.html
 
 <p class="description">The responsive layout grid adapts to screen size and orientation, ensuring consistency across layouts.</p>
 
-{{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
-
 The `Grid` component works well for a layout with a known number of columns.
 The columns can be configured with multiple breakpoints to specify the column span of each child.
+
+{{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
 
 ## What's changed
 


### PR DESCRIPTION
The problem https://next--material-ui.netlify.app/material-ui/react-grid2/

<img width="514" alt="SCR-20240608-mqyg" src="https://github.com/mui/material-ui/assets/3165635/89de3056-5b50-458d-aae0-88a7a287e31f">

---

I couldn't find any other page broken like this:

<img width="1068" alt="SCR-20240608-mrch" src="https://github.com/mui/material-ui/assets/3165635/57230f46-0416-46dc-a0b0-3f0e59c31812">
