### PR TITLE
[docs-infra] Fix wrong migration

### DIFF
--- a/docs/src/modules/components/DemoToolbarRoot.ts
+++ b/docs/src/modules/components/DemoToolbarRoot.ts
@@ -32,14 +32,15 @@ const DemoToolbarRoot = styled('div', {
       {
         props: ({ demoOptions }) => demoOptions.bg === 'inline',
         style: {
-          marginTop: theme.spacing(1),
-          borderTopWidth: 1,
+          [theme.breakpoints.up('sm')]: { marginTop: theme.spacing(1), borderTopWidth: 1 },
         },
       },
       {
         props: ({ openDemoSource }) => openDemoSource,
         style: {
-          borderRadius: 0,
+          [theme.breakpoints.up('sm')]: {
+            borderRadius: 0,
+          },
         },
       },
     ],

--- a/docs/src/modules/components/DemoToolbarRoot.ts
+++ b/docs/src/modules/components/DemoToolbarRoot.ts
@@ -32,7 +32,10 @@ const DemoToolbarRoot = styled('div', {
       {
         props: ({ demoOptions }) => demoOptions.bg === 'inline',
         style: {
-          [theme.breakpoints.up('sm')]: { marginTop: theme.spacing(1), borderTopWidth: 1 },
+          [theme.breakpoints.up('sm')]: {
+            marginTop: theme.spacing(1),
+            borderTopWidth: 1,
+          },
         },
       },
       {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

A regression from https://github.com/mui/material-ui/pull/42498

I think this case was my manual adjustment mistake. I missed the `theme.breakpoints.up`. The codemod improvement will come in a separate PR.


| Before | After |
|--------|--------|
| <img width="832" alt="Screenshot 2024-06-18 at 08 43 48" src="https://github.com/mui/material-ui/assets/67129314/5cd44cbc-1848-4d1a-8344-27e576504581"> | <img width="832" alt="Screenshot 2024-06-18 at 08 43 41" src="https://github.com/mui/material-ui/assets/67129314/26a6bdcc-a9b0-4bf2-8af1-8156ff32d8e9"> | 
