### PR TITLE
[docs] Fix wrong description for `UseTabParameters.onChange`

### DIFF
--- a/docs/translations/api-docs/use-tab/use-tab.json
+++ b/docs/translations/api-docs/use-tab/use-tab.json
@@ -5,7 +5,7 @@
     "id": {
       "description": "The id of the tab. If not provided, it will be automatically generated."
     },
-    "onChange": { "description": "If <code>true</code>, the tab will be disabled." },
+    "onChange": { "description": "Callback invoked when new value is being set." },
     "onClick": { "description": "Callback fired when the tab is clicked." },
     "rootRef": { "description": "Ref to the root slot&#39;s DOM element." },
     "value": {

--- a/packages/mui-base/src/useTab/useTab.types.ts
+++ b/packages/mui-base/src/useTab/useTab.types.ts
@@ -9,7 +9,7 @@ export interface UseTabParameters {
    */
   value?: number | string;
   /**
-   * If `true`, the tab will be disabled.
+   * Callback invoked when new value is being set.
    */
   onChange?: (event: React.SyntheticEvent, value: number | string) => void;
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes wrong comment & description for `useTab`'s `onChange` parameter, where it showed a wrong description on the [official doc](https://mui.com/base-ui/react-tabs/hooks-api/)

<img width="1030" alt="Screenshot 2024-06-25 at 4 16 14 PM" src="https://github.com/mui/material-ui/assets/7628805/a97ad870-c273-408b-b046-17fe9655af44">

The new description is from [Tab API](https://mui.com/base-ui/react-tabs/components-api/#tab)
