### PR TITLE
[docs-infra] Fix layout shift demo toolbar

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -45,7 +45,7 @@ function DemoToolbarFallback() {
   const t = useTranslate();
 
   // Sync with styles from DemoToolbar, we can't import the styles
-  return <Box sx={{ height: 40 }} aria-busy aria-label={t('demoToolbarLabel')} role="toolbar" />;
+  return <Box sx={{ height: 42 }} aria-busy aria-label={t('demoToolbarLabel')} role="toolbar" />;
 }
 
 function getDemoName(location) {

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -60,7 +60,7 @@ const Root = styled('div')(({ theme }) => [
 function DemoTooltip(props) {
   return (
     <Tooltip
-      componentsProps={{
+      slotProps={{
         popper: {
           sx: {
             zIndex: (theme) => theme.zIndex.appBar - 1,

--- a/docs/src/modules/components/DemoToolbarRoot.ts
+++ b/docs/src/modules/components/DemoToolbarRoot.ts
@@ -15,7 +15,7 @@ const DemoToolbarRoot = styled('div', {
       maxHeight: 50,
       display: 'block',
       marginTop: -1,
-      padding: theme.spacing(0.5, 1),
+      padding: theme.spacing('2px', 1),
       border: `1px solid ${(theme.vars || theme).palette.divider}`,
       borderTopWidth: 0,
       backgroundColor: alpha(theme.palette.grey[50], 0.2),
@@ -54,4 +54,5 @@ const DemoToolbarRoot = styled('div', {
     },
   }),
 ]);
+
 export default DemoToolbarRoot;


### PR DESCRIPTION
A small regression coming from #41948.

## Before

https://pagespeed.web.dev/analysis/https-next-mui-com-material-ui-getting-started-usage/slg9l5xc3c?form_factor=desktop

<img width="932" alt="SCR-20240624-psfn" src="https://github.com/mui/material-ui/assets/3165635/12826f21-48da-42c4-957c-434560dbb6a1">

https://github.com/mui/material-ui/assets/3165635/758ffdfb-81fb-4801-b3e6-74052e7e7a05

## After

The 2px layout shift is gone.

https://deploy-preview-42743--material-ui.netlify.app/material-ui/getting-started/usage/