### PR TITLE
fix: properly filter palettes

### DIFF
--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -60,7 +60,7 @@ export const SliderRoot = styled('span', {
   },
   variants: [
     ...Object.keys((theme.vars ?? theme).palette)
-      .filter((key) => (theme.vars ?? theme).palette[key].main)
+      .filter((key) => typeof (theme.vars ?? theme).palette[key].main === 'string')
       .map((color) => ({
         props: { color },
         style: {
@@ -202,7 +202,7 @@ export const SliderTrack = styled('span', {
         },
       },
       ...Object.keys((theme.vars ?? theme).palette)
-        .filter((key) => (theme.vars ?? theme).palette[key].main)
+        .filter((key) => typeof (theme.vars ?? theme).palette[key].main === 'string')
         .map((color) => ({
           props: { color, track: 'inverted' },
           style: {
@@ -302,7 +302,7 @@ export const SliderThumb = styled('span', {
       },
     },
     ...Object.keys((theme.vars ?? theme).palette)
-      .filter((key) => (theme.vars ?? theme).palette[key].main)
+      .filter((key) => typeof (theme.vars ?? theme).palette[key].main === 'string')
       .map((color) => ({
         props: { color },
         style: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

If there is a palette with a main non-string field, it crashes