### PR TITLE
[material-ui][docs] Fix type error in virtualized table demo

### DIFF
--- a/docs/data/material/components/table/ReactVirtualizedTable.js
+++ b/docs/data/material/components/table/ReactVirtualizedTable.js
@@ -64,8 +64,8 @@ const VirtuosoTableComponents = {
   Table: (props) => (
     <Table {...props} sx={{ borderCollapse: 'separate', tableLayout: 'fixed' }} />
   ),
-  TableHead,
-  TableRow: ({ item: _item, ...props }) => <TableRow {...props} />,
+  TableHead: React.forwardRef((props, ref) => <TableHead {...props} ref={ref} />),
+  TableRow,
   TableBody: React.forwardRef((props, ref) => <TableBody {...props} ref={ref} />),
 };
 

--- a/docs/data/material/components/table/ReactVirtualizedTable.tsx
+++ b/docs/data/material/components/table/ReactVirtualizedTable.tsx
@@ -89,8 +89,10 @@ const VirtuosoTableComponents: TableComponents<Data> = {
   Table: (props) => (
     <Table {...props} sx={{ borderCollapse: 'separate', tableLayout: 'fixed' }} />
   ),
-  TableHead,
-  TableRow: ({ item: _item, ...props }) => <TableRow {...props} />,
+  TableHead: React.forwardRef<HTMLTableSectionElement>((props, ref) => (
+    <TableHead {...props} ref={ref} />
+  )),
+  TableRow,
   TableBody: React.forwardRef<HTMLTableSectionElement>((props, ref) => (
     <TableBody {...props} ref={ref} />
   )),


### PR DESCRIPTION
Fixes a TypeScript error in the virtualized table demo. The error happened when trying `@types/react@18.3.3`.

<img width="1011" alt="image" src="https://github.com/mui/material-ui/assets/7225802/3b00873b-08ba-48cf-b72f-3f93f8f2c945">

https://app.circleci.com/pipelines/github/mui/material-ui/132266/workflows/3b0dfe5d-9138-4ccc-ba2d-7f55f0542eb9/jobs/713336?invite=true#step-108-176
