### PR TITLE
[material-ui][Tab] Fix failing test

### DIFF
--- a/packages/mui-codemod/src/deprecations/tab-classes/test-cases/actual.css
+++ b/packages/mui-codemod/src/deprecations/tab-classes/test-cases/actual.css
@@ -1,4 +1,3 @@
 .MuiTab-root .MuiTab-iconWrapper {
   color: red;
 }
-


### PR DESCRIPTION
A failing test was introduced in https://github.com/mui/material-ui/pull/42647#issuecomment-2178551391 because we had a temporary bug that caused most unit test to not run in CI.