### PR TITLE
[test-utils] Fix flushMicrotasks, export types

### DIFF
--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -333,7 +333,7 @@ function renderToString(
   };
 }
 
-interface Clock {
+export interface Clock {
   /**
    * Runs all timers until there are no more remaining.
    * WARNING: This may cause an infinite loop if a timeout constantly schedules another timeout.
@@ -363,7 +363,7 @@ interface Clock {
   restore(): void;
 }
 
-type ClockConfig = undefined | number | Date;
+export type ClockConfig = undefined | number | Date;
 
 function createClock(defaultMode: 'fake' | 'real', config: ClockConfig): Clock {
   let clock: ReturnType<typeof useFakeTimers> | null = null;
@@ -436,7 +436,7 @@ function createClock(defaultMode: 'fake' | 'real', config: ClockConfig): Clock {
   };
 }
 
-interface Renderer {
+export interface Renderer {
   clock: Clock;
   render(element: React.ReactElement<any>, options?: RenderOptions): MuiRenderResult;
   renderToString(

--- a/packages-internal/test-utils/src/flushMicrotasks.ts
+++ b/packages-internal/test-utils/src/flushMicrotasks.ts
@@ -3,6 +3,6 @@ import { act } from './createRenderer';
 export default async function flushMicrotasks() {
   if (/jsdom/.test(window.navigator.userAgent)) {
     // This is only needed for JSDOM and causes issues in real browsers
-    await act(() => async () => {});
+    await act(async () => {});
   }
 }

--- a/packages-internal/test-utils/tsconfig.json
+++ b/packages-internal/test-utils/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["es2020", "dom"],
     "noEmit": true,
     "moduleResolution": "node",
     "types": ["node"],

--- a/packages/mui-base/src/Select/Select.test.tsx
+++ b/packages/mui-base/src/Select/Select.test.tsx
@@ -1013,8 +1013,8 @@ describe('<Select />', () => {
       expect(select).to.have.attribute('aria-expanded', 'true');
     });
 
-    it('should have the aria-controls attribute', () => {
-      render(
+    it('should have the aria-controls attribute', async () => {
+      await render(
         <Select>
           <Option value={1}>One</Option>
         </Select>,
@@ -1033,8 +1033,8 @@ describe('<Select />', () => {
       expect(select).to.have.attribute('aria-controls', listboxId!);
     });
 
-    it('should have the correct tabindex attribute', () => {
-      render(
+    it('should have the correct tabindex attribute', async () => {
+      await render(
         <Select>
           <Option value={1}>One</Option>
         </Select>,

--- a/packages/mui-base/src/Select/Select.test.tsx
+++ b/packages/mui-base/src/Select/Select.test.tsx
@@ -998,8 +998,8 @@ describe('<Select />', () => {
       expect(screen.getByRole('combobox')).to.have.attribute('aria-expanded', 'false');
     });
 
-    it('should have the aria-expanded attribute set to true when the listbox is open', () => {
-      render(
+    it('should have the aria-expanded attribute set to true when the listbox is open', async () => {
+      await render(
         <Select>
           <Option value={1}>One</Option>
         </Select>,


### PR DESCRIPTION
- Fixed the `flushMicrotasks` function as per https://floating-ui.com/docs/react#testing
- Exported types required to customize the createRenderer function in other repos