### PR TITLE
[Grid] Fix support for CSS variables

### DIFF
--- a/packages/mui-material/src/Grid/Grid.js
+++ b/packages/mui-material/src/Grid/Grid.js
@@ -25,14 +25,6 @@ import useTheme from '../styles/useTheme';
 import GridContext from './GridContext';
 import gridClasses, { getGridUtilityClass } from './gridClasses';
 
-function getOffset(val) {
-  const parse = parseFloat(val);
-  if (Number.isNaN(parse)) {
-    return val;
-  }
-  return `${parse}${String(val).replace(String(parse), '') || 'px'}`;
-}
-
 export function generateGrid({ theme, ownerState }) {
   let size;
 
@@ -81,7 +73,7 @@ export function generateGrid({ theme, ownerState }) {
       if (ownerState.container && ownerState.item && ownerState.columnSpacing !== 0) {
         const themeSpacing = theme.spacing(ownerState.columnSpacing);
         if (themeSpacing !== '0px') {
-          const fullWidth = `calc(${width} + ${getOffset(themeSpacing)})`;
+          const fullWidth = `calc(${width} + ${themeSpacing})`;
           more = {
             flexBasis: fullWidth,
             maxWidth: fullWidth,
@@ -178,9 +170,9 @@ export function generateRowGap({ theme, ownerState }) {
 
       if (themeSpacing !== '0px') {
         return {
-          marginTop: `-${getOffset(themeSpacing)}`,
+          marginTop: theme.spacing(-propValue),
           [`& > .${gridClasses.item}`]: {
-            paddingTop: getOffset(themeSpacing),
+            paddingTop: themeSpacing,
           },
         };
       }
@@ -222,11 +214,12 @@ export function generateColumnGap({ theme, ownerState }) {
     styles = handleBreakpoints({ theme }, columnSpacingValues, (propValue, breakpoint) => {
       const themeSpacing = theme.spacing(propValue);
       if (themeSpacing !== '0px') {
+        const negativeValue = theme.spacing(-propValue);
         return {
-          width: `calc(100% + ${getOffset(themeSpacing)})`,
-          marginLeft: `-${getOffset(themeSpacing)}`,
+          width: `calc(100% + ${themeSpacing})`,
+          marginLeft: negativeValue,
           [`& > .${gridClasses.item}`]: {
-            paddingLeft: getOffset(themeSpacing),
+            paddingLeft: themeSpacing,
           },
         };
       }

--- a/packages/mui-system/src/spacing/spacing.test.js
+++ b/packages/mui-system/src/spacing/spacing.test.js
@@ -155,7 +155,7 @@ describe('system spacing', () => {
       expect(output).to.deep.equal({ padding: '-2em' });
     });
 
-    it('should support CSS variables', () => {
+    it('should support CSS variables single value', () => {
       const output = spacing({
         theme: {
           vars: {
@@ -165,6 +165,24 @@ describe('system spacing', () => {
         p: 1,
       });
       expect(output).to.deep.equal({ padding: 'calc(1 * var(--mui-spacing))' });
+    });
+
+    it('should support CSS variables array', () => {
+      const output = spacing({
+        theme: {
+          vars: {
+            spacing: [
+              'var(--mui-spacing-0)',
+              'var(--mui-spacing-1)',
+              'var(--mui-spacing-2)',
+              'var(--mui-spacing-3)',
+              'var(--mui-spacing-4)',
+            ],
+          },
+        },
+        p: 2,
+      });
+      expect(output).to.deep.equal({ padding: 'var(--mui-spacing-2)' });
     });
 
     it('should support breakpoints', () => {

--- a/packages/mui-system/src/spacing/spacing.test.js
+++ b/packages/mui-system/src/spacing/spacing.test.js
@@ -160,7 +160,7 @@ describe('system spacing', () => {
         theme: {
           vars: {
             spacing: 'var(--mui-spacing)',
-          }
+          },
         },
         p: 1,
       });

--- a/packages/mui-system/src/spacing/spacing.test.js
+++ b/packages/mui-system/src/spacing/spacing.test.js
@@ -155,6 +155,18 @@ describe('system spacing', () => {
       expect(output).to.deep.equal({ padding: '-2em' });
     });
 
+    it('should support CSS variables', () => {
+      const output = spacing({
+        theme: {
+          vars: {
+            spacing: 'var(--mui-spacing)',
+          }
+        },
+        p: 1,
+      });
+      expect(output).to.deep.equal({ padding: 'calc(1 * var(--mui-spacing))' });
+    });
+
     it('should support breakpoints', () => {
       const output1 = spacing({
         p: [1, 2],


### PR DESCRIPTION
The Grid is broken when using CSS variables, the regression was introduced in #40224 (visible on the description of the PR).

## Before

<img width="371" alt="SCR-20240608-roiu" src="https://github.com/mui/material-ui/assets/3165635/d0d7698a-85ed-478a-ac5b-63626465937b">

https://next--material-ui.netlify.app/core/

<img width="405" alt="SCR-20240608-rnio" src="https://github.com/mui/material-ui/assets/3165635/1c9fd796-5281-497e-b939-823f026e1089">

## After

<img width="370" alt="SCR-20240608-rogm" src="https://github.com/mui/material-ui/assets/3165635/ed4d6a18-f2b3-491f-af69-e2863d41a547">

https://deploy-preview-42574--material-ui.netlify.app/core/

<img width="416" alt="SCR-20240608-rnor" src="https://github.com/mui/material-ui/assets/3165635/954f62bd-d357-4e8d-abc6-4a32b9ba6eb7">

Now, I imagine that during v6 lifecycle we will deprecate https://mui.com/material-ui/react-grid/ for https://mui.com/material-ui/react-grid2/. But first, we will need to migrate all our marketing pages to use the new grid. And even once we do, the deprecated version should continue to work with CSS variables so developers can migrate to it.