### PR TITLE
[docs-infra] Allow Link component to receive the `role` attribute

### DIFF
--- a/docs/pages/experiments/website/branding-theme-test.tsx
+++ b/docs/pages/experiments/website/branding-theme-test.tsx
@@ -10,6 +10,7 @@ import AppHeader from 'docs/src/layouts/AppHeader';
 import Section from 'docs/src/layouts/Section';
 import AppFooter from 'docs/src/layouts/AppFooter';
 import GitHubIcon from '@mui/icons-material/GitHub';
+import { Link } from '@mui/docs/Link';
 
 export default function BrandingThemeTest() {
   return (
@@ -18,6 +19,12 @@ export default function BrandingThemeTest() {
       <AppHeader gitHubRepository="https://github.com/mui/material-ui" />
       <main id="main-content">
         <Section>
+          <Stack direction="row" spacing={2} useFlexGap sx={{ width: 'fit-content', mb: 4 }}>
+            <Link href="/">Link with no role</Link>
+            <Link href="/" role="menuitem">
+              Link role menuitem
+            </Link>
+          </Stack>
           <Stack direction="row" spacing={2} useFlexGap sx={{ width: 'fit-content' }}>
             <Chip size="small" variant="outlined" color="primary" label="Hiring" />
             <Chip size="small" variant="outlined" color="info" label="Hiring" />

--- a/packages/mui-docs/src/Link/Link.tsx
+++ b/packages/mui-docs/src/Link/Link.tsx
@@ -80,7 +80,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link
     noLinkStyle,
     prefetch,
     replace,
-    role, // Link don't have roles.
     scroll,
     shallow,
     ...other

--- a/packages/mui-docs/src/branding/brandingTheme.ts
+++ b/packages/mui-docs/src/branding/brandingTheme.ts
@@ -933,7 +933,7 @@ export function getThemedComponents(): ThemeOptions {
           root: ({ theme }) => ({
             display: 'inline-flex',
             alignItems: 'center',
-            fontWeight: theme.typography.fontWeightSemiBold,
+            fontWeight: theme.typography.fontWeightMedium,
             '&.MuiTypography-body1 > svg': {
               marginTop: 2,
             },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I'm not sure why the docs-infra LInk component had the "Link don't have roles" rule, which seems like an incorrect thing according to the `<a>` tag specs ([see MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#technical_summary)). 

A use case for a custom `role` in links is when you have a menu, and you want each menu item rendered as an `a` tag instead of `button`. Still, you'd need to use the correct role assignment—and thus `role="menuitem"` should be there—regardless of the tag. That's exactly what I was trying to do in https://github.com/mui/material-ui/pull/42603 and couldn't with the docs-infra Link component.

Let me know if there's anything to do aside from just removing the prop there!

Preview: https://deploy-preview-42629--material-ui.netlify.app/experiments/website/branding-theme-test/