### PR TITLE
[material-ui] Support CssVarsTheme in responsiveFontSizes types (#42760)

### DIFF
--- a/packages/mui-material/src/styles/responsiveFontSizes.d.ts
+++ b/packages/mui-material/src/styles/responsiveFontSizes.d.ts
@@ -1,6 +1,5 @@
 import { Breakpoint } from '@mui/system';
 import { Typography } from './createTypography';
-import { Theme } from './createTheme';
 
 export interface ResponsiveFontSizesOptions {
   breakpoints?: Breakpoint[];
@@ -9,7 +8,7 @@ export interface ResponsiveFontSizesOptions {
   variants?: Array<keyof Typography>;
 }
 
-export default function responsiveFontSizes(
-  theme: Theme,
+export default function responsiveFontSizes<T extends { typography: Typography }>(
+  theme: T,
   options?: ResponsiveFontSizesOptions,
-): Theme;
+): T;


### PR DESCRIPTION


- [ x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
