### PR TITLE
[material-ui][Divider] To propose usability improvements for Divider component when has children.

### DIFF
--- a/packages/mui-material/src/Divider/Divider.js
+++ b/packages/mui-material/src/Divider/Divider.js
@@ -141,6 +141,7 @@ const DividerRoot = styled('div', {
         '&::before, &::after': {
           content: '""',
           alignSelf: 'center',
+          border: 0,
         },
       },
     },


### PR DESCRIPTION
fixes [#42569](https://github.com/mui/material-ui/issues/42569)

If Divider component has children, rendered using 'div' tag but border style actually in pseudo elements(::befote, ::after)
So custom style applied only div tag like below.
```
const StyledDivider = styled(Divider)(({}) => ({
  "&::before": {
    width: "3.75rem",
    flex: "0 0 3.75rem",
  },
  borderStyle: `dashed`, // this is apply only 'div'
}));
```

If we want to use it immediately, use [this way](https://github.com/mui/material-ui/issues/42569#issuecomment-2156420010).

but someone don't know border "top" style, or border "bottom" style ~ whatever.
This PR simply requires writing "borderStyle" in the pseudo-element.

### example
```
const StyledDivider = styled(Divider)(({}) => ({
  "&::before": {
    width: "3.75rem",
    flex: "0 0 3.75rem",
    borderStyle: `dashed`
  },
  "&::after": {
    borderStyle: `dashed`
  },
}));
```

Thanks for read!