### PR TITLE
[codemod] Support dynamic props styled transformation

### DIFF
--- a/packages/mui-codemod/src/util/migrateToVariants.js
+++ b/packages/mui-codemod/src/util/migrateToVariants.js
@@ -368,39 +368,46 @@ export default function migrateToVariants(j, styles) {
     } else if (style.body.type === 'ConditionalExpression') {
       // skip ConditionalExpression
     } else {
-      let objectExpression = style.body;
-      let counter = 0;
-      while (objectExpression.type !== 'ObjectExpression' && counter < MAX_DEPTH) {
-        counter += 1;
-        if (objectExpression.type === 'BlockStatement') {
-          objectExpression = objectExpression.body.find(
-            (item) => item.type === 'ReturnStatement',
-          ).argument;
+      const expressions = [];
+      if (style.body.type === 'ArrayExpression') {
+        expressions.push(...style.body.elements);
+      } else {
+        expressions.push(style.body);
+      }
+      expressions.forEach((objectExpression) => {
+        let counter = 0;
+        while (objectExpression.type !== 'ObjectExpression' && counter < MAX_DEPTH) {
+          counter += 1;
+          if (objectExpression.type === 'BlockStatement') {
+            objectExpression = objectExpression.body.find(
+              (item) => item.type === 'ReturnStatement',
+            ).argument;
+          }
         }
-      }
 
-      recurseObjectExpression({ node: objectExpression, buildStyle: createBuildStyle() });
+        recurseObjectExpression({ node: objectExpression, buildStyle: createBuildStyle() });
 
-      if (variants.length) {
-        objectExpression.properties.push(
-          j.objectProperty(
-            j.identifier('variants'),
-            j.arrayExpression(
-              variants.filter((variant) => {
-                const props = variant.properties.find((prop) => prop.key.name === 'props');
-                const styleVal = variant.properties.find((prop) => prop.key.name === 'style');
-                return (
-                  props &&
-                  styleVal &&
-                  (!styleVal.value.properties || styleVal.value.properties.length > 0) &&
-                  (props.value.type === 'ArrowFunctionExpression' ||
-                    props.value.properties.length > 0)
-                );
-              }),
+        if (variants.length && objectExpression.type === 'ObjectExpression') {
+          objectExpression.properties.push(
+            j.objectProperty(
+              j.identifier('variants'),
+              j.arrayExpression(
+                variants.filter((variant) => {
+                  const props = variant.properties.find((prop) => prop.key.name === 'props');
+                  const styleVal = variant.properties.find((prop) => prop.key.name === 'style');
+                  return (
+                    props &&
+                    styleVal &&
+                    (!styleVal.value.properties || styleVal.value.properties.length > 0) &&
+                    (props.value.type === 'ArrowFunctionExpression' ||
+                      props.value.properties.length > 0)
+                  );
+                }),
+              ),
             ),
-          ),
-        );
-      }
+          );
+        }
+      });
     }
 
     function recurseObjectExpression(data) {

--- a/packages/mui-codemod/src/util/migrateToVariants.js
+++ b/packages/mui-codemod/src/util/migrateToVariants.js
@@ -553,19 +553,26 @@ export default function migrateToVariants(j, styles) {
             };
             variants.push(buildObjectAST(variant));
 
-            // create another variant with inverted condition
-            let props2 = buildProps(inverseBinaryExpression(data.node.test));
-            if (data.props) {
-              props2 = mergeProps(data.props, props2);
-            }
-            const styleVal2 = data.buildStyle(data.node.alternate);
-            const variant2 = {
-              props: props2,
-              style: styleVal2,
-            };
-            variants.push(buildObjectAST(variant2));
-            if (data.parentNode?.type === 'ObjectExpression') {
-              removeProperty(data.parentNode, data.node);
+            if (
+              data.node.consequent.type === 'ObjectExpression' &&
+              data.node.alternate.type === 'ObjectExpression'
+            ) {
+              // create another variant with inverted condition
+              let props2 = buildProps(inverseBinaryExpression(data.node.test));
+              if (data.props) {
+                props2 = mergeProps(data.props, props2);
+              }
+              const styleVal2 = data.buildStyle(data.node.alternate);
+              const variant2 = {
+                props: props2,
+                style: styleVal2,
+              };
+              variants.push(buildObjectAST(variant2));
+              if (data.parentNode?.type === 'ObjectExpression') {
+                removeProperty(data.parentNode, data.node);
+              }
+            } else {
+              data.replaceValue?.(data.node.alternate);
             }
           }
           if (

--- a/packages/mui-codemod/src/v6.0.0/styled/styled-v6.test.js
+++ b/packages/mui-codemod/src/v6.0.0/styled/styled-v6.test.js
@@ -177,5 +177,29 @@ describe('@mui/codemod', () => {
         expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
     });
+
+    describe('dynamic props styled-v6', () => {
+      it('transforms props as needed', () => {
+        const actual = transform(
+          { source: read('./test-cases/DynamicPropsStyled.actual.js') },
+          { jscodeshift },
+          { printOptions: { trailingComma: false } },
+        );
+
+        const expected = read('./test-cases/DynamicPropsStyled.expected.js');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+
+      it('should be idempotent', () => {
+        const actual = transform(
+          { source: read('./test-cases/DynamicPropsStyled.expected.js') },
+          { jscodeshift },
+          {},
+        );
+
+        const expected = read('./test-cases/DynamicPropsStyled.expected.js');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+    });
   });
 });

--- a/packages/mui-codemod/src/v6.0.0/styled/test-cases/ConditionalStyled.expected.js
+++ b/packages/mui-codemod/src/v6.0.0/styled/test-cases/ConditionalStyled.expected.js
@@ -21,7 +21,9 @@ const LinearProgressBar1 = styled('span', {
       variant: 'buffer'
     },
     style: {
-      '&:hover': {}
+      backgroundColor:
+        (theme.vars || theme).palette[ownerState.color].light,
+      '&:hover': {},
     }
   }, {
     props: (
@@ -32,14 +34,6 @@ const LinearProgressBar1 = styled('span', {
     ) => variant === 'buffer' && ownerState.color !== 'normal',
     style: {
       backgroundColor: 'currentColor'
-    }
-  }, {
-    props: {
-      variant: 'buffer',
-      color: 'normal'
-    },
-    style: {
-      backgroundColor: (theme.vars || theme).palette[ownerState.color].light
     }
   }, {
     props: (
@@ -66,21 +60,22 @@ const LinearProgressBar1 = styled('span', {
   }, {
     props: (
       {
+        ownerState
+      }
+    ) => ownerState.variant !== 'buffer',
+    style: {
+      backgroundColor:
+        (theme.vars || theme).palette[ownerState.color].main,
+    }
+  }, {
+    props: (
+      {
         ownerState,
         color
       }
     ) => ownerState.variant !== 'buffer' && color === 'inherit',
     style: {
       backgroundColor: 'currentColor'
-    }
-  }, {
-    props: (
-      {
-        ownerState
-      }
-    ) => ownerState.variant !== 'buffer' && ownerState.color !== 'inherit',
-    style: {
-      backgroundColor: (theme.vars || theme).palette[ownerState.color].main
     }
   }]
 }));
@@ -91,6 +86,7 @@ const ExpandMore = styled((props) => {
 })(({
   theme
 }) => ({
+  transform: 'rotate(180deg)',
   marginLeft: 'auto',
   transition: theme.transitions.create('transform', {
     duration: theme.transitions.duration.shortest,
@@ -104,16 +100,7 @@ const ExpandMore = styled((props) => {
     style: {
       transform: 'rotate(0deg)'
     }
-  }, {
-    props: (
-      {
-        expand
-      }
-    ) => !!expand,
-    style: {
-      transform: 'rotate(180deg)'
-    }
-  }],
+  }]
 }));
 
 const Main = styled('main', {

--- a/packages/mui-codemod/src/v6.0.0/styled/test-cases/DynamicPropsStyled.actual.js
+++ b/packages/mui-codemod/src/v6.0.0/styled/test-cases/DynamicPropsStyled.actual.js
@@ -1,0 +1,34 @@
+import { styled, alpha } from '@mui/material/styles';
+
+const DemoToolbarRoot = styled('div', {
+  shouldForwardProp: (prop) => prop !== 'demoOptions' && prop !== 'openDemoSource',
+})(({ theme, demoOptions, openDemoSource }) => [
+  {
+    display: 'none',
+    [theme.breakpoints.up('sm')]: {
+      top: 0,
+      maxHeight: 50,
+      display: 'block',
+      marginTop: demoOptions.bg === 'inline' ? theme.spacing(1) : -1,
+      padding: theme.spacing(0.5, 1),
+      border: `1px solid ${(theme.vars || theme).palette.divider}`,
+      borderTopWidth: demoOptions.bg === 'inline' ? 1 : 0,
+      backgroundColor: alpha(theme.palette.grey[50], 0.2),
+      borderRadius: openDemoSource ? 0 : '0 0 12px 12px',
+      transition: theme.transitions.create('border-radius'),
+      ...(theme.direction === 'rtl' && {
+        left: theme.spacing(1),
+      }),
+      ...(theme.direction !== 'rtl' && {
+        right: theme.spacing(1),
+      }),
+    },
+  },
+  theme.applyDarkStyles({
+    [theme.breakpoints.up('sm')]: {
+      backgroundColor: alpha(theme.palette.primaryDark[800], 0.2),
+    },
+  }),
+]);
+
+export default DemoToolbarRoot;

--- a/packages/mui-codemod/src/v6.0.0/styled/test-cases/DynamicPropsStyled.expected.js
+++ b/packages/mui-codemod/src/v6.0.0/styled/test-cases/DynamicPropsStyled.expected.js
@@ -1,0 +1,95 @@
+import { styled, alpha } from '@mui/material/styles';
+
+const DemoToolbarRoot = styled('div', {
+  shouldForwardProp: (prop) => prop !== 'demoOptions' && prop !== 'openDemoSource',
+})(({
+  theme
+}) => [
+  {
+    display: 'none',
+    [theme.breakpoints.up('sm')]: {
+      top: 0,
+      maxHeight: 50,
+      display: 'block',
+      padding: theme.spacing(0.5, 1),
+      border: `1px solid ${(theme.vars || theme).palette.divider}`,
+      backgroundColor: alpha(theme.palette.grey[50], 0.2),
+      transition: theme.transitions.create('border-radius'),
+      ...theme.applyStyles("rtl", {
+        left: theme.spacing(1),
+      }),
+      ...theme.applyStyles("rtl", {
+        right: theme.spacing(1),
+      })
+    },
+    variants: [{
+      props: {
+        bg: 'inline'
+      },
+      style: {
+        [theme.breakpoints.up('sm')]: {
+          marginTop: theme.spacing(1)
+        }
+      }
+    }, {
+      props: (
+        {
+          demoOptions
+        }
+      ) => demoOptions.bg !== 'inline',
+      style: {
+        [theme.breakpoints.up('sm')]: {
+          marginTop: -1
+        }
+      }
+    }, {
+      props: {
+        bg: 'inline'
+      },
+      style: {
+        [theme.breakpoints.up('sm')]: {
+          borderTopWidth: 1
+        }
+      }
+    }, {
+      props: (
+        {
+          demoOptions
+        }
+      ) => demoOptions.bg !== 'inline',
+      style: {
+        [theme.breakpoints.up('sm')]: {
+          borderTopWidth: 0
+        }
+      }
+    }, {
+      props: (
+        {
+          openDemoSource
+        }
+      ) => openDemoSource,
+      style: {
+        [theme.breakpoints.up('sm')]: {
+          borderRadius: 0
+        }
+      }
+    }, {
+      props: (
+        {
+          openDemoSource
+        }
+      ) => !openDemoSource,
+      style: {
+        [theme.breakpoints.up('sm')]: {
+          borderRadius: '0 0 12px 12px'
+        }
+      }
+    }]
+  },
+  theme.applyDarkStyles({
+    [theme.breakpoints.up('sm')]: {
+      backgroundColor: alpha(theme.palette.primaryDark[800], 0.2),
+    },
+  }),
+]);
+export default DemoToolbarRoot;

--- a/packages/mui-codemod/src/v6.0.0/styled/test-cases/DynamicPropsStyled.expected.js
+++ b/packages/mui-codemod/src/v6.0.0/styled/test-cases/DynamicPropsStyled.expected.js
@@ -11,16 +11,19 @@ const DemoToolbarRoot = styled('div', {
       top: 0,
       maxHeight: 50,
       display: 'block',
+      marginTop: -1,
       padding: theme.spacing(0.5, 1),
       border: `1px solid ${(theme.vars || theme).palette.divider}`,
+      borderTopWidth: 0,
       backgroundColor: alpha(theme.palette.grey[50], 0.2),
+      borderRadius: '0 0 12px 12px',
       transition: theme.transitions.create('border-radius'),
       ...theme.applyStyles("rtl", {
         left: theme.spacing(1),
       }),
       ...theme.applyStyles("rtl", {
         right: theme.spacing(1),
-      })
+      }),
     },
     variants: [{
       props: {
@@ -29,17 +32,6 @@ const DemoToolbarRoot = styled('div', {
       style: {
         [theme.breakpoints.up('sm')]: {
           marginTop: theme.spacing(1)
-        }
-      }
-    }, {
-      props: (
-        {
-          demoOptions
-        }
-      ) => demoOptions.bg !== 'inline',
-      style: {
-        [theme.breakpoints.up('sm')]: {
-          marginTop: -1
         }
       }
     }, {
@@ -54,34 +46,12 @@ const DemoToolbarRoot = styled('div', {
     }, {
       props: (
         {
-          demoOptions
-        }
-      ) => demoOptions.bg !== 'inline',
-      style: {
-        [theme.breakpoints.up('sm')]: {
-          borderTopWidth: 0
-        }
-      }
-    }, {
-      props: (
-        {
           openDemoSource
         }
       ) => openDemoSource,
       style: {
         [theme.breakpoints.up('sm')]: {
           borderRadius: 0
-        }
-      }
-    }, {
-      props: (
-        {
-          openDemoSource
-        }
-      ) => !openDemoSource,
-      style: {
-        [theme.breakpoints.up('sm')]: {
-          borderRadius: '0 0 12px 12px'
         }
       }
     }]

--- a/packages/mui-codemod/src/v6.0.0/styled/test-cases/NestedSpread.expected.js
+++ b/packages/mui-codemod/src/v6.0.0/styled/test-cases/NestedSpread.expected.js
@@ -28,6 +28,13 @@ const Component = styled('div')(({
       }
     }, {
       props: {
+        edge: 'start'
+      },
+      style: {
+        marginLeft: -12,
+      }
+    }, {
+      props: {
         edge: 'start',
         size: 'small'
       },
@@ -35,14 +42,11 @@ const Component = styled('div')(({
         marginLeft: -3
       }
     }, {
-      props: (
-        {
-          edge,
-          ownerState
-        }
-      ) => edge === 'start' && ownerState.size !== 'small',
+      props: {
+        edge: 'end'
+      },
       style: {
-        marginLeft: -12
+        marginRight: -12,
       }
     }, {
       props: {
@@ -51,16 +55,6 @@ const Component = styled('div')(({
       },
       style: {
         marginRight: -3
-      }
-    }, {
-      props: (
-        {
-          edge,
-          ownerState
-        }
-      ) => edge === 'end' && ownerState.size !== 'small',
-      style: {
-        marginRight: -12
       }
     }, {
       props: (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

An improvement to cover https://github.com/mui/material-ui/pull/42675

- dynamic props specified in the callback object (works with nested style)

   ```js
   // before
   const DemoToolbarRoot = styled('div', {
    shouldForwardProp: (prop) => prop !== 'demoOptions' && prop !== 'openDemoSource',
  })(({ theme, demoOptions, openDemoSource }) => [
    {
      [theme.breakpoints.up('sm')]: {
        marginTop: demoOptions.bg === 'inline' ? theme.spacing(1) : -1,
        
        
   // after
   const DemoToolbarRoot = styled('div', {
    shouldForwardProp: (prop) => prop !== 'demoOptions' && prop !== 'openDemoSource',
  })(({ theme }) => [
    {
      [theme.breakpoints.up('sm')]: {
        marginTop: -1,
      },
      variants: [
        {
        props: ({ demoOptions }) => demoOptions.bg === 'inline',
          style: { marginTop: theme.spacing(1) }
        },
      ]
   ```
- reduce the number of generated variants

   ```js
   // before
  {
    marginTop: demoOptions.bg === 'inline' ? theme.spacing(1) : -1,
  }
  
  // after: create one new variant instead of two
  {
    marginTop: -1,
    variants: [
      {
      props: ({ demoOptions }) => demoOptions.bg === 'inline',
        style: { marginTop: theme.spacing(1) }
      },
    ]
  }
   ```

I suggest to review only the [test case](https://github.com/mui/material-ui/pull/42683/files#diff-5329f2516e5885c331c4d47701792f472539ff0a4477619f12a9486c153d0204).

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
