### PR TITLE
[core] Allow `for..of` loops

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const { rules: baseStyleRules } = require('eslint-config-airbnb-base/rules/style');
 
 const OneLevelImportMessage = [
   'Prefer one level nested imports to avoid bundling everything in dev mode or breaking CJS/ESM split.',
@@ -185,8 +184,7 @@ module.exports = {
     'react/jsx-no-target-blank': ['error', { allowReferrer: true }],
 
     'no-restricted-syntax': [
-      // See https://github.com/eslint/eslint/issues/9192 for why it's needed
-      ...baseStyleRules['no-restricted-syntax'],
+      'error',
       {
         message:
           "Do not import default or named exports from React. Use a namespace import (import * as React from 'react';) instead.",

--- a/docs/data/joy/customization/theme-colors/PaletteThemeViewer.js
+++ b/docs/data/joy/customization/theme-colors/PaletteThemeViewer.js
@@ -18,7 +18,6 @@ const traverseObject = (palette) => {
   const result = {};
   const traverse = (object, parts = []) => {
     if (object && typeof object === 'object') {
-      // eslint-disable-next-line no-restricted-syntax
       for (const key of Object.keys(object)) {
         traverse(object[key], [...parts, key]);
       }

--- a/docs/data/joy/customization/theme-colors/PaletteThemeViewer.tsx
+++ b/docs/data/joy/customization/theme-colors/PaletteThemeViewer.tsx
@@ -18,7 +18,6 @@ const traverseObject = (palette: Palette) => {
   const result: Record<string, any> = {};
   const traverse = (object: any, parts: string[] = []) => {
     if (object && typeof object === 'object') {
-      // eslint-disable-next-line no-restricted-syntax
       for (const key of Object.keys(object)) {
         traverse(object[key], [...parts, key]);
       }

--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
     "enzyme": "^3.11.0",
     "eslint": "^8.57.0",
     "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-webpack": "^0.13.8",

--- a/packages/api-docs-builder/utils/parseTest.ts
+++ b/packages/api-docs-builder/utils/parseTest.ts
@@ -136,7 +136,6 @@ export default async function parseTest(componentFilename: string): Promise<Pars
   let descriptor: ReturnType<typeof findConformanceDescriptor> = null;
 
   try {
-    // eslint-disable-next-line no-restricted-syntax
     for await (const testFilename of testFilenames) {
       if (descriptor === null) {
         const babelParseResult = await parseWithConfig(testFilename);

--- a/packages/mui-base/scripts/testModuleAugmentation.js
+++ b/packages/mui-base/scripts/testModuleAugmentation.js
@@ -38,7 +38,6 @@ async function main() {
   // approximate pnpm lerna --concurrency 7
   const tsconfigPathsChunks = chunk(tsconfigPaths, 7);
 
-  // eslint-disable-next-line no-restricted-syntax
   for await (const tsconfigPathsChunk of tsconfigPathsChunks) {
     await Promise.all(
       tsconfigPathsChunk.map(async (tsconfigPath) => {

--- a/packages/mui-codemod/codemod.js
+++ b/packages/mui-codemod/codemod.js
@@ -23,7 +23,6 @@ async function runJscodeshiftTransform(transform, files, flags, codemodFlags) {
 
   let transformerPath;
   let error;
-  // eslint-disable-next-line no-restricted-syntax
   for (const item of paths) {
     try {
       // eslint-disable-next-line no-await-in-loop
@@ -113,7 +112,6 @@ async function runPostcssTransform(transform, files) {
 
   let configPath;
   let error;
-  // eslint-disable-next-line no-restricted-syntax
   for (const item of paths) {
     try {
       // eslint-disable-next-line no-await-in-loop

--- a/packages/mui-joy/scripts/testModuleAugmentation.js
+++ b/packages/mui-joy/scripts/testModuleAugmentation.js
@@ -38,7 +38,6 @@ async function main() {
   // approximate pnpm lerna --concurrency 7
   const tsconfigPathsChunks = chunk(tsconfigPaths, 7);
 
-  // eslint-disable-next-line no-restricted-syntax
   for await (const tsconfigPathsChunk of tsconfigPathsChunks) {
     await Promise.all(
       tsconfigPathsChunk.map(async (tsconfigPath) => {

--- a/packages/mui-material/scripts/testModuleAugmentation.js
+++ b/packages/mui-material/scripts/testModuleAugmentation.js
@@ -38,7 +38,6 @@ async function main() {
   // approximate pnpm lerna --concurrency 7
   const tsconfigPathsChunks = chunk(tsconfigPaths, 7);
 
-  // eslint-disable-next-line no-restricted-syntax
   for await (const tsconfigPathsChunk of tsconfigPathsChunks) {
     await Promise.all(
       tsconfigPathsChunk.map(async (tsconfigPath) => {

--- a/packages/mui-material/src/styles/createTheme.js
+++ b/packages/mui-material/src/styles/createTheme.js
@@ -65,7 +65,7 @@ function createTheme(options = {}, ...args) {
     const traverse = (node, component) => {
       let key;
 
-      // eslint-disable-next-line guard-for-in, no-restricted-syntax
+      // eslint-disable-next-line guard-for-in
       for (key in node) {
         const child = node[key];
         if (stateClasses.indexOf(key) !== -1 && Object.keys(child).length > 0) {

--- a/packages/mui-styles/src/getThemeProps/getThemeProps.js
+++ b/packages/mui-styles/src/getThemeProps/getThemeProps.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax */
 export default function getThemeProps(params) {
   const { theme, name, props } = params;
 

--- a/packages/mui-system/scripts/testModuleAugmentation.js
+++ b/packages/mui-system/scripts/testModuleAugmentation.js
@@ -38,7 +38,6 @@ async function main() {
   // approximate pnpm lerna --concurrency 7
   const tsconfigPathsChunks = chunk(tsconfigPaths, 7);
 
-  // eslint-disable-next-line no-restricted-syntax
   for await (const tsconfigPathsChunk of tsconfigPathsChunks) {
     await Promise.all(
       tsconfigPathsChunk.map(async (tsconfigPath) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,9 +185,6 @@ importers:
       eslint-config-airbnb:
         specifier: ^19.0.4
         version: 19.0.4(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-webpack@0.13.8)(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.7.1(eslint@8.57.0))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.0))(eslint-plugin-react@7.34.2(eslint@8.57.0))(eslint@8.57.0)
-      eslint-config-airbnb-base:
-        specifier: ^15.0.0
-        version: 15.0.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-webpack@0.13.8)(eslint@8.57.0))(eslint@8.57.0)
       eslint-config-airbnb-typescript:
         specifier: ^18.0.0
         version: 18.0.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-webpack@0.13.8)(eslint@8.57.0))(eslint@8.57.0)


### PR DESCRIPTION
Removed the `eslint-config-airbnb-base` package. It is meant to be used in non-React apps.
The primary reason for its removal is to allow using iterators and the `for..of` loops, as the browser support is good (the spec is a part of ES2015).

Removal of this package also removes 3 additional no-restricted-syntax rules:
```js
{
  selector: 'ForInStatement',
  message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
},
{
  selector: 'LabeledStatement',
  message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
},
{
  selector: 'WithStatement',
  message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
},
```

However, we have other rules that prevent writing unsafe code using these constructs: `guard-for-in`, `no-labels`, and `no-with`.

Note that writing for..of loops in projects in this repo is still prevented by tsconfig's `target` being set to "ES5". Changing this should be discussed first in a separate PR.