### PR TITLE
[material-ui][docs] Fix typo on Sign-in/Sign-up templates

### DIFF
--- a/docs/data/material/getting-started/templates/sign-in/SignIn.js
+++ b/docs/data/material/getting-started/templates/sign-in/SignIn.js
@@ -86,7 +86,7 @@ const Card = styled(MuiCard)(({ theme }) => ({
 
 const SignInContainer = styled(Stack)(({ theme }) => ({
   height: 'auto',
-  padingBottom: theme.spacing(12),
+  paddingBottom: theme.spacing(12),
   backgroundImage:
     theme.palette.mode === 'light'
       ? 'radial-gradient(ellipse at 50% 50%, hsl(210, 100%, 97%), hsl(0, 0%, 100%))'

--- a/docs/data/material/getting-started/templates/sign-in/SignIn.tsx
+++ b/docs/data/material/getting-started/templates/sign-in/SignIn.tsx
@@ -86,7 +86,7 @@ const Card = styled(MuiCard)(({ theme }) => ({
 
 const SignInContainer = styled(Stack)(({ theme }) => ({
   height: 'auto',
-  padingBottom: theme.spacing(12),
+  paddingBottom: theme.spacing(12),
   backgroundImage:
     theme.palette.mode === 'light'
       ? 'radial-gradient(ellipse at 50% 50%, hsl(210, 100%, 97%), hsl(0, 0%, 100%))'

--- a/docs/data/material/getting-started/templates/sign-up/SignUp.js
+++ b/docs/data/material/getting-started/templates/sign-up/SignUp.js
@@ -85,7 +85,7 @@ const Card = styled(MuiCard)(({ theme }) => ({
 
 const SignUpContainer = styled(Stack)(({ theme }) => ({
   height: 'auto',
-  padingBottom: theme.spacing(12),
+  paddingBottom: theme.spacing(12),
   backgroundImage:
     theme.palette.mode === 'light'
       ? 'radial-gradient(ellipse at 50% 50%, hsl(210, 100%, 97%), hsl(0, 0%, 100%))'

--- a/docs/data/material/getting-started/templates/sign-up/SignUp.tsx
+++ b/docs/data/material/getting-started/templates/sign-up/SignUp.tsx
@@ -85,7 +85,7 @@ const Card = styled(MuiCard)(({ theme }) => ({
 
 const SignUpContainer = styled(Stack)(({ theme }) => ({
   height: 'auto',
-  padingBottom: theme.spacing(12),
+  paddingBottom: theme.spacing(12),
   backgroundImage:
     theme.palette.mode === 'light'
       ? 'radial-gradient(ellipse at 50% 50%, hsl(210, 100%, 97%), hsl(0, 0%, 100%))'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fix typo (`padingBottom` to `paddingBottom`) on the sign-in and sign-up templates according to [this comment](https://github.com/mui/material-ui/pull/41845#discussion_r1633519740)