### PR TITLE
[material-ui][Dialog] Revert incorrect textAlign style removal

### DIFF
--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -138,6 +138,7 @@ const DialogPaper = styled(Paper, {
       style: {
         display: 'inline-block',
         verticalAlign: 'middle',
+        textAlign: 'initial',
       },
     },
     {


### PR DESCRIPTION
In https://github.com/mui/material-ui/pull/42283, a `textAlign` style was incorrectly removed: https://github.com/mui/material-ui/pull/42283/files#r1610471431. This PR implements the correct style.

Before: https://next.mui.com/material-ui/react-dialog/#scrolling-long-content
After: https://deploy-preview-42778--material-ui.netlify.app/material-ui/react-dialog/#scrolling-long-content
