### PR TITLE
[code-infra] Allow other packages than base to export hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@babel/cli": "^7.24.7",
     "@babel/core": "^7.24.7",
     "@babel/node": "^7.24.7",
+    "@babel/parser": "^7.24.7",
     "@babel/plugin-transform-react-constant-elements": "^7.24.7",
     "@babel/plugin-transform-runtime": "^7.24.7",
     "@babel/preset-env": "^7.24.7",

--- a/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
@@ -199,7 +199,7 @@ async function annotateHookDefinition(
         if (node.declaration.id?.name !== fileName) {
           return;
         }
-      } else if (!node.declaration) {
+      } else if (node.declaration == null) {
         // export { useHook };
 
         node.specifiers.forEach((specifier) => {

--- a/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
@@ -192,7 +192,7 @@ async function annotateHookDefinition(
     },
 
     ExportNamedDeclaration(babelPath) {
-      let node = babelPath.node;
+      let node: babel.Node = babelPath.node;
 
       if (babel.types.isTSDeclareFunction(node.declaration)) {
         // export function useHook() in .d.ts

--- a/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
@@ -192,14 +192,14 @@ async function annotateHookDefinition(
     },
 
     ExportNamedDeclaration(babelPath) {
-      let node: babel.Node = babelPath.node;
+      let node = babelPath.node;
 
       if (babel.types.isTSDeclareFunction(node.declaration)) {
         // export function useHook() in .d.ts
         if (node.declaration.id?.name !== fileName) {
           return;
         }
-      } else if (node.declaration == null) {
+      } else if (!node.declaration) {
         // export { useHook };
 
         node.specifiers.forEach((specifier) => {

--- a/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
@@ -192,10 +192,6 @@ async function annotateHookDefinition(
     },
 
     ExportNamedDeclaration(babelPath) {
-      if (!api.filename.includes('mui-base')) {
-        return;
-      }
-
       let node: babel.Node = babelPath.node;
 
       if (babel.types.isTSDeclareFunction(node.declaration)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@babel/node':
         specifier: ^7.24.7
         version: 7.24.7(@babel/core@7.24.7)
+      '@babel/parser':
+        specifier: ^7.24.7
+        version: 7.24.7
       '@babel/plugin-transform-react-constant-elements':
         specifier: ^7.24.7
         version: 7.24.7(@babel/core@7.24.7)


### PR DESCRIPTION
Make hooks api doc generation work in Toolpad

Adding `@babel/parser`, otherwise it doesn't seem to be able to type the `ParseResult` correctly. Not completely sure why exactly.