### PR TITLE
[draft][material-ui][docs] Revamp templates page

### DIFF
--- a/docs/pages/material-ui/getting-started/templates.js
+++ b/docs/pages/material-ui/getting-started/templates.js
@@ -3,5 +3,5 @@ import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import * as pageProps from 'docs/data/material/getting-started/templates/templates.md?muiMarkdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} disableToc disableAd />;
+  return <MarkdownDocs {...pageProps} disableAd />;
 }

--- a/docs/src/modules/components/MaterialFreeTemplatesCollection.js
+++ b/docs/src/modules/components/MaterialFreeTemplatesCollection.js
@@ -5,69 +5,73 @@ import Card from '@mui/material/Card';
 import CardMedia from '@mui/material/CardMedia';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
 import Visibility from '@mui/icons-material/Visibility';
 import CodeRoundedIcon from '@mui/icons-material/CodeRounded';
+import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded';
 import { useTranslate } from '@mui/docs/i18n';
 import { useTheme } from '@mui/material/styles';
 
 const sourcePrefix = `${process.env.SOURCE_CODE_REPO}/tree/v${process.env.LIB_VERSION}`;
 
-function layouts(translatation, theme) {
+function layouts(translation, theme) {
   const imageSuffix = theme.palette.mode === 'dark' ? '-dark' : '-light';
   return [
     {
-      title: translatation('dashboardTitle'),
-      description: translatation('dashboardDescr'),
+      title: translation('dashboardTitle'),
+      description: translation('dashboardDescr'),
       src: `/static/images/templates/dashboard${imageSuffix}.png`,
       href: '/material-ui/getting-started/templates/dashboard/',
       source: `${sourcePrefix}/docs/data/material/getting-started/templates/dashboard`,
     },
     {
-      title: translatation('landingPageTitle'),
-      description: translatation('landingPageDescr'),
+      title: translation('landingPageTitle'),
+      description: translation('landingPageDescr'),
       src: `/static/images/templates/landing-page${imageSuffix}.png`,
       href: '/material-ui/getting-started/templates/landing-page/',
       source: `${sourcePrefix}/docs/data/material/getting-started/templates/landing-page`,
     },
     {
-      title: translatation('checkoutTitle'),
-      description: translatation('checkoutDescr'),
+      title: translation('checkoutTitle'),
+      description: translation('checkoutDescr'),
       src: `/static/images/templates/checkout${imageSuffix}.png`,
       href: '/material-ui/getting-started/templates/checkout/',
       source: `${sourcePrefix}/docs/data/material/getting-started/templates/checkout`,
     },
     {
-      title: translatation('signInTitle'),
-      description: translatation('signInDescr'),
+      title: translation('signInTitle'),
+      description: translation('signInDescr'),
       src: `/static/images/templates/sign-in${imageSuffix}.png`,
       href: '/material-ui/getting-started/templates/sign-in/',
       source: `${sourcePrefix}/docs/data/material/getting-started/templates/sign-in`,
     },
     {
-      title: translatation('signInSideTitle'),
-      description: translatation('signInSideDescr'),
+      title: translation('signInSideTitle'),
+      description: translation('signInSideDescr'),
       src: `/static/images/templates/sign-in-side${imageSuffix}.png`,
       href: '/material-ui/getting-started/templates/sign-in-side/',
       source: `${sourcePrefix}/docs/data/material/getting-started/templates/sign-in-side`,
     },
     {
-      title: translatation('signUpTitle'),
-      description: translatation('signUpDescr'),
+      title: translation('signUpTitle'),
+      description: translation('signUpDescr'),
       src: `/static/images/templates/sign-up${imageSuffix}.png`,
       href: '/material-ui/getting-started/templates/sign-up/',
       source: `${sourcePrefix}/docs/data/material/getting-started/templates/sign-up`,
     },
     {
-      title: translatation('blogTitle'),
-      description: translatation('blogDescr'),
+      title: translation('blogTitle'),
+      description: translation('blogDescr'),
       src: `/static/images/templates/blog${imageSuffix}.png`,
       href: '/material-ui/getting-started/templates/blog/',
       source: `${sourcePrefix}/docs/data/material/getting-started/templates/blog`,
     },
     {
-      title: translatation('stickyFooterTitle'),
-      description: translatation('stickyFooterDescr'),
+      title: translation('stickyFooterTitle'),
+      description: translation('stickyFooterDescr'),
       src: `/static/images/templates/sticky-footer${imageSuffix}.png`,
       href: '/material-ui/getting-started/templates/sticky-footer/',
       source: `${sourcePrefix}/docs/data/material/getting-started/templates/sticky-footer`,
@@ -76,13 +80,24 @@ function layouts(translatation, theme) {
 }
 
 export default function Templates() {
-  const translatation = useTranslate();
+  const translation = useTranslate();
   const theme = useTheme();
+  const [templateTheme, setTemplateTheme] = React.useState('');
+
+  const handleChange = (event) => {
+    setTemplateTheme(event.target.value);
+  };
 
   return (
-    <Grid container spacing={2} sx={{ py: 2 }}>
-      {layouts(translatation, theme).map((layout) => (
-        <Grid item xs={12} sm={6} key={layout.title}>
+    <Stack gap={4}>
+      {layouts(translation, theme).map((layout) => (
+        <Stack gap={1} key={layout.title}>
+          <Typography component="h3" variant="subtitle1" sx={{ fontWeight: 'semiBold' }}>
+            {layout.title}
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
+            {layout.description}
+          </Typography>
           <Card
             variant="outlined"
             sx={{
@@ -92,28 +107,57 @@ export default function Templates() {
               borderColor: 'divider',
             }}
           >
-            <CardMedia
-              component="img"
-              image={layout.src}
-              title={layout.title}
+            <Box
               sx={{
-                aspectRatio: '16 / 9',
-                objectPosition: 'top',
-                borderBottom: '1px solid',
-                borderColor: 'divider',
+                position: 'relative',
+                '&:hover button': {
+                  opacity: 1,
+                },
+                '&:hover img': {
+                  filter: 'brightness(0.7)',
+                  transition: 'filter 0.5s',
+                },
               }}
-            />
-            <Box sx={{ p: 2, pt: 1.5 }}>
-              <Typography component="h3" variant="body1" sx={{ fontWeight: 'semiBold' }}>
-                {layout.title}
-              </Typography>
-              <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
-                {layout.description}
-              </Typography>
+            >
+              <CardMedia
+                component="img"
+                image={layout.src}
+                title={layout.title}
+                sx={{
+                  aspectRatio: '16 / 9',
+                  objectPosition: 'top',
+                  borderBottom: '1px solid',
+                  borderColor: 'divider',
+                }}
+              />
+              <Button
+                variant="contained"
+                color="secondary"
+                sx={{
+                  position: 'absolute',
+                  top: '50%',
+                  left: '50%',
+                  transform: 'translate(-50%, -50%)',
+                  opacity: 0,
+                  transition: 'opacity 0.3s',
+                }}
+              >
+                Live preview
+              </Button>
+            </Box>
+            <Box
+              sx={{
+                p: 2,
+                pt: 1.5,
+                display: 'flex',
+                justifyContent: 'space-between',
+                flexDirection: 'row',
+                backgroundColor: 'background.paper',
+              }}
+            >
               <Box
                 sx={{
                   display: 'flex',
-                  flexDirection: { xs: 'column', sm: 'row' },
                   gap: 1,
                   mt: 'auto',
                 }}
@@ -122,7 +166,6 @@ export default function Templates() {
                   component="a"
                   href={layout.href}
                   size="small"
-                  fullWidth
                   variant="outlined"
                   color="secondary"
                   startIcon={<Visibility sx={{ mr: 0.5 }} />}
@@ -136,7 +179,6 @@ export default function Templates() {
                   component="a"
                   href={layout.source}
                   size="small"
-                  fullWidth
                   variant="outlined"
                   color="secondary"
                   startIcon={<CodeRoundedIcon sx={{ mr: 0.5 }} />}
@@ -144,10 +186,42 @@ export default function Templates() {
                   Source code
                 </Button>
               </Box>
+              <Box
+                sx={{
+                  display: 'flex',
+                  gap: 1,
+                  mt: 'auto',
+                }}
+              >
+                <Button
+                  size="small"
+                  variant="text"
+                  color="primary"
+                  startIcon={<DownloadRoundedIcon sx={{ mr: 0.5 }} />}
+                  data-ga-event-category="material-ui-template"
+                  data-ga-event-label={layout.title}
+                  data-ga-event-action="download-theme"
+                >
+                  Download theme
+                </Button>
+                <Select
+                  labelId="demo-simple-select-label"
+                  id="demo-simple-select"
+                  value={templateTheme}
+                  size="small"
+                  displayEmpty
+                  onChange={handleChange}
+                  sx={{ width: '180px' }}
+                >
+                  <MenuItem value="">Material Design 2</MenuItem>
+                  <MenuItem value={1}>Sober</MenuItem>
+                  <MenuItem value={2}>Sleek</MenuItem>
+                </Select>
+              </Box>
             </Box>
           </Card>
-        </Grid>
+        </Stack>
       ))}
-    </Grid>
+    </Stack>
   );
 }

--- a/docs/src/modules/components/MaterialFreeTemplatesCollection.js
+++ b/docs/src/modules/components/MaterialFreeTemplatesCollection.js
@@ -114,7 +114,7 @@ export default function Templates() {
                   opacity: 1,
                 },
                 '&:hover img': {
-                  filter: 'brightness(0.7)',
+                  filter: 'brightness(0.5)',
                   transition: 'filter 0.5s',
                 },
               }}
@@ -133,6 +133,7 @@ export default function Templates() {
               <Button
                 variant="contained"
                 color="secondary"
+                size="small"
                 sx={{
                   position: 'absolute',
                   top: '50%',

--- a/packages/mui-docs/src/branding/brandingTheme.ts
+++ b/packages/mui-docs/src/branding/brandingTheme.ts
@@ -1,4 +1,4 @@
-import type { CSSObject } from '@mui/system';
+import { borderColor, type CSSObject } from '@mui/system';
 import type {} from '@mui/material/themeCssVarsAugmentation';
 import ArrowDropDownRounded from '@mui/icons-material/ArrowDropDownRounded';
 import { createTheme, ThemeOptions, Theme, alpha } from '@mui/material/styles';
@@ -618,6 +618,23 @@ export function getThemedComponents(): ThemeOptions {
                   backgroundColor: (theme.vars || theme).palette.primaryDark[700],
                 },
               }),
+            ...(ownerState.variant === 'contained' &&
+              ownerState.color === 'secondary' && {
+                color: 'hsl(0, 0%, 0%)',
+                backgroundColor: (theme.vars || theme).palette.grey[100],
+                boxShadow: `hsla(0, 0%, 100%, 0.5) 0 2px 0 inset, ${theme.palette.grey[300]} 0 -2px 0 inset, ${alpha(theme.palette.common.black, 0.1)} 0 2px 4px 0`,
+                '&:hover': {
+                  backgroundColor: (theme.vars || theme).palette.grey[200],
+                },
+                ...theme.applyDarkStyles({
+                  color: 'hsl(0, 0%, 100%)',
+                  backgroundColor: (theme.vars || theme).palette.grey[800],
+                  boxShadow: `${alpha(theme.palette.grey[700], 0.5)} 0 2px 0 inset, ${alpha(theme.palette.grey[900], 0.5)} 0 -2px 0 inset, ${alpha(theme.palette.common.black, 0.1)} 0 2px 4px 0`,
+                  '&:hover': {
+                    backgroundColor: (theme.vars || theme).palette.grey[900],
+                  },
+                }),
+              }),
             ...(ownerState.variant === 'text' &&
               ownerState.color === 'secondary' && {
                 color: (theme.vars || theme).palette.text.secondary,
@@ -1155,6 +1172,28 @@ export function getThemedComponents(): ThemeOptions {
           iconFilled: {
             top: 'calc(50% - .25em)',
           },
+          root: ({ theme }) => ({
+            borderRadius: 10,
+            backgroundColor: theme.palette.background.paper,
+            boxShadow: `inset 0 2px 0 1px hsla(220, 0%, 100%, 0.6), inset 0 -1px 0 2px hsla(220, 35%, 90%, 0.5)`,
+            '&:hover': {
+              backgroundColor: theme.palette.background.paper,
+              boxShadow: 'none',
+            },
+            '&:before, &:after': {
+              display: 'none',
+            },
+            ...theme.applyDarkStyles({
+              boxShadow: `inset 0 2px 0 1px ${alpha(grey[700], 0.15)}, inset 0 -2px 0 1px hsla(220, 0%, 0%, 0.7)`,
+            }),
+          }),
+          select: ({ theme }) => ({
+            display: 'flex',
+            alignItems: 'center',
+            padding: theme.spacing(0, 2),
+            fontSize: theme.typography.pxToRem(14),
+            fontWeight: 500,
+          }),
         },
       },
       MuiTab: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/41469

| ⚠️ **Work in progress** ⚠️ |
|--------|
| _This is an initial draft and further improvements are expected based on feedback and visual explorations._ | 

## Summary

This PR is a **draft** to explore various design alternatives for the templates page. The goal is to address as many points mentioned in issue #41469 as possible, ensuring a seamless and user-friendly experience.

## Objectives:

Enhance the overall user experience on the templates page, providing a greater flexibility and functionality when interacting with templates and custom themes.

### Key Features:

1. **Download Custom Theme**: Users can now download custom themes directly from the templates page.
2. **Template Preview**: Users can view a preview of a template before selecting or downloading it.
3. **Select Template Theme:** Users have the option to choose a theme for their template before opening it.
4. **Preview Selected Theme**: A preview of the selected theme is provided, giving users a clear idea of how the template will look with the chosen theme.
5. **Navigate Template Folder**: Allow users to easily navigate through the template folder, making it simpler to find and select the desired template.
6. **Guides**: Provide how-to-guides for using the templates and the themes.

### Implementation Details:

Design improvements have been made to enhance the visual appeal and usability of the templates page. The full fledge prototype is available on [Figma](https://www.figma.com/design/i63tvNvhL631TmLcJktp5r/Material-UI-Templates?node-id=1605-284&t=Efha6uwHP6cF2pRa-11) (feel free to leave comments)

### Preview

👉 https://deploy-preview-42710--material-ui.netlify.app/material-ui/getting-started/templates/

![image](https://github.com/mui/material-ui/assets/37222944/9af344b8-c3d6-44fc-a2b2-ecb11b5cabe5)

## Next Steps:

- Review the design and functionality changes.
- Gather feedback about the templates' files organization.
- Gather feedback about the features, and how to build them.
- Create the how-to-guides for using the templates and themes.