### PR TITLE
[material-ui][Autocomplete] Fix more React 18.3 key spread warnings in demos

### DIFF
--- a/docs/data/material/components/autocomplete/CheckboxesTags.js
+++ b/docs/data/material/components/autocomplete/CheckboxesTags.js
@@ -16,17 +16,20 @@ export default function CheckboxesTags() {
       options={top100Films}
       disableCloseOnSelect
       getOptionLabel={(option) => option.title}
-      renderOption={(props, option, { selected }) => (
-        <li {...props}>
-          <Checkbox
-            icon={icon}
-            checkedIcon={checkedIcon}
-            style={{ marginRight: 8 }}
-            checked={selected}
-          />
-          {option.title}
-        </li>
-      )}
+      renderOption={(props, option, { selected }) => {
+        const { key, ...optionProps } = props;
+        return (
+          <li key={key} {...optionProps}>
+            <Checkbox
+              icon={icon}
+              checkedIcon={checkedIcon}
+              style={{ marginRight: 8 }}
+              checked={selected}
+            />
+            {option.title}
+          </li>
+        );
+      }}
       style={{ width: 500 }}
       renderInput={(params) => (
         <TextField {...params} label="Checkboxes" placeholder="Favorites" />

--- a/docs/data/material/components/autocomplete/CheckboxesTags.tsx
+++ b/docs/data/material/components/autocomplete/CheckboxesTags.tsx
@@ -16,17 +16,20 @@ export default function CheckboxesTags() {
       options={top100Films}
       disableCloseOnSelect
       getOptionLabel={(option) => option.title}
-      renderOption={(props, option, { selected }) => (
-        <li {...props}>
-          <Checkbox
-            icon={icon}
-            checkedIcon={checkedIcon}
-            style={{ marginRight: 8 }}
-            checked={selected}
-          />
-          {option.title}
-        </li>
-      )}
+      renderOption={(props, option, { selected }) => {
+        const { key, ...optionProps } = props;
+        return (
+          <li key={key} {...optionProps}>
+            <Checkbox
+              icon={icon}
+              checkedIcon={checkedIcon}
+              style={{ marginRight: 8 }}
+              checked={selected}
+            />
+            {option.title}
+          </li>
+        );
+      }}
       style={{ width: 500 }}
       renderInput={(params) => (
         <TextField {...params} label="Checkboxes" placeholder="Favorites" />

--- a/docs/data/material/components/autocomplete/CountrySelect.js
+++ b/docs/data/material/components/autocomplete/CountrySelect.js
@@ -11,18 +11,26 @@ export default function CountrySelect() {
       options={countries}
       autoHighlight
       getOptionLabel={(option) => option.label}
-      renderOption={(props, option) => (
-        <Box component="li" sx={{ '& > img': { mr: 2, flexShrink: 0 } }} {...props}>
-          <img
-            loading="lazy"
-            width="20"
-            srcSet={`https://flagcdn.com/w40/${option.code.toLowerCase()}.png 2x`}
-            src={`https://flagcdn.com/w20/${option.code.toLowerCase()}.png`}
-            alt=""
-          />
-          {option.label} ({option.code}) +{option.phone}
-        </Box>
-      )}
+      renderOption={(props, option) => {
+        const { key, ...optionProps } = props;
+        return (
+          <Box
+            key={key}
+            component="li"
+            sx={{ '& > img': { mr: 2, flexShrink: 0 } }}
+            {...optionProps}
+          >
+            <img
+              loading="lazy"
+              width="20"
+              srcSet={`https://flagcdn.com/w40/${option.code.toLowerCase()}.png 2x`}
+              src={`https://flagcdn.com/w20/${option.code.toLowerCase()}.png`}
+              alt=""
+            />
+            {option.label} ({option.code}) +{option.phone}
+          </Box>
+        );
+      }}
       renderInput={(params) => (
         <TextField
           {...params}

--- a/docs/data/material/components/autocomplete/CountrySelect.tsx
+++ b/docs/data/material/components/autocomplete/CountrySelect.tsx
@@ -11,18 +11,26 @@ export default function CountrySelect() {
       options={countries}
       autoHighlight
       getOptionLabel={(option) => option.label}
-      renderOption={(props, option) => (
-        <Box component="li" sx={{ '& > img': { mr: 2, flexShrink: 0 } }} {...props}>
-          <img
-            loading="lazy"
-            width="20"
-            srcSet={`https://flagcdn.com/w40/${option.code.toLowerCase()}.png 2x`}
-            src={`https://flagcdn.com/w20/${option.code.toLowerCase()}.png`}
-            alt=""
-          />
-          {option.label} ({option.code}) +{option.phone}
-        </Box>
-      )}
+      renderOption={(props, option) => {
+        const { key, ...optionProps } = props;
+        return (
+          <Box
+            key={key}
+            component="li"
+            sx={{ '& > img': { mr: 2, flexShrink: 0 } }}
+            {...optionProps}
+          >
+            <img
+              loading="lazy"
+              width="20"
+              srcSet={`https://flagcdn.com/w40/${option.code.toLowerCase()}.png 2x`}
+              src={`https://flagcdn.com/w20/${option.code.toLowerCase()}.png`}
+              alt=""
+            />
+            {option.label} ({option.code}) +{option.phone}
+          </Box>
+        );
+      }}
       renderInput={(params) => (
         <TextField
           {...params}

--- a/docs/data/material/components/autocomplete/FreeSoloCreateOption.js
+++ b/docs/data/material/components/autocomplete/FreeSoloCreateOption.js
@@ -56,7 +56,14 @@ export default function FreeSoloCreateOption() {
         // Regular option
         return option.title;
       }}
-      renderOption={(props, option) => <li {...props}>{option.title}</li>}
+      renderOption={(props, option) => {
+        const { key, ...optionProps } = props;
+        return (
+          <li key={key} {...optionProps}>
+            {option.title}
+          </li>
+        );
+      }}
       sx={{ width: 300 }}
       freeSolo
       renderInput={(params) => (

--- a/docs/data/material/components/autocomplete/FreeSoloCreateOption.tsx
+++ b/docs/data/material/components/autocomplete/FreeSoloCreateOption.tsx
@@ -56,7 +56,14 @@ export default function FreeSoloCreateOption() {
         // Regular option
         return option.title;
       }}
-      renderOption={(props, option) => <li {...props}>{option.title}</li>}
+      renderOption={(props, option) => {
+        const { key, ...optionProps } = props;
+        return (
+          <li key={key} {...optionProps}>
+            {option.title}
+          </li>
+        );
+      }}
       sx={{ width: 300 }}
       freeSolo
       renderInput={(params) => (

--- a/docs/data/material/components/autocomplete/FreeSoloCreateOptionDialog.js
+++ b/docs/data/material/components/autocomplete/FreeSoloCreateOptionDialog.js
@@ -87,7 +87,14 @@ export default function FreeSoloCreateOptionDialog() {
         selectOnFocus
         clearOnBlur
         handleHomeEndKeys
-        renderOption={(props, option) => <li {...props}>{option.title}</li>}
+        renderOption={(props, option) => {
+          const { key, ...optionProps } = props;
+          return (
+            <li key={key} {...optionProps}>
+              {option.title}
+            </li>
+          );
+        }}
         sx={{ width: 300 }}
         freeSolo
         renderInput={(params) => <TextField {...params} label="Free solo dialog" />}

--- a/docs/data/material/components/autocomplete/FreeSoloCreateOptionDialog.tsx
+++ b/docs/data/material/components/autocomplete/FreeSoloCreateOptionDialog.tsx
@@ -87,7 +87,14 @@ export default function FreeSoloCreateOptionDialog() {
         selectOnFocus
         clearOnBlur
         handleHomeEndKeys
-        renderOption={(props, option) => <li {...props}>{option.title}</li>}
+        renderOption={(props, option) => {
+          const { key, ...optionProps } = props;
+          return (
+            <li key={key} {...optionProps}>
+              {option.title}
+            </li>
+          );
+        }}
         sx={{ width: 300 }}
         freeSolo
         renderInput={(params) => <TextField {...params} label="Free solo dialog" />}

--- a/docs/data/material/components/autocomplete/GitHubLabel.js
+++ b/docs/data/material/components/autocomplete/GitHubLabel.js
@@ -214,51 +214,54 @@ export default function GitHubLabel() {
               disableCloseOnSelect
               renderTags={() => null}
               noOptionsText="No labels"
-              renderOption={(props, option, { selected }) => (
-                <li {...props}>
-                  <Box
-                    component={DoneIcon}
-                    sx={{ width: 17, height: 17, mr: '5px', ml: '-2px' }}
-                    style={{
-                      visibility: selected ? 'visible' : 'hidden',
-                    }}
-                  />
-                  <Box
-                    component="span"
-                    sx={{
-                      width: 14,
-                      height: 14,
-                      flexShrink: 0,
-                      borderRadius: '3px',
-                      mr: 1,
-                      mt: '2px',
-                    }}
-                    style={{ backgroundColor: option.color }}
-                  />
-                  <Box
-                    sx={(t) => ({
-                      flexGrow: 1,
-                      '& span': {
-                        color: '#8b949e',
-                        ...t.applyStyles('light', {
-                          color: '#586069',
-                        }),
-                      },
-                    })}
-                  >
-                    {option.name}
-                    <br />
-                    <span>{option.description}</span>
-                  </Box>
-                  <Box
-                    component={CloseIcon}
-                    sx={{ opacity: 0.6, width: 18, height: 18 }}
-                    style={{
-                      visibility: selected ? 'visible' : 'hidden',
-                    }}
-                  />
-                </li>
-              )}
+              renderOption={(props, option, { selected }) => {
+                const { key, ...optionProps } = props;
+                return (
+                  <li key={key} {...optionProps}>
+                    <Box
+                      component={DoneIcon}
+                      sx={{ width: 17, height: 17, mr: '5px', ml: '-2px' }}
+                      style={{
+                        visibility: selected ? 'visible' : 'hidden',
+                      }}
+                    />
+                    <Box
+                      component="span"
+                      sx={{
+                        width: 14,
+                        height: 14,
+                        flexShrink: 0,
+                        borderRadius: '3px',
+                        mr: 1,
+                        mt: '2px',
+                      }}
+                      style={{ backgroundColor: option.color }}
+                    />
+                    <Box
+                      sx={(t) => ({
+                        flexGrow: 1,
+                        '& span': {
+                          color: '#8b949e',
+                          ...t.applyStyles('light', {
+                            color: '#586069',
+                          }),
+                        },
+                      })}
+                    >
+                      {option.name}
+                      <br />
+                      <span>{option.description}</span>
+                    </Box>
+                    <Box
+                      component={CloseIcon}
+                      sx={{ opacity: 0.6, width: 18, height: 18 }}
+                      style={{
+                        visibility: selected ? 'visible' : 'hidden',
+                      }}
+                    />
+                  </li>
+                );
+              }}
               options={[...labels].sort((a, b) => {
                 // Display the selected labels first.
                 let ai = value.indexOf(a);

--- a/docs/data/material/components/autocomplete/GitHubLabel.tsx
+++ b/docs/data/material/components/autocomplete/GitHubLabel.tsx
@@ -222,51 +222,54 @@ export default function GitHubLabel() {
               disableCloseOnSelect
               renderTags={() => null}
               noOptionsText="No labels"
-              renderOption={(props, option, { selected }) => (
-                <li {...props}>
-                  <Box
-                    component={DoneIcon}
-                    sx={{ width: 17, height: 17, mr: '5px', ml: '-2px' }}
-                    style={{
-                      visibility: selected ? 'visible' : 'hidden',
-                    }}
-                  />
-                  <Box
-                    component="span"
-                    sx={{
-                      width: 14,
-                      height: 14,
-                      flexShrink: 0,
-                      borderRadius: '3px',
-                      mr: 1,
-                      mt: '2px',
-                    }}
-                    style={{ backgroundColor: option.color }}
-                  />
-                  <Box
-                    sx={(t) => ({
-                      flexGrow: 1,
-                      '& span': {
-                        color: '#8b949e',
-                        ...t.applyStyles('light', {
-                          color: '#586069',
-                        }),
-                      },
-                    })}
-                  >
-                    {option.name}
-                    <br />
-                    <span>{option.description}</span>
-                  </Box>
-                  <Box
-                    component={CloseIcon}
-                    sx={{ opacity: 0.6, width: 18, height: 18 }}
-                    style={{
-                      visibility: selected ? 'visible' : 'hidden',
-                    }}
-                  />
-                </li>
-              )}
+              renderOption={(props, option, { selected }) => {
+                const { key, ...optionProps } = props;
+                return (
+                  <li key={key} {...optionProps}>
+                    <Box
+                      component={DoneIcon}
+                      sx={{ width: 17, height: 17, mr: '5px', ml: '-2px' }}
+                      style={{
+                        visibility: selected ? 'visible' : 'hidden',
+                      }}
+                    />
+                    <Box
+                      component="span"
+                      sx={{
+                        width: 14,
+                        height: 14,
+                        flexShrink: 0,
+                        borderRadius: '3px',
+                        mr: 1,
+                        mt: '2px',
+                      }}
+                      style={{ backgroundColor: option.color }}
+                    />
+                    <Box
+                      sx={(t) => ({
+                        flexGrow: 1,
+                        '& span': {
+                          color: '#8b949e',
+                          ...t.applyStyles('light', {
+                            color: '#586069',
+                          }),
+                        },
+                      })}
+                    >
+                      {option.name}
+                      <br />
+                      <span>{option.description}</span>
+                    </Box>
+                    <Box
+                      component={CloseIcon}
+                      sx={{ opacity: 0.6, width: 18, height: 18 }}
+                      style={{
+                        visibility: selected ? 'visible' : 'hidden',
+                      }}
+                    />
+                  </li>
+                );
+              }}
               options={[...labels].sort((a, b) => {
                 // Display the selected labels first.
                 let ai = value.indexOf(a);

--- a/docs/data/material/components/autocomplete/GloballyCustomizedOptions.js
+++ b/docs/data/material/components/autocomplete/GloballyCustomizedOptions.js
@@ -14,21 +14,25 @@ const customTheme = (outerTheme) =>
     components: {
       MuiAutocomplete: {
         defaultProps: {
-          renderOption: (props, option, state, ownerState) => (
-            <Box
-              sx={{
-                borderRadius: '8px',
-                margin: '5px',
-                [`&.${autocompleteClasses.option}`]: {
-                  padding: '8px',
-                },
-              }}
-              component="li"
-              {...props}
-            >
-              {ownerState.getOptionLabel(option)}
-            </Box>
-          ),
+          renderOption: (props, option, state, ownerState) => {
+            const { key, ...optionProps } = props;
+            return (
+              <Box
+                key={key}
+                sx={{
+                  borderRadius: '8px',
+                  margin: '5px',
+                  [`&.${autocompleteClasses.option}`]: {
+                    padding: '8px',
+                  },
+                }}
+                component="li"
+                {...optionProps}
+              >
+                {ownerState.getOptionLabel(option)}
+              </Box>
+            );
+          },
         },
       },
     },

--- a/docs/data/material/components/autocomplete/GloballyCustomizedOptions.tsx
+++ b/docs/data/material/components/autocomplete/GloballyCustomizedOptions.tsx
@@ -14,21 +14,25 @@ const customTheme = (outerTheme: Theme) =>
     components: {
       MuiAutocomplete: {
         defaultProps: {
-          renderOption: (props, option, state, ownerState) => (
-            <Box
-              sx={{
-                borderRadius: '8px',
-                margin: '5px',
-                [`&.${autocompleteClasses.option}`]: {
-                  padding: '8px',
-                },
-              }}
-              component="li"
-              {...props}
-            >
-              {ownerState.getOptionLabel(option)}
-            </Box>
-          ),
+          renderOption: (props, option, state, ownerState) => {
+            const { key, ...optionProps } = props;
+            return (
+              <Box
+                key={key}
+                sx={{
+                  borderRadius: '8px',
+                  margin: '5px',
+                  [`&.${autocompleteClasses.option}`]: {
+                    padding: '8px',
+                  },
+                }}
+                component="li"
+                {...optionProps}
+              >
+                {ownerState.getOptionLabel(option)}
+              </Box>
+            );
+          },
         },
       },
     },

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -113,6 +113,7 @@ export default function GoogleMaps() {
         <TextField {...params} label="Add a location" fullWidth />
       )}
       renderOption={(props, option) => {
+        const { key, ...optionProps } = props;
         const matches =
           option.structured_formatting.main_text_matched_substrings || [];
 
@@ -120,7 +121,6 @@ export default function GoogleMaps() {
           option.structured_formatting.main_text,
           matches.map((match) => [match.offset, match.offset + match.length]),
         );
-        const { key, ...optionProps } = props;
         return (
           <li key={key} {...optionProps}>
             <Grid container sx={{ alignItems: 'center' }}>

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -120,9 +120,9 @@ export default function GoogleMaps() {
           option.structured_formatting.main_text,
           matches.map((match) => [match.offset, match.offset + match.length]),
         );
-        const { key, ...nonKeyProps } = props;
+        const { key, ...optionProps } = props;
         return (
-          <li key={key} {...nonKeyProps}>
+          <li key={key} {...optionProps}>
             <Grid container sx={{ alignItems: 'center' }}>
               <Grid item sx={{ display: 'flex', width: 44 }}>
                 <LocationOnIcon sx={{ color: 'text.secondary' }} />

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -120,9 +120,9 @@ export default function GoogleMaps() {
           option.structured_formatting.main_text,
           matches.map((match) => [match.offset, match.offset + match.length]),
         );
-
+        const { key, ...nonKeyProps } = props;
         return (
-          <li {...props}>
+          <li key={key} {...nonKeyProps}>
             <Grid container sx={{ alignItems: 'center' }}>
               <Grid item sx={{ display: 'flex', width: 44 }}>
                 <LocationOnIcon sx={{ color: 'text.secondary' }} />

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -144,9 +144,9 @@ export default function GoogleMaps() {
           option.structured_formatting.main_text,
           matches.map((match: any) => [match.offset, match.offset + match.length]),
         );
-
+        const {key, ...nonKeyProps} = props as any;
         return (
-          <li {...props}>
+          <li key={key} {...nonKeyProps}>
             <Grid container sx={{ alignItems: 'center' }}>
               <Grid item sx={{ display: 'flex', width: 44 }}>
                 <LocationOnIcon sx={{ color: 'text.secondary' }} />

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -137,6 +137,7 @@ export default function GoogleMaps() {
         <TextField {...params} label="Add a location" fullWidth />
       )}
       renderOption={(props, option) => {
+        const { key, ...optionProps } = props;
         const matches =
           option.structured_formatting.main_text_matched_substrings || [];
 
@@ -144,7 +145,6 @@ export default function GoogleMaps() {
           option.structured_formatting.main_text,
           matches.map((match: any) => [match.offset, match.offset + match.length]),
         );
-        const { key, ...optionProps } = props;
         return (
           <li key={key} {...optionProps}>
             <Grid container sx={{ alignItems: 'center' }}>

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -144,7 +144,7 @@ export default function GoogleMaps() {
           option.structured_formatting.main_text,
           matches.map((match: any) => [match.offset, match.offset + match.length]),
         );
-        const {key, ...nonKeyProps} = props as any;
+        const { key, ...nonKeyProps } = props;
         return (
           <li key={key} {...nonKeyProps}>
             <Grid container sx={{ alignItems: 'center' }}>

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -144,9 +144,9 @@ export default function GoogleMaps() {
           option.structured_formatting.main_text,
           matches.map((match: any) => [match.offset, match.offset + match.length]),
         );
-        const { key, ...nonKeyProps } = props;
+        const { key, ...optionProps } = props;
         return (
-          <li key={key} {...nonKeyProps}>
+          <li key={key} {...optionProps}>
             <Grid container sx={{ alignItems: 'center' }}>
               <Grid item sx={{ display: 'flex', width: 44 }}>
                 <LocationOnIcon sx={{ color: 'text.secondary' }} />

--- a/docs/data/material/components/autocomplete/Highlights.js
+++ b/docs/data/material/components/autocomplete/Highlights.js
@@ -14,11 +14,12 @@ export default function Highlights() {
         <TextField {...params} label="Highlights" margin="normal" />
       )}
       renderOption={(props, option, { inputValue }) => {
+        const { key, ...optionProps } = props;
         const matches = match(option.title, inputValue, { insideWords: true });
         const parts = parse(option.title, matches);
 
         return (
-          <li {...props}>
+          <li key={key} {...optionProps}>
             <div>
               {parts.map((part, index) => (
                 <span

--- a/docs/data/material/components/autocomplete/Highlights.tsx
+++ b/docs/data/material/components/autocomplete/Highlights.tsx
@@ -14,11 +14,12 @@ export default function Highlights() {
         <TextField {...params} label="Highlights" margin="normal" />
       )}
       renderOption={(props, option, { inputValue }) => {
+        const { key, ...optionProps } = props;
         const matches = match(option.title, inputValue, { insideWords: true });
         const parts = parse(option.title, matches);
 
         return (
-          <li {...props}>
+          <li key={key} {...optionProps}>
             <div>
               {parts.map((part, index) => (
                 <span

--- a/docs/data/material/components/autocomplete/UseAutocomplete.js
+++ b/docs/data/material/components/autocomplete/UseAutocomplete.js
@@ -64,7 +64,7 @@ export default function UseAutocomplete() {
       {groupedOptions.length > 0 ? (
         <Listbox {...getListboxProps()}>
           {groupedOptions.map((option, index) => {
-            const { key, ...optionProps } = { ...getOptionProps({ option, index }) };
+            const { key, ...optionProps } = getOptionProps({ option, index });
             return (
               <li key={key} {...optionProps}>
                 {option.title}

--- a/docs/data/material/components/autocomplete/UseAutocomplete.js
+++ b/docs/data/material/components/autocomplete/UseAutocomplete.js
@@ -63,9 +63,14 @@ export default function UseAutocomplete() {
       </div>
       {groupedOptions.length > 0 ? (
         <Listbox {...getListboxProps()}>
-          {groupedOptions.map((option, index) => (
-            <li {...getOptionProps({ option, index })}>{option.title}</li>
-          ))}
+          {groupedOptions.map((option, index) => {
+            const { key, ...optionProps } = { ...getOptionProps({ option, index }) };
+            return (
+              <li key={key} {...optionProps}>
+                {option.title}
+              </li>
+            );
+          })}
         </Listbox>
       ) : null}
     </div>

--- a/docs/data/material/components/autocomplete/UseAutocomplete.tsx
+++ b/docs/data/material/components/autocomplete/UseAutocomplete.tsx
@@ -64,7 +64,7 @@ export default function UseAutocomplete() {
       {groupedOptions.length > 0 ? (
         <Listbox {...getListboxProps()}>
           {(groupedOptions as typeof top100Films).map((option, index) => {
-            const { key, ...optionProps } = { ...getOptionProps({ option, index }) };
+            const { key, ...optionProps } = getOptionProps({ option, index });
             return (
               <li key={key} {...optionProps}>
                 {option.title}

--- a/docs/data/material/components/autocomplete/UseAutocomplete.tsx
+++ b/docs/data/material/components/autocomplete/UseAutocomplete.tsx
@@ -63,9 +63,14 @@ export default function UseAutocomplete() {
       </div>
       {groupedOptions.length > 0 ? (
         <Listbox {...getListboxProps()}>
-          {(groupedOptions as typeof top100Films).map((option, index) => (
-            <li {...getOptionProps({ option, index })}>{option.title}</li>
-          ))}
+          {(groupedOptions as typeof top100Films).map((option, index) => {
+            const { key, ...optionProps } = { ...getOptionProps({ option, index }) };
+            return (
+              <li key={key} {...optionProps}>
+                {option.title}
+              </li>
+            );
+          })}
         </Listbox>
       ) : null}
     </div>

--- a/docs/data/material/components/autocomplete/UseAutocomplete.tsx.preview
+++ b/docs/data/material/components/autocomplete/UseAutocomplete.tsx.preview
@@ -5,7 +5,7 @@
 {groupedOptions.length > 0 ? (
   <Listbox {...getListboxProps()}>
     {(groupedOptions as typeof top100Films).map((option, index) => {
-      const { key, ...optionProps } = { ...getOptionProps({ option, index }) };
+      const { key, ...optionProps } = getOptionProps({ option, index });
       return (
         <li key={key} {...optionProps}>
           {option.title}

--- a/docs/data/material/components/autocomplete/UseAutocomplete.tsx.preview
+++ b/docs/data/material/components/autocomplete/UseAutocomplete.tsx.preview
@@ -4,8 +4,13 @@
 </div>
 {groupedOptions.length > 0 ? (
   <Listbox {...getListboxProps()}>
-    {(groupedOptions as typeof top100Films).map((option, index) => (
-      <li {...getOptionProps({ option, index })}>{option.title}</li>
-    ))}
+    {(groupedOptions as typeof top100Films).map((option, index) => {
+      const { key, ...optionProps } = { ...getOptionProps({ option, index }) };
+      return (
+        <li key={key} {...optionProps}>
+          {option.title}
+        </li>
+      );
+    })}
   </Listbox>
 ) : null}

--- a/docs/data/material/components/autocomplete/Virtualize.js
+++ b/docs/data/material/components/autocomplete/Virtualize.js
@@ -27,8 +27,10 @@ function renderRow(props) {
     );
   }
 
+  const { key, ...optionProps } = dataSet[0];
+
   return (
-    <Typography component="li" {...dataSet[0]} noWrap style={inlineStyle}>
+    <Typography key={key} component="li" {...optionProps} noWrap style={inlineStyle}>
       {`#${dataSet[2] + 1} - ${dataSet[1]}`}
     </Typography>
   );

--- a/docs/data/material/components/autocomplete/Virtualize.tsx
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx
@@ -26,8 +26,10 @@ function renderRow(props: ListChildComponentProps) {
     );
   }
 
+  const { key, ...optionProps } = dataSet[0];
+
   return (
-    <Typography component="li" {...dataSet[0]} noWrap style={inlineStyle}>
+    <Typography key={key} component="li" {...optionProps} noWrap style={inlineStyle}>
       {`#${dataSet[2] + 1} - ${dataSet[1]}`}
     </Typography>
   );


### PR DESCRIPTION
Note: the PR has expanded to solve all errors in all Autocomplete demos, not only the Google Maps demo as the original PR description explained. 

---

When using the demo code for autocomplete with Google Maps, there is an error thrown which seems to be discussed in other issues with respect to other broken examples, but I don't see a solution in place yet.
This addresses the Google Maps example only.  There are probably other examples that should be updated too, but getting this merged seems like a positive step forward even if there are other positive steps forward that can follow.  

Examples of issues closed as incomplete without a solution that seem to be reporting a similar error, especially with NextJS and React 18.3+:

- https://github.com/mui/material-ui/issues/41486 
- https://github.com/mui/material-ui/issues/41035
- https://github.com/mui/material-ui/issues/40905
- https://github.com/mui/material-ui/issues/39966
- https://github.com/mui/material-ui/issues/39474
- https://github.com/mui/material-ui/issues/38272 

This is still open:

- https://github.com/mui/material-ui/issues/39833

The issue appears to have been partially addressed in 

- https://github.com/mui/material-ui/pull/39795 
- https://github.com/mui/material-ui/pull/40968 

but this particular issue is still in the latest, so here's a step to fix it.

This borrows from https://github.com/mui/material-ui/issues/39833#issuecomment-2164181730 in place of a slightly less elegant earlier draft. 