### PR TITLE
[styles][withStyles] Expect React defaultProps warning in test

### DIFF
--- a/packages/mui-styles/src/withStyles/withStyles.test.js
+++ b/packages/mui-styles/src/withStyles/withStyles.test.js
@@ -136,7 +136,16 @@ describe('withStyles', () => {
       const jssCallbackStub = stub().returns({});
       const styles = { root: jssCallbackStub };
       const StyledComponent = withStyles(styles)(MyComp);
-      render(<StyledComponent mySuppliedProp={222} />);
+      const renderCb = () => render(<StyledComponent mySuppliedProp={222} />);
+
+      // React 18.3.0 started warning for deprecated defaultProps for function components
+      if (React.version.startsWith('18.3')) {
+        expect(renderCb).toErrorDev([
+          'Warning: MyComp: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.',
+        ]);
+      } else {
+        renderCb();
+      }
 
       expect(jssCallbackStub.callCount).to.equal(1);
       expect(jssCallbackStub.args[0][0]).to.deep.equal({
@@ -179,24 +188,33 @@ describe('withStyles', () => {
 
       const styles = { root: { display: 'flex' } };
       const StyledComponent = withStyles(styles, { name: 'MuiFoo' })(MuiFoo);
-
-      const { container } = render(
-        <ThemeProvider
-          theme={createTheme({
-            components: {
-              MuiFoo: {
-                defaultProps: {
-                  foo: 'bar',
+      const renderCb = () =>
+        render(
+          <ThemeProvider
+            theme={createTheme({
+              components: {
+                MuiFoo: {
+                  defaultProps: {
+                    foo: 'bar',
+                  },
                 },
               },
-            },
-          })}
-        >
-          <StyledComponent foo={undefined} />
-        </ThemeProvider>,
-      );
+            })}
+          >
+            <StyledComponent foo={undefined} />
+          </ThemeProvider>,
+        );
 
-      expect(container).to.have.text('bar');
+      // React 18.3.0 started warning for deprecated defaultProps for function components
+      if (React.version.startsWith('18.3')) {
+        expect(renderCb).toErrorDev([
+          'Warning: MuiFoo: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.',
+        ]);
+      } else {
+        renderCb();
+      }
+
+      expect(screen.getByText('bar')).not.to.equal(null);
     });
 
     it('should work when depending on a theme', () => {


### PR DESCRIPTION
### Context

React 18.3.0 started to Warn for deprecated `defaultProps` for function components. See https://github.com/facebook/react/blob/main/CHANGELOG.md#1830-april-25-2024. Since `withStyles` reads `defaultProps` from components, there's a couple of React component using `defaultProps` in tests that fail because of the React warnings.

This PR updates the tests to expect such React warning when running the tests with React 18.3.x

### How to test

Tests should pass in CI because we still use React 18.2 by default. I tried running CI with React 18.3 but it [failed](https://app.circleci.com/pipelines/github/mui/material-ui/132334/workflows/2d42af42-00d2-4cee-af45-c623602d358d/jobs/713668).

To test it locally, you should update React to 18.3.1 and run the related tests (`pnpm tc "withStyles"`) to verify everything works as expected.