### PR TITLE
Refactor typeScript types for button component

### DIFF
--- a/apps/local-ui-lib/index.d.ts
+++ b/apps/local-ui-lib/index.d.ts
@@ -1,9 +1,9 @@
-import * as React from 'react';
+// specific types for better readability and reusability
+type ButtonProps = React.JSX.IntrinsicElements['button'] & {
+  isRed?: boolean; 
+  sx?: React.CSSProperties; // React.CSSProperties for better integration with CSS in JS
+};
 
 export const bounceAnim: string;
-export const Button: React.ComponentType<
-  React.JSX.IntrinsicElements['button'] & {
-    isRed?: boolean;
-    sx?: unknown;
-  }
->;
+export const Button: React.ComponentType<ButtonProps>;
+


### PR DESCRIPTION
Changed the type of sx from unknown to React.CSSProperties, it provides a more specific and useful type hint that integrates better with TypeScript's type checking, button component's are now reusable, export statements remain untouched in terms of their purpose but now reference improved types, making them more robust in a type-checked environment

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
