### PR TITLE
[joy-ui][Autocomplete] Fix spread key error in test

### DIFF
--- a/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
@@ -480,11 +480,14 @@ describe('Joy <Autocomplete />', () => {
           renderTags={(value, getTagProps) =>
             value
               .filter((x, index) => index === 1)
-              .map((option, index) => (
-                <Chip key={index} endDecorator={<ChipDelete {...getTagProps({ index })} />}>
-                  {option.title}
-                </Chip>
-              ))
+              .map((option, index) => {
+                const { key, ...tagProps } = getTagProps({ index });
+                return (
+                  <Chip key={index} endDecorator={<ChipDelete key={key} {...tagProps} />}>
+                    {option.title}
+                  </Chip>
+                );
+              })
           }
           onChange={handleChange}
           autoFocus


### PR DESCRIPTION
Fixes a React warning caused by `key` being spread. This only happens starting with React 18.3 

<img width="1083" alt="image" src="https://github.com/mui/material-ui/assets/7225802/ee70f00d-d645-4d60-9f33-653b49550737">
