### PR TITLE
[docs-infra] Fix visual look of in-house ad

### DIFF
--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -25,7 +25,7 @@ function PleaseDisableAdblock(props) {
       <Typography variant="body2" component="span" gutterBottom sx={{ display: 'block' }}>
         {t('adblock')}
       </Typography>
-      <Typography variant="body2" component="span" gutterBottom sx={{ display: 'block' }}>
+      <Typography variant="body2" component="span" sx={{ display: 'block' }}>
         {t('thanks')}{' '}
         <span role="img" aria-label={t('emojiLove')}>
           ❤️

--- a/docs/src/modules/components/AdDisplay.js
+++ b/docs/src/modules/components/AdDisplay.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
+import { adShape } from 'docs/src/modules/components/AdManager';
 import { GA_ADS_DISPLAY_RATIO } from 'docs/src/modules/constants';
 import { adStylesObject } from 'docs/src/modules/components/ad.styles';
 
@@ -31,7 +32,7 @@ const ImageShape = styled('span')(({ theme }) => {
 });
 
 export default function AdDisplay(props) {
-  const { ad, className, shape = 'auto' } = props;
+  const { ad, className, shape: shapeProp = 'auto' } = props;
 
   React.useEffect(() => {
     // Avoid an exceed on the Google Analytics quotas.
@@ -45,13 +46,16 @@ export default function AdDisplay(props) {
     });
   }, [ad.label]);
 
-  let Root = 'span';
+  const shape = shapeProp === 'auto' ? adShape : shapeProp;
+
+  let Root;
   if (shape === 'inline') {
     Root = InlineShape;
   }
   if (shape === 'image') {
     Root = ImageShape;
   }
+
   /* eslint-disable material-ui/no-hardcoded-labels, react/no-danger */
   return (
     <Root className={className}>

--- a/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
+++ b/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
@@ -669,23 +669,27 @@ const Root = styled('div')(
       '& hr': {
         backgroundColor: `var(--muidocs-palette-divider, ${darkTheme.palette.divider})`,
       },
+      '& a': {
+        color: `var(--muidocs-palette-primary-300, ${darkTheme.palette.primary[300]})`,
+      },
+      '& a code': {
+        color: `var(--muidocs-palette-primary-light, ${darkTheme.palette.primary.light})`,
+      },
       '& h1, & h2, & h3, & h4, & h5': {
         color: `var(--muidocs-palette-grey-50, ${darkTheme.palette.grey[50]})`,
-      },
-      '& p, & ul, & ol': {
-        color: `var(--muidocs-palette-grey-400, ${darkTheme.palette.grey[400]})`,
-      },
-      '& h1, & h2, & h3, & h4': {
-        '&:hover .anchor-icon, & .comment-link': {
+        '& .anchor-icon, & .comment-link': {
           color: `var(--muidocs-palette-primary-300, ${darkTheme.palette.primaryDark[300]})`,
           borderColor: `var(--muidocs-palette-divider, ${darkTheme.palette.divider})`,
           backgroundColor: alpha(darkTheme.palette.primaryDark[700], 0.5),
           '&:hover': {
+            color: `var(--muidocs-palette-primary-100, ${darkTheme.palette.primary[100]})`,
             borderColor: `var(--muidocs-palette-primary-900, ${darkTheme.palette.primary[900]})`,
             backgroundColor: alpha(darkTheme.palette.primary[900], 0.6),
-            color: `var(--muidocs-palette-primary-100, ${darkTheme.palette.primary[100]})`,
           },
         },
+      },
+      '& p, & ul, & ol': {
+        color: `var(--muidocs-palette-grey-400, ${darkTheme.palette.grey[400]})`,
       },
       '& h1 code, & h2 code, & h3 code': {
         color: `var(--muidocs-palette-grey-100, ${darkTheme.palette.grey[100]})`,
@@ -777,12 +781,6 @@ const Root = styled('div')(
             color: `var(--muidocs-palette-warning-100, ${darkTheme.palette.warning[100]})`,
           },
         },
-      },
-      '& a': {
-        color: `var(--muidocs-palette-primary-300, ${darkTheme.palette.primary[300]})`,
-      },
-      '& a code': {
-        color: `var(--muidocs-palette-primary-light, ${darkTheme.palette.primary.light})`,
       },
       '& kbd.key': {
         color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,

--- a/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
+++ b/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
@@ -121,6 +121,43 @@ const Root = styled('div')(
         marginBottom: 6,
       },
     },
+    '& a[target="_blank"]::after': {
+      content: '""',
+      maskImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' focusable='false' aria-hidden='true' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M6 6v2h8.59L5 17.59 6.41 19 16 9.41V18h2V6z'%3E%3C/path%3E%3C/svg%3E")`,
+      display: 'inline-flex',
+      width: '1em',
+      height: '1em',
+      color: 'inherit',
+      backgroundColor: 'currentColor',
+      transform: 'translate(0, 2px)',
+      transition: 'transform 0.3s cubic-bezier(0.1, 0.8, 0.3, 1)', // bounce effect
+      opacity: 0.8,
+    },
+    '& a[target="_blank"]:hover::after': {
+      opacity: 1,
+      transform: 'translate(1px, 0)',
+    },
+    '& a.remove-link-arrow::after': {
+      // Allows to remove link arrows for images
+      display: 'none',
+    },
+    '& .Ad-root a::after': {
+      // Remove link arrow for ads
+      display: 'none',
+    },
+    '& a': {
+      // Style taken from the Link component
+      color: `var(--muidocs-palette-primary-600, ${lightTheme.palette.primary[600]})`,
+      fontWeight: theme.typography.fontWeightMedium,
+      textDecoration: 'underline',
+      textDecorationColor: alpha(lightTheme.palette.primary.main, 0.4),
+      '&:hover': {
+        textDecorationColor: 'inherit',
+      },
+    },
+    '& a code': {
+      color: darken(lightTheme.palette.primary.main, 0.2),
+    },
     '& h1, & h2, & h3, & h4': {
       display: 'flex',
       alignItems: 'center',
@@ -134,6 +171,8 @@ const Root = styled('div')(
       '& .title-link-to-anchor': {
         color: 'inherit',
         textDecoration: 'none',
+        boxShadow: 'none',
+        fontWeight: 'inherit',
         position: 'relative',
         display: 'flex',
         alignItems: 'center',
@@ -144,12 +183,6 @@ const Root = styled('div')(
         display: 'inline-flex',
         alignItems: 'center',
         visibility: 'hidden',
-      },
-      '& a:not(.title-link-to-anchor):hover': {
-        color: 'currentColor',
-        border: 'none',
-        boxShadow: '0 1px 0 0 currentColor',
-        textDecoration: 'none',
       },
       '& .anchor-icon, & .comment-link': {
         padding: 0,
@@ -408,46 +441,6 @@ const Root = styled('div')(
           },
         },
       },
-    },
-    '& a[target="_blank"]::after': {
-      content: '""',
-      maskImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' focusable='false' aria-hidden='true' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M6 6v2h8.59L5 17.59 6.41 19 16 9.41V18h2V6z'%3E%3C/path%3E%3C/svg%3E")`,
-      display: 'inline-flex',
-      width: '1em',
-      height: '1em',
-      color: 'inherit',
-      backgroundColor: 'currentColor',
-      transform: 'translate(0, 2px)',
-      transition: 'transform 0.3s cubic-bezier(0.1, 0.8, 0.3, 1)', // bounce effect
-      opacity: 0.8,
-    },
-    '& a[target="_blank"]:hover::after': {
-      opacity: 1,
-      transform: 'translate(1px, 0)',
-    },
-    '& a.remove-link-arrow::after': {
-      // Allows to remove link arrows for images
-      display: 'none',
-    },
-    '& .Ad-root a::after': {
-      // Remove link arrow for ads
-      display: 'none',
-    },
-    '& a:not(.title-link-to-anchor), & a:not(.title-link-to-anchor) code': {
-      // Style taken from the Link component
-      color: `var(--muidocs-palette-primary-600, ${lightTheme.palette.primary[600]})`,
-      fontWeight: theme.typography.fontWeightMedium,
-      textDecoration: 'underline',
-      textDecorationColor: alpha(lightTheme.palette.primary.main, 0.4),
-      '&:hover': {
-        textDecorationColor: 'inherit',
-      },
-    },
-    '& a code': {
-      color: darken(lightTheme.palette.primary.main, 0.04),
-    },
-    '& a:not(.title-link-to-anchor) code': {
-      color: darken(lightTheme.palette.primary.main, 0.2),
     },
     '& img, & video': {
       // Use !important so that inline style on <img> or <video> can't win.
@@ -785,10 +778,10 @@ const Root = styled('div')(
           },
         },
       },
-      '& a:not(.title-link-to-anchor), & a:not(.title-link-to-anchor) code': {
+      '& a': {
         color: `var(--muidocs-palette-primary-300, ${darkTheme.palette.primary[300]})`,
       },
-      '& a:not(.title-link-to-anchor) code': {
+      '& a code': {
         color: `var(--muidocs-palette-primary-light, ${darkTheme.palette.primary.light})`,
       },
       '& kbd.key': {


### PR DESCRIPTION
Fix regression introduced in #39603 and #42498.

#39603 introduced the broken anchor blue color

#42498 introduced the broken style rendering logic

## Before

<img width="831" alt="SCR-20240623-tfzn" src="https://github.com/mui/material-ui/assets/3165635/9788e082-766d-4953-bebf-d25a3fece2fb">

## After

<img width="840" alt="SCR-20240623-uaec" src="https://github.com/mui/material-ui/assets/3165635/a9e47f5a-dcaf-4b58-9e06-c12da8dab26a">

Preview https://deploy-preview-42735--material-ui.netlify.app/material-ui/getting-started/ 
