### PR TITLE
[mui-material][Breadcrumbs] Enable onClick to be an editable prop

### DIFF
--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
@@ -113,6 +113,7 @@ const Breadcrumbs = React.forwardRef(function Breadcrumbs(inProps, ref) {
   const collapsedIconSlotProps = useSlotProps({
     elementType: slots.CollapsedIcon,
     externalSlotProps: slotProps.collapsedIcon,
+    onClick: slotProps.onClick,
     ownerState,
   });
 
@@ -152,7 +153,7 @@ const Breadcrumbs = React.forwardRef(function Breadcrumbs(inProps, ref) {
         key="ellipsis"
         slots={{ CollapsedIcon: slots.CollapsedIcon }}
         slotProps={{ collapsedIcon: collapsedIconSlotProps }}
-        onClick={handleClickExpand}
+        onClick={collapsedIconSlotProps.onClick || handleClickExpand}
       />,
       ...allItems.slice(allItems.length - itemsAfterCollapse, allItems.length),
     ];
@@ -254,14 +255,14 @@ Breadcrumbs.propTypes /* remove-proptypes */ = {
    */
   separator: PropTypes.node,
   /**
-   * The props used for each slot inside the Breadcumb.
+   * The props used for each slot inside the Breadcrumb.
    * @default {}
    */
   slotProps: PropTypes.shape({
     collapsedIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   }),
   /**
-   * The components used for each slot inside the Breadcumb.
+   * The components used for each slot inside the Breadcrumb.
    * Either a string to use a HTML element or a component.
    * @default {}
    */

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.test.js
@@ -82,6 +82,37 @@ describe('<Breadcrumbs />', () => {
     expect(getAllByRole('listitem', { hidden: false })).to.have.length(9);
   });
 
+  it('should not expand if onClick of `CollapsedIcon` is provided', () => {
+    const { getAllByRole, getByRole } = render(
+      <Breadcrumbs
+        slots={{
+          CollapsedIcon: FirstPageIcon,
+        }}
+        slotProps={{
+          collapsedIcon: {
+            onClick: () => {},
+          },
+        }}
+      >
+        <span>first</span>
+        <span>second</span>
+        <span>third</span>
+        <span>fourth</span>
+        <span>fifth</span>
+        <span>sixth</span>
+        <span>seventh</span>
+        <span>eighth</span>
+        <span>ninth</span>
+      </Breadcrumbs>,
+    );
+
+    act(() => {
+      getByRole('button').click();
+    });
+
+    expect(getAllByRole('listitem', { hidden: false })).to.have.length(3);
+  });
+
   it('should warn about invalid input', () => {
     expect(() => {
       render(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
