### PR TITLE
[material-ui][FocusTrap] Update getTabbable return type from string[] to HTMLElement[]

### DIFF
--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -278,7 +278,7 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
         return;
       }
 
-      let tabbable: ReadonlyArray<string> | HTMLElement[] = [];
+      let tabbable: ReadonlyArray<HTMLElement> | HTMLElement[] = [];
       if (
         doc.activeElement === sentinelStart.current ||
         doc.activeElement === sentinelEnd.current

--- a/packages/mui-base/src/FocusTrap/FocusTrap.types.ts
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.types.ts
@@ -10,7 +10,7 @@ export interface FocusTrapProps {
    * For instance, you can provide the "tabbable" npm dependency.
    * @param {HTMLElement} root
    */
-  getTabbable?: (root: HTMLElement) => ReadonlyArray<string>;
+  getTabbable?: (root: HTMLElement) => ReadonlyArray<HTMLElement>;
   /**
    * This prop extends the `open` prop.
    * It allows to toggle the open state without having to wait for a rerender when changing the `open` prop.


### PR DESCRIPTION
Two files upadated
1.FocusTrap.ts : Change the return type of the getTabbable function from ReadonlyArray<string> to 2.ReadonlyArray<HTMLElement>.
FocusTrap.types.ts : Change the return type of the getTabbable function from ReadonlyArray<string> to ReadonlyArray<HTMLElement>.


- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
