### PR TITLE
[docs] Recommend setting HTML attribute instead of DOM property for RTL

### DIFF
--- a/docs/data/joy/customization/right-to-left/right-to-left.md
+++ b/docs/data/joy/customization/right-to-left/right-to-left.md
@@ -23,7 +23,7 @@ Add `dir="rtl"` to the app's root `<html>` tag to set the global text direction:
 If your React app doesn't control the root `<html>`, use the JavaScript API before the component tree is rendered, as a workaround:
 
 ```js
-document.dir = 'rtl';
+document.documentElement.setAttribute('dir', 'rtl');
 ```
 
 #### Locally

--- a/docs/data/joy/customization/right-to-left/right-to-left.md
+++ b/docs/data/joy/customization/right-to-left/right-to-left.md
@@ -20,7 +20,7 @@ Add `dir="rtl"` to the app's root `<html>` tag to set the global text direction:
 <html dir="rtl"></html>
 ```
 
-If your React app doesn't control the root `<html>`, use the JavaScript API before the component tree is rendered, as a workaround:
+If you can't set the `dir` attribute directly on the root `<html>` element, as a workaround, use the JavaScript API before the page is rendered:
 
 ```js
 document.documentElement.setAttribute('dir', 'rtl');

--- a/docs/data/material/customization/right-to-left/right-to-left.md
+++ b/docs/data/material/customization/right-to-left/right-to-left.md
@@ -20,7 +20,7 @@ Add `dir="rtl"` to the app's root `<html>` to set the global text direction:
 <html dir="rtl"></html>
 ```
 
-If your React app doesn't control the root `<html>`, use the JavaScript API before the component tree is rendered, as a workaround:
+If you can't set the `dir` attribute directly on the the root `<html>` element, as a workaround, use the JavaScript API before the page is rendered:
 
 ```js
 document.documentElement.setAttribute('dir', 'rtl');

--- a/docs/data/material/customization/right-to-left/right-to-left.md
+++ b/docs/data/material/customization/right-to-left/right-to-left.md
@@ -23,7 +23,7 @@ Add `dir="rtl"` to the app's root `<html>` to set the global text direction:
 If your React app doesn't control the root `<html>`, use the JavaScript API before the component tree is rendered, as a workaround:
 
 ```js
-document.dir = 'rtl';
+document.documentElement.setAttribute('dir', 'rtl');
 ```
 
 #### Locally


### PR DESCRIPTION
Update docs on how to set `dir="rtl"`. Recommend using an HTML attribute instead of using a DOM property. This seems more correct per https://jakearchibald.com/2024/attributes-vs-properties.

Suggested by @oliviertassinari in https://github.com/mui/material-ui/pull/42566#discussion_r1631604244.