### PR TITLE
[material-ui][Rating] fix defaultLabelText a11y issue with undefine value input and hint

### DIFF
--- a/docs/data/material/migration/migrating-to-v6/migrating-to-v6.md
+++ b/docs/data/material/migration/migrating-to-v6/migrating-to-v6.md
@@ -255,6 +255,11 @@ Note that the items' position doesn't change.
 We recommend adopting this new behavior and **not trying to replicate the old one**, as this is a more predictable and modern approach.
 :::
 
+### Rating
+
+Previously, due to a bug, the `aria-label` attribute was "null Stars" when no value was set in the Rating component.
+This is fixed in v6, with the `aria-label` attribute being "0 Stars" when no value is set.
+
 ### useMediaQuery
 
 The following deprecated types were removed:

--- a/docs/pages/material-ui/api/rating.json
+++ b/docs/pages/material-ui/api/rating.json
@@ -7,7 +7,7 @@
     "emptyLabelText": { "type": { "name": "node" }, "default": "'Empty'" },
     "getLabelText": {
       "type": { "name": "func" },
-      "default": "function defaultLabelText(value) {\n  return `${value} Star${value !== 1 ? 's' : ''}`;\n}",
+      "default": "function defaultLabelText(value) {\n  return `${value || '0'} Star${value !== 1 ? 's' : ''}`;\n}",
       "signature": { "type": "function(value: number) => string", "describedArgs": ["value"] }
     },
     "highlightSelectedOnly": { "type": { "name": "bool" }, "default": "false" },

--- a/packages/mui-material/src/Rating/Rating.d.ts
+++ b/packages/mui-material/src/Rating/Rating.d.ts
@@ -44,7 +44,7 @@ export interface RatingProps
    * @param {number} value The rating label's value to format.
    * @returns {string}
    * @default function defaultLabelText(value) {
-   *   return `${value} Star${value !== 1 ? 's' : ''}`;
+   *   return `${value || '0'} Star${value !== 1 ? 's' : ''}`;
    * }
    */
   getLabelText?: (value: number) => string;

--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -321,8 +321,7 @@ const defaultIcon = <Star fontSize="inherit" />;
 const defaultEmptyIcon = <StarBorder fontSize="inherit" />;
 
 function defaultLabelText(value) {
-  const _value = value || 0;
-  return `${_value} Star${_value > 1 ? 's' : ''}`;
+  return `${value || '0'} Star${value !== 1 ? 's' : ''}`;
 }
 
 const Rating = React.forwardRef(function Rating(inProps, ref) {
@@ -671,8 +670,7 @@ Rating.propTypes /* remove-proptypes */ = {
    * @param {number} value The rating label's value to format.
    * @returns {string}
    * @default function defaultLabelText(value) {
-   *    const _value = value || 0;
-   *    return `${_value} Star${_value > 1 ? 's' : ''}`;
+   *    return `${value || '0'} Star${value !== 1 ? 's' : ''}`;
    * }
    */
   getLabelText: PropTypes.func,

--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -321,7 +321,8 @@ const defaultIcon = <Star fontSize="inherit" />;
 const defaultEmptyIcon = <StarBorder fontSize="inherit" />;
 
 function defaultLabelText(value) {
-  return `${value} Star${value !== 1 ? 's' : ''}`;
+  const _value = value || 0;
+  return `${_value} Star${_value > 1 ? 's' : ''}`;
 }
 
 const Rating = React.forwardRef(function Rating(inProps, ref) {
@@ -670,7 +671,8 @@ Rating.propTypes /* remove-proptypes */ = {
    * @param {number} value The rating label's value to format.
    * @returns {string}
    * @default function defaultLabelText(value) {
-   *   return `${value} Star${value !== 1 ? 's' : ''}`;
+   *    const _value = value || 0;
+   *    return `${_value} Star${_value > 1 ? 's' : ''}`;
    * }
    */
   getLabelText: PropTypes.func,

--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -670,7 +670,7 @@ Rating.propTypes /* remove-proptypes */ = {
    * @param {number} value The rating label's value to format.
    * @returns {string}
    * @default function defaultLabelText(value) {
-   *   return `${value} Star${value !== 1 ? 's' : ''}`;
+   *   return `${value || '0'} Star${value !== 1 ? 's' : ''}`;
    * }
    */
   getLabelText: PropTypes.func,

--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -670,7 +670,7 @@ Rating.propTypes /* remove-proptypes */ = {
    * @param {number} value The rating label's value to format.
    * @returns {string}
    * @default function defaultLabelText(value) {
-   *    return `${value || '0'} Star${value !== 1 ? 's' : ''}`;
+   *   return `${value} Star${value !== 1 ? 's' : ''}`;
    * }
    */
   getLabelText: PropTypes.func,

--- a/packages/mui-material/src/Rating/Rating.test.js
+++ b/packages/mui-material/src/Rating/Rating.test.js
@@ -225,7 +225,7 @@ describe('<Rating />', () => {
       expect(screen.getByRole('img')).toHaveAccessibleName('Stars: 2');
     });
 
-    it('can be labelled with getLabelText when non set value', () => {
+    it('should have a correct label when no value is set', () => {
       render(<Rating readOnly />);
 
       expect(screen.getByRole('img')).toHaveAccessibleName('0 Stars');

--- a/packages/mui-material/src/Rating/Rating.test.js
+++ b/packages/mui-material/src/Rating/Rating.test.js
@@ -228,7 +228,7 @@ describe('<Rating />', () => {
     it('can be labelled with getLabelText when non set value', () => {
       render(<Rating readOnly />);
 
-      expect(screen.getByRole('img')).toHaveAccessibleName('0 Heart');
+      expect(screen.getByRole('img')).toHaveAccessibleName('0 Stars');
     });
 
     it('should have readOnly class applied', () => {

--- a/packages/mui-material/src/Rating/Rating.test.js
+++ b/packages/mui-material/src/Rating/Rating.test.js
@@ -225,6 +225,12 @@ describe('<Rating />', () => {
       expect(screen.getByRole('img')).toHaveAccessibleName('Stars: 2');
     });
 
+    it('can be labelled with getLabelText when non set value', () => {
+      render(<Rating readOnly />);
+
+      expect(screen.getByRole('img')).toHaveAccessibleName('0 Heart');
+    });
+
     it('should have readOnly class applied', () => {
       render(<Rating readOnly value={2} />);
 


### PR DESCRIPTION
when I use Rating readOnly mode, I found there is a issue with the aria-label by default `defaultLabelText`

which will render like below `aria-label="null Hearts"`

![image](https://github.com/mui/material-ui/assets/5878538/c4ce1d0c-fbe5-4abd-9d27-64463ce9a2cf)


- [ x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
