### PR TITLE
[joy-ui][Autocomplete] Fix React key spread warnings

### DIFF
--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -409,13 +409,14 @@ const Autocomplete = React.forwardRef(function Autocomplete(
       selectedOptions = renderTags(value as Array<unknown>, getCustomizedTagProps, ownerState);
     } else {
       selectedOptions = (value as Array<unknown>).map((option, index) => {
+        const { key: endDecoratorKey, ...endDecoratorProps } = getCustomizedTagProps({ index });
         return (
           <Chip
             key={index}
             size={size}
             variant="soft"
             color="neutral"
-            endDecorator={<ChipDelete {...getCustomizedTagProps({ index })} />}
+            endDecorator={<ChipDelete key={endDecoratorKey} {...endDecoratorProps} />}
             sx={{ minWidth: 0 }}
           >
             {getOptionLabel(option)}


### PR DESCRIPTION
Fixes a React 18.3 warning when using `renderTags` props in Joy's Autocomplete component:

```
A props object containing a "key" prop is being spread into JSX
```