### PR TITLE
[material-ui][Autocomplete] check for previousProps value being not-null after handling option click

### DIFF
--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -476,7 +476,7 @@ export function useAutocomplete(props) {
       previousProps.filteredOptions &&
       previousProps.filteredOptions.length !== filteredOptions.length &&
       previousProps.inputValue === inputValue &&
-      (multiple
+      (multiple && previousProps.value
         ? value.length === previousProps.value.length &&
           previousProps.value.every((val, i) => getOptionLabel(value[i]) === getOptionLabel(val))
         : isSameValue(previousProps.value, value))


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

We were using an old beta version (@material-ui/lab) of Autocomplete in our codebase and after finally upgrading to v5 we noticed a regression in one of our components based on Autocomplete due to this line checking for `previousProps.value.length` while `previousProps.value` was `null`. I think this is the only place were `previousProps.value.length` is checked.

Context:

We probably do some weird hack in which we switch from a non-multiple to multiple autocomplete dropdown, this is because on first render, we populate the options with a list and then upon user selection, load another list and allow the user to select multiple values out of the dropdown.

Please let me know if there's any test I should be adding/modifying. Thank you!

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
