### PR TITLE
[docs] Migrate to GA4

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -142,11 +142,15 @@ function Analytics() {
 
   const codeVariant = usePersistCodeVariant();
   React.useEffect(() => {
-    window.ga('set', 'dimension1', codeVariant);
+    window.gtag('set', 'user_properties', {
+      codeVariant,
+    });
   }, [codeVariant]);
 
   React.useEffect(() => {
-    window.ga('set', 'dimension2', options.userLanguage);
+    window.gtag('set', 'user_properties', {
+      userLanguage: options.userLanguage,
+    });
   }, [options.userLanguage]);
 
   React.useEffect(() => {
@@ -160,7 +164,9 @@ function Analytics() {
      * Adjusted to track 3 or more different ratios
      */
     function trackDevicePixelRation() {
-      window.ga('set', 'dimension3', Math.round(window.devicePixelRatio * 10) / 10);
+      window.gtag('set', 'user_properties', {
+        devicePixelRatio: Math.round(window.devicePixelRatio * 10) / 10,
+      });
 
       matchMedia = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
       // Need to setup again.

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -26,7 +26,8 @@ if (process.env.NODE_ENV === 'production') {
   cleanCSS = new CleanCSS();
 }
 
-const GOOGLE_ID = process.env.NODE_ENV === 'production' ? 'UA-106598593-2' : 'UA-106598593-3';
+const GOOGLE_ANALYTICS_ID_V4 =
+  process.env.NODE_ENV === 'production' ? 'G-5NXDQLC2ZK' : 'G-XJ83JQEK7J';
 
 export default class MyDocument extends Document {
   render() {
@@ -85,10 +86,19 @@ export default class MyDocument extends Document {
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html: `
-                window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-                window.ga('create','${GOOGLE_ID}','auto');
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+window.gtag = gtag;
+gtag('js', new Date());
+gtag('config', '${GOOGLE_ANALYTICS_ID_V4}', {
+  send_page_view: false,
+});
               `,
             }}
+          />
+          <script
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID_V4}`}
           />
           <NextScript />
         </body>

--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -76,8 +76,7 @@ const inHouseAds = [
   },
   {
     name: 'themes',
-    link:
-      'https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=in-house-themes',
+    link: 'https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=in-house-themes',
     img: '/static/ads-in-house/themes.png',
     description:
       '<b>Premium Themes</b>. Kickstart your application development with a ready-made theme.',
@@ -194,9 +193,7 @@ function Ad(props) {
     }
 
     const delay = setTimeout(() => {
-      window.ga('send', {
-        hitType: 'event',
-        eventCategory: 'ad',
+      window.gtag('event', 'ad', {
         eventAction: 'display',
         eventLabel,
       });

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -17,9 +17,7 @@ function handleClick(event) {
 
     // We reach a tracking element, no need to look higher in the dom tree.
     if (category) {
-      window.ga('send', {
-        hitType: 'event',
-        eventCategory: category,
+      window.gtag('event', category, {
         eventAction: element.getAttribute('data-ga-event-action'),
         eventLabel: element.getAttribute('data-ga-event-label'),
       });
@@ -33,12 +31,20 @@ function handleClick(event) {
 let bound = false;
 
 export default function GoogleAnalytics() {
+  const timeout = React.useRef();
+
   React.useEffect(() => {
     // Wait for the title to be updated.
-    setTimeout(() => {
+    // React fires useEffect twice in dev mode
+    clearTimeout(timeout.current);
+    timeout.current = setTimeout(() => {
       const { canonical } = pathnameToLanguage(window.location.pathname);
-      window.ga('set', { page: canonical });
-      window.ga('send', { hitType: 'pageview' });
+
+      // https://developers.google.com/analytics/devguides/collection/ga4/views?client_type=gtag
+      window.gtag('event', 'page_view', {
+        page_title: document.title,
+        page_location: canonical,
+      });
     });
 
     if (bound) {

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -424,9 +424,7 @@ export default function SearchIcons() {
 
             // Keep track of the no results so we can add synonyms in the future.
             if (value.length >= 4 && results.length === 0) {
-              window.ga('send', {
-                hitType: 'event',
-                eventCategory: 'material-icons',
+              window.gtag('event', 'material-icons', {
                 eventAction: 'no-results',
                 eventLabel: value,
               });


### PR DESCRIPTION
Rollout #36123 to https://v4.mui.com/. For context: https://docs.google.com/presentation/d/1-nxGF1N_WepPmIZEu7Og7tQ1V6T5xPwiC-MBai0pvpM/edit?disco=AAABPstWhaA.

I'm curious to see how GA4 will handle these subdomains, we will need to make it work for https://www.notion.so/mui-org/docs-infra-Change-docs-domain-0ce329e7ebc34aba8fbf4f3c5e13eb5d. Apparently, it's messy. Another case where Google Universal was better than GA4: https://www.analyticsmania.com/post/subdomain-tracking-with-google-analytics-and-google-tag-manager/#full-urls

P.S. The CI is red, it's expected, it can't run anymore, the dependencies are gone.