### PR TITLE
[material-ui] Add `DefaultPropsProvider`

### DIFF
--- a/packages/api-docs-builder-core/materialUi/projectSettings.ts
+++ b/packages/api-docs-builder-core/materialUi/projectSettings.ts
@@ -28,7 +28,7 @@ export const projectSettings: ProjectSettings = {
   getComponentInfo: getMaterialUiComponentInfo,
   translationLanguages: LANGUAGES,
   skipComponent(filename: string) {
-    return filename.match(/(ThemeProvider|CssVarsProvider|Grid2)/) !== null;
+    return filename.match(/(ThemeProvider|CssVarsProvider|DefaultPropsProvider|Grid2)/) !== null;
   },
   translationPagesDirectory: 'docs/translations/api-docs',
   generateClassName: generateUtilityClass,

--- a/packages/api-docs-builder-core/muiSystem/projectSettings.ts
+++ b/packages/api-docs-builder-core/muiSystem/projectSettings.ts
@@ -23,7 +23,9 @@ export const projectSettings: ProjectSettings = {
   getComponentInfo: getSystemComponentInfo,
   translationLanguages: LANGUAGES,
   skipComponent(filename) {
-    return filename.match(/(ThemeProvider|CssVarsProvider|GlobalStyles)/) !== null;
+    return (
+      filename.match(/(ThemeProvider|CssVarsProvider|DefaultPropsProvider|GlobalStyles)/) !== null
+    );
   },
   translationPagesDirectory: 'docs/translations/api-docs',
   generateClassName: generateUtilityClass,

--- a/packages/eslint-plugin-material-ui/src/rules/mui-name-matches-component-name.js
+++ b/packages/eslint-plugin-material-ui/src/rules/mui-name-matches-component-name.js
@@ -78,7 +78,8 @@ const rule = {
         }
 
         let nameLiteral = null;
-        const isUseThemePropsCall = node.callee.name === 'useThemeProps';
+        const isUseThemePropsCall =
+          node.callee.name === 'useThemeProps' || node.callee.name === 'useDefaultProps';
         if (isUseThemePropsCall) {
           let isCalledFromCustomHook = false;
           let parent = node.parent;

--- a/packages/eslint-plugin-material-ui/src/rules/mui-name-matches-component-name.test.js
+++ b/packages/eslint-plugin-material-ui/src/rules/mui-name-matches-component-name.test.js
@@ -4,6 +4,7 @@ const rule = require('./mui-name-matches-component-name');
 const ruleTester = new eslint.RuleTester({ parser: require.resolve('@typescript-eslint/parser') });
 ruleTester.run('mui-name-matches-component-name', rule, {
   valid: [
+    // useThemeProps
     `
       const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TDate>(
         inProps: StaticDateRangePickerProps<TDate>,
@@ -45,8 +46,56 @@ ruleTester.run('mui-name-matches-component-name', rule, {
       useThemeProps: (inProps) => useThemeProps({ props: inProps, name: 'MuiGrid2' }),
     }) as OverridableComponent<Grid2TypeMap>;
     `,
+    {
+      code: `
+        function useDatePickerDefaultizedProps(props, name) {
+          useThemeProps({ props, name });
+        }
+      `,
+      options: [{ customHooks: ['useDatePickerDefaultizedProps'] }],
+    },
+    // ================
+    // useDefaultProps
     `
-    const useThemeProps = createUseThemeProps('MuiBadge');
+      const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TDate>(
+        inProps: StaticDateRangePickerProps<TDate>,
+        ref: React.Ref<HTMLDivElement>,
+      ) {
+        const props = useDefaultProps({ props: inProps, name: 'MuiStaticDateRangePicker' });
+      });
+    `,
+    `
+      function CssBaseline(inProps) {
+        useDefaultProps({ props: inProps, name: 'MuiCssBaseline' });
+      }
+    `,
+    `
+    const Container = createContainer({
+      createStyledComponent: styled('div', {
+        name: 'MuiContainer',
+        slot: 'Root',
+        overridesResolver: (props, styles) => {
+          const { ownerState } = props;
+
+          return [
+            styles.root,
+            ownerState.fixed && styles.fixed,
+            ownerState.disableGutters && styles.disableGutters,
+          ];
+        },
+      }),
+      useDefaultProps: (inProps) => useDefaultProps({ props: inProps, name: 'MuiContainer' }),
+    });
+    `,
+    `
+    const Grid2 = createGrid2({
+      createStyledComponent: styled('div', {
+        name: 'MuiGrid2',
+        overridesResolver: (props, styles) => styles.root,
+      }),
+      componentName: 'MuiGrid2',
+      useDefaultProps: (inProps) => useDefaultProps({ props: inProps, name: 'MuiGrid2' }),
+    }) as OverridableComponent<Grid2TypeMap>;
     `,
     {
       code: `
@@ -62,13 +111,14 @@ ruleTester.run('mui-name-matches-component-name', rule, {
     {
       code: `
         function useDatePickerDefaultizedProps(props, name) {
-          useThemeProps({ props, name });
+          useDefaultProps({ props, name });
         }
       `,
       options: [{ customHooks: ['useDatePickerDefaultizedProps'] }],
     },
   ],
   invalid: [
+    // useThemeProps
     {
       code: `
         const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TDate>(
@@ -115,6 +165,66 @@ ruleTester.run('mui-name-matches-component-name', rule, {
           inProps: StaticDateRangePickerProps<TDate>,
           ref: React.Ref<HTMLDivElement>,
         ) {
+          const props = useDatePickerDefaultizedProps(inProps, 'MuiPickersDateRangePicker');
+        });
+      `,
+      options: [{ customHooks: ['useDatePickerDefaultizedProps'] }],
+      errors: [
+        {
+          message:
+            "Expected `name` to be 'MuiStaticDateRangePicker' but instead got 'MuiPickersDateRangePicker'.",
+          type: 'Literal',
+        },
+      ],
+    },
+    // ================
+    // useDefaultProps
+    {
+      code: `
+        const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TDate>(
+          inProps: StaticDateRangePickerProps<TDate>,
+          ref: React.Ref<HTMLDivElement>,
+        ) {
+          const props = useDefaultProps({ props: inProps, name: 'MuiPickersDateRangePicker' });
+        });
+      `,
+      errors: [
+        {
+          message:
+            "Expected `name` to be 'MuiStaticDateRangePicker' but instead got 'MuiPickersDateRangePicker'.",
+          type: 'Literal',
+        },
+      ],
+    },
+    {
+      code: 'useDefaultProps({ props: inProps })',
+      errors: [
+        {
+          message: 'Unable to find `name` property. Did you forget to pass `name`?',
+          type: 'ObjectExpression',
+        },
+      ],
+    },
+    {
+      code: 'useDefaultProps({ props: inProps, name })',
+      errors: [
+        {
+          message:
+            'Unable to resolve `name`. Please hardcode the `name` i.e. use a string literal.',
+          type: 'Identifier',
+        },
+      ],
+    },
+    {
+      code: "useDefaultProps({ props: inProps, name: 'MuiPickersDateRangePicker' })",
+      errors: [{ message: 'Unable to find component for this call.', type: 'CallExpression' }],
+    },
+    {
+      code: `
+        const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TDate>(
+          inProps: StaticDateRangePickerProps<TDate>,
+          ref: React.Ref<HTMLDivElement>,
+        ) {
           const props = useDatePickerDefaultizedProps(inProps);
         });
       `,
@@ -127,6 +237,8 @@ ruleTester.run('mui-name-matches-component-name', rule, {
         },
       ],
     },
+    // ================
+    // customHooks
     {
       code: `
         const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TDate>(
@@ -142,38 +254,6 @@ ruleTester.run('mui-name-matches-component-name', rule, {
           message:
             "Expected `name` to be 'MuiStaticDateRangePicker' but instead got 'MuiPickersDateRangePicker'.",
           type: 'Literal',
-        },
-      ],
-    },
-    {
-      code: `
-        const useThemeProps = createUseThemeProps();
-
-        const Badge = React.forwardRef(function Badge(inProps, ref) {
-          const props = useThemeProps({ props: inProps, name: 'MuiBadge' });
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Unable to resolve `name`. Please hardcode the `name` i.e. use a string literal.',
-          type: 'CallExpression',
-        },
-      ],
-    },
-    {
-      code: `
-        const useThemeProps = createUseThemeProps({ name: 'MuiBadge' });
-
-        const Badge = React.forwardRef(function Badge(inProps, ref) {
-          const props = useThemeProps({ props: inProps, name: 'MuiBadge' });
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Unable to resolve `name`. Please hardcode the `name` i.e. use a string literal.',
-          type: 'ObjectExpression',
         },
       ],
     },

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 import { chainPropTypes } from '@mui/utils';
 import { capitalize, unstable_useId as useId } from '@mui/material/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
-import { styled, useThemeProps } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
+import { useDefaultProps } from '@mui/material/DefaultPropsProvider';
 import Button from '@mui/material/Button';
 import { ButtonGroupContext } from '@mui/material/ButtonGroup';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -140,7 +141,7 @@ const LoadingButtonLoadingIndicator = styled('span', {
 const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
   const contextProps = React.useContext(ButtonGroupContext);
   const resolvedProps = resolveProps(contextProps, inProps);
-  const props = useThemeProps({ props: resolvedProps, name: 'MuiLoadingButton' });
+  const props = useDefaultProps({ props: resolvedProps, name: 'MuiLoadingButton' });
   const {
     children,
     disabled = false,

--- a/packages/mui-material/src/Accordion/Accordion.js
+++ b/packages/mui-material/src/Accordion/Accordion.js
@@ -13,7 +13,7 @@ import useControlled from '../utils/useControlled';
 import useSlot from '../utils/useSlot';
 import accordionClasses, { getAccordionUtilityClass } from './accordionClasses';
 
-const useThemeProps = createUseThemeProps('MuiAccordion');
+const useDefaultProps = createUseThemeProps('MuiAccordion');
 
 const useUtilityClasses = (ownerState) => {
   const { classes, square, expanded, disabled, disableGutters } = ownerState;
@@ -126,7 +126,7 @@ const AccordionRoot = styled(Paper, {
 );
 
 const Accordion = React.forwardRef(function Accordion(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiAccordion' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiAccordion' });
   const {
     children: childrenProp,
     className,

--- a/packages/mui-material/src/AccordionActions/AccordionActions.js
+++ b/packages/mui-material/src/AccordionActions/AccordionActions.js
@@ -6,7 +6,7 @@ import composeClasses from '@mui/utils/composeClasses';
 import { styled, createUseThemeProps } from '../zero-styled';
 import { getAccordionActionsUtilityClass } from './accordionActionsClasses';
 
-const useThemeProps = createUseThemeProps('MuiAccordionActions');
+const useDefaultProps = createUseThemeProps('MuiAccordionActions');
 
 const useUtilityClasses = (ownerState) => {
   const { classes, disableSpacing } = ownerState;
@@ -44,7 +44,7 @@ const AccordionActionsRoot = styled('div', {
 });
 
 const AccordionActions = React.forwardRef(function AccordionActions(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiAccordionActions' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiAccordionActions' });
   const { className, disableSpacing = false, ...other } = props;
   const ownerState = { ...props, disableSpacing };
 

--- a/packages/mui-material/src/AccordionDetails/AccordionDetails.js
+++ b/packages/mui-material/src/AccordionDetails/AccordionDetails.js
@@ -6,7 +6,7 @@ import composeClasses from '@mui/utils/composeClasses';
 import { styled, createUseThemeProps } from '../zero-styled';
 import { getAccordionDetailsUtilityClass } from './accordionDetailsClasses';
 
-const useThemeProps = createUseThemeProps('MuiAccordionDetails');
+const useDefaultProps = createUseThemeProps('MuiAccordionDetails');
 
 const useUtilityClasses = (ownerState) => {
   const { classes } = ownerState;
@@ -27,7 +27,7 @@ const AccordionDetailsRoot = styled('div', {
 }));
 
 const AccordionDetails = React.forwardRef(function AccordionDetails(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiAccordionDetails' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiAccordionDetails' });
   const { className, ...other } = props;
   const ownerState = props;
   const classes = useUtilityClasses(ownerState);

--- a/packages/mui-material/src/AccordionSummary/AccordionSummary.js
+++ b/packages/mui-material/src/AccordionSummary/AccordionSummary.js
@@ -10,7 +10,7 @@ import accordionSummaryClasses, {
   getAccordionSummaryUtilityClass,
 } from './accordionSummaryClasses';
 
-const useThemeProps = createUseThemeProps('MuiAccordionSummary');
+const useDefaultProps = createUseThemeProps('MuiAccordionSummary');
 
 const useUtilityClasses = (ownerState) => {
   const { classes, expanded, disabled, disableGutters } = ownerState;
@@ -101,7 +101,7 @@ const AccordionSummaryExpandIconWrapper = styled('div', {
 }));
 
 const AccordionSummary = React.forwardRef(function AccordionSummary(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiAccordionSummary' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiAccordionSummary' });
   const { children, className, expandIcon, focusVisibleClassName, onClick, ...other } = props;
 
   const { disabled = false, disableGutters, expanded, toggle } = React.useContext(AccordionContext);

--- a/packages/mui-material/src/Alert/Alert.js
+++ b/packages/mui-material/src/Alert/Alert.js
@@ -16,7 +16,7 @@ import ErrorOutlineIcon from '../internal/svg-icons/ErrorOutline';
 import InfoOutlinedIcon from '../internal/svg-icons/InfoOutlined';
 import CloseIcon from '../internal/svg-icons/Close';
 
-const useThemeProps = createUseThemeProps('MuiAlert');
+const useDefaultProps = createUseThemeProps('MuiAlert');
 
 const useUtilityClasses = (ownerState) => {
   const { variant, color, severity, classes } = ownerState;
@@ -157,7 +157,7 @@ const defaultIconMapping = {
 };
 
 const Alert = React.forwardRef(function Alert(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiAlert' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiAlert' });
   const {
     action,
     children,

--- a/packages/mui-material/src/AlertTitle/AlertTitle.js
+++ b/packages/mui-material/src/AlertTitle/AlertTitle.js
@@ -7,7 +7,7 @@ import { styled, createUseThemeProps } from '../zero-styled';
 import Typography from '../Typography';
 import { getAlertTitleUtilityClass } from './alertTitleClasses';
 
-const useThemeProps = createUseThemeProps('MuiAlertTitle');
+const useDefaultProps = createUseThemeProps('MuiAlertTitle');
 
 const useUtilityClasses = (ownerState) => {
   const { classes } = ownerState;
@@ -31,7 +31,7 @@ const AlertTitleRoot = styled(Typography, {
 });
 
 const AlertTitle = React.forwardRef(function AlertTitle(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiAlertTitle',
   });

--- a/packages/mui-material/src/AppBar/AppBar.js
+++ b/packages/mui-material/src/AppBar/AppBar.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import capitalize from '../utils/capitalize';
 import Paper from '../Paper';
 import { getAppBarUtilityClass } from './appBarClasses';
@@ -138,7 +138,7 @@ const AppBarRoot = styled(Paper, {
 });
 
 const AppBar = React.forwardRef(function AppBar(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiAppBar' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiAppBar' });
   const {
     className,
     color = 'primary',

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -23,7 +23,7 @@ import autocompleteClasses, { getAutocompleteUtilityClass } from './autocomplete
 import capitalize from '../utils/capitalize';
 import useForkRef from '../utils/useForkRef';
 
-const useThemeProps = createUseThemeProps('MuiAutocomplete');
+const useDefaultProps = createUseThemeProps('MuiAutocomplete');
 
 const useUtilityClasses = (ownerState) => {
   const {
@@ -411,7 +411,7 @@ const AutocompleteGroupUl = styled('ul', {
 export { createFilterOptions };
 
 const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiAutocomplete' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiAutocomplete' });
 
   /* eslint-disable @typescript-eslint/no-unused-vars */
   const {

--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -8,7 +8,7 @@ import Person from '../internal/svg-icons/Person';
 import { getAvatarUtilityClass } from './avatarClasses';
 import useSlot from '../utils/useSlot';
 
-const useThemeProps = createUseThemeProps('MuiAvatar');
+const useDefaultProps = createUseThemeProps('MuiAvatar');
 
 const useUtilityClasses = (ownerState) => {
   const { classes, variant, colorDefault } = ownerState;
@@ -143,7 +143,7 @@ function useLoaded({ crossOrigin, referrerPolicy, src, srcSet }) {
 }
 
 const Avatar = React.forwardRef(function Avatar(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiAvatar' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiAvatar' });
   const {
     alt,
     children: childrenProp,

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import Avatar, { avatarClasses } from '../Avatar';
 import avatarGroupClasses, { getAvatarGroupUtilityClass } from './avatarGroupClasses';
 
@@ -54,7 +54,7 @@ const AvatarGroupRoot = styled('div', {
 });
 
 const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiAvatarGroup',
   });

--- a/packages/mui-material/src/Backdrop/Backdrop.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import Fade from '../Fade';
 import { getBackdropUtilityClass } from './backdropClasses';
 
@@ -43,7 +43,7 @@ const BackdropRoot = styled('div', {
 }));
 
 const Backdrop = React.forwardRef(function Backdrop(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiBackdrop' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiBackdrop' });
   const {
     children,
     className,

--- a/packages/mui-material/src/Badge/Badge.js
+++ b/packages/mui-material/src/Badge/Badge.js
@@ -13,7 +13,7 @@ import badgeClasses, { getBadgeUtilityClass } from './badgeClasses';
 const RADIUS_STANDARD = 10;
 const RADIUS_DOT = 4;
 
-const useThemeProps = createUseThemeProps('MuiBadge');
+const useDefaultProps = createUseThemeProps('MuiBadge');
 
 const useUtilityClasses = (ownerState) => {
   const { color, anchorOrigin, invisible, overlap, variant, classes = {} } = ownerState;
@@ -244,7 +244,7 @@ const BadgeBadge = styled('span', {
 }));
 
 const Badge = React.forwardRef(function Badge(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiBadge' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiBadge' });
   const {
     anchorOrigin: anchorOriginProp = {
       vertical: 'top',

--- a/packages/mui-material/src/BottomNavigation/BottomNavigation.js
+++ b/packages/mui-material/src/BottomNavigation/BottomNavigation.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getBottomNavigationUtilityClass } from './bottomNavigationClasses';
 
 const useUtilityClasses = (ownerState) => {
@@ -30,7 +30,7 @@ const BottomNavigationRoot = styled('div', {
 }));
 
 const BottomNavigation = React.forwardRef(function BottomNavigation(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiBottomNavigation' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiBottomNavigation' });
   const {
     children,
     className,

--- a/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import ButtonBase from '../ButtonBase';
 import unsupportedProp from '../utils/unsupportedProp';
 import bottomNavigationActionClasses, {
@@ -75,7 +75,7 @@ const BottomNavigationActionLabel = styled('span', {
 }));
 
 const BottomNavigationAction = React.forwardRef(function BottomNavigationAction(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiBottomNavigationAction' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiBottomNavigationAction' });
   const {
     className,
     icon,

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
@@ -7,7 +7,7 @@ import integerPropType from '@mui/utils/integerPropType';
 import { useSlotProps } from '@mui/base/utils';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import Typography from '../Typography';
 import BreadcrumbCollapsed from './BreadcrumbCollapsed';
 import breadcrumbsClasses, { getBreadcrumbsUtilityClass } from './breadcrumbsClasses';
@@ -80,7 +80,7 @@ function insertSeparators(items, className, separator, ownerState) {
 }
 
 const Breadcrumbs = React.forwardRef(function Breadcrumbs(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiBreadcrumbs' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiBreadcrumbs' });
   const {
     children,
     className,

--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -6,7 +6,7 @@ import resolveProps from '@mui/utils/resolveProps';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';
 import styled, { rootShouldForwardProp } from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import ButtonBase from '../ButtonBase';
 import capitalize from '../utils/capitalize';
 import buttonClasses, { getButtonUtilityClass } from './buttonClasses';
@@ -301,7 +301,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
   const contextProps = React.useContext(ButtonGroupContext);
   const buttonGroupButtonContextPositionClassName = React.useContext(ButtonGroupButtonContext);
   const resolvedProps = resolveProps(contextProps, inProps);
-  const props = useThemeProps({ props: resolvedProps, name: 'MuiButton' });
+  const props = useDefaultProps({ props: resolvedProps, name: 'MuiButton' });
   const {
     children,
     color = 'primary',

--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -6,7 +6,7 @@ import refType from '@mui/utils/refType';
 import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import useForkRef from '../utils/useForkRef';
 import useEventCallback from '../utils/useEventCallback';
 import useIsFocusVisible from '../utils/useIsFocusVisible';
@@ -73,7 +73,7 @@ export const ButtonBaseRoot = styled('button', {
  * It contains a load of style reset and some focus/ripple logic.
  */
 const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiButtonBase' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiButtonBase' });
   const {
     action,
     centerRipple = false,
@@ -340,7 +340,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
   const classes = useUtilityClasses(ownerState);
 
   return (
-    <ButtonBaseRoot
+    (<ButtonBaseRoot
       as={ComponentProp}
       className={clsx(classes.root, className)}
       ownerState={ownerState}
@@ -366,9 +366,9 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
       {children}
       {enableTouchRipple ? (
         /* TouchRipple is only needed client-side, x2 boost on the server. */
-        <TouchRipple ref={handleRippleRef} center={centerRipple} {...TouchRippleProps} />
+        (<TouchRipple ref={handleRippleRef} center={centerRipple} {...TouchRippleProps} />)
       ) : null}
-    </ButtonBaseRoot>
+    </ButtonBaseRoot>)
   );
 });
 

--- a/packages/mui-material/src/ButtonBase/TouchRipple.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import { keyframes } from '@mui/system';
 import useTimeout from '@mui/utils/useTimeout';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import Ripple from './Ripple';
 import touchRippleClasses from './touchRippleClasses';
 
@@ -120,7 +120,7 @@ export const TouchRippleRipple = styled(Ripple, {
  * TODO v5: Make private
  */
 const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTouchRipple' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTouchRipple' });
 
   const { center: centerProp = false, classes = {}, className, ...other } = props;
   const [ripples, setRipples] = React.useState([]);

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -7,7 +7,7 @@ import { alpha } from '@mui/system/colorManipulator';
 import getValidReactChildren from '@mui/utils/getValidReactChildren';
 import capitalize from '../utils/capitalize';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import buttonGroupClasses, { getButtonGroupUtilityClass } from './buttonGroupClasses';
 import ButtonGroupContext from './ButtonGroupContext';
 import ButtonGroupButtonContext from './ButtonGroupButtonContext';
@@ -199,7 +199,7 @@ const ButtonGroupRoot = styled('div', {
 }));
 
 const ButtonGroup = React.forwardRef(function ButtonGroup(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiButtonGroup' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiButtonGroup' });
   const {
     children,
     className,

--- a/packages/mui-material/src/Card/Card.js
+++ b/packages/mui-material/src/Card/Card.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import Paper from '../Paper';
 import { getCardUtilityClass } from './cardClasses';
 
@@ -30,7 +30,7 @@ const CardRoot = styled(Paper, {
 });
 
 const Card = React.forwardRef(function Card(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiCard',
   });

--- a/packages/mui-material/src/CardActionArea/CardActionArea.js
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import cardActionAreaClasses, { getCardActionAreaUtilityClass } from './cardActionAreaClasses';
 import ButtonBase from '../ButtonBase';
@@ -60,7 +60,7 @@ const CardActionAreaFocusHighlight = styled('span', {
 }));
 
 const CardActionArea = React.forwardRef(function CardActionArea(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiCardActionArea' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiCardActionArea' });
   const { children, className, focusVisibleClassName, ...other } = props;
 
   const ownerState = props;

--- a/packages/mui-material/src/CardActions/CardActions.js
+++ b/packages/mui-material/src/CardActions/CardActions.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getCardActionsUtilityClass } from './cardActionsClasses';
 
 const useUtilityClasses = (ownerState) => {
@@ -37,7 +37,7 @@ const CardActionsRoot = styled('div', {
 }));
 
 const CardActions = React.forwardRef(function CardActions(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiCardActions',
   });

--- a/packages/mui-material/src/CardContent/CardContent.js
+++ b/packages/mui-material/src/CardContent/CardContent.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getCardContentUtilityClass } from './cardContentClasses';
 
 const useUtilityClasses = (ownerState) => {
@@ -31,7 +31,7 @@ const CardContentRoot = styled('div', {
 });
 
 const CardContent = React.forwardRef(function CardContent(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiCardContent',
   });

--- a/packages/mui-material/src/CardHeader/CardHeader.js
+++ b/packages/mui-material/src/CardHeader/CardHeader.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import Typography from '../Typography';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import cardHeaderClasses, { getCardHeaderUtilityClass } from './cardHeaderClasses';
 
@@ -68,7 +68,7 @@ const CardHeaderContent = styled('div', {
 });
 
 const CardHeader = React.forwardRef(function CardHeader(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiCardHeader' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiCardHeader' });
   const {
     action,
     avatar,

--- a/packages/mui-material/src/CardMedia/CardMedia.js
+++ b/packages/mui-material/src/CardMedia/CardMedia.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { getCardMediaUtilityClass } from './cardMediaClasses';
 
@@ -45,7 +45,7 @@ const MEDIA_COMPONENTS = ['video', 'audio', 'picture', 'iframe', 'img'];
 const IMAGE_COMPONENTS = ['picture', 'img'];
 
 const CardMedia = React.forwardRef(function CardMedia(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiCardMedia' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiCardMedia' });
   const { children, className, component = 'div', image, src, style, ...other } = props;
 
   const isMediaComponent = MEDIA_COMPONENTS.indexOf(component) !== -1;

--- a/packages/mui-material/src/Checkbox/Checkbox.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.js
@@ -10,7 +10,7 @@ import CheckBoxOutlineBlankIcon from '../internal/svg-icons/CheckBoxOutlineBlank
 import CheckBoxIcon from '../internal/svg-icons/CheckBox';
 import IndeterminateCheckBoxIcon from '../internal/svg-icons/IndeterminateCheckBox';
 import capitalize from '../utils/capitalize';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled, { rootShouldForwardProp } from '../styles/styled';
 import checkboxClasses, { getCheckboxUtilityClass } from './checkboxClasses';
 
@@ -85,7 +85,7 @@ const defaultIcon = <CheckBoxOutlineBlankIcon />;
 const defaultIndeterminateIcon = <IndeterminateCheckBoxIcon />;
 
 const Checkbox = React.forwardRef(function Checkbox(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiCheckbox' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiCheckbox' });
   const {
     checkedIcon = defaultCheckedIcon,
     color = 'primary',

--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -9,7 +9,7 @@ import useForkRef from '../utils/useForkRef';
 import unsupportedProp from '../utils/unsupportedProp';
 import capitalize from '../utils/capitalize';
 import ButtonBase from '../ButtonBase';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import chipClasses, { getChipUtilityClass } from './chipClasses';
 
@@ -332,7 +332,7 @@ function isDeleteKeyboardEvent(keyboardEvent) {
  * Chips represent complex entities in small blocks, such as a contact.
  */
 const Chip = React.forwardRef(function Chip(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiChip' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiChip' });
   const {
     avatar: avatarProp,
     className,

--- a/packages/mui-material/src/CircularProgress/CircularProgress.js
+++ b/packages/mui-material/src/CircularProgress/CircularProgress.js
@@ -6,7 +6,7 @@ import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';
 import { keyframes, css } from '@mui/system';
 import capitalize from '../utils/capitalize';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { getCircularProgressUtilityClass } from './circularProgressClasses';
 
@@ -130,7 +130,7 @@ const CircularProgressCircle = styled('circle', {
  * attribute to `true` on that region until it has finished loading.
  */
 const CircularProgress = React.forwardRef(function CircularProgress(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiCircularProgress' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiCircularProgress' });
   const {
     className,
     color = 'primary',

--- a/packages/mui-material/src/Collapse/Collapse.js
+++ b/packages/mui-material/src/Collapse/Collapse.js
@@ -7,7 +7,7 @@ import useTimeout from '@mui/utils/useTimeout';
 import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { duration } from '../styles/createTransitions';
 import { getTransitionProps } from '../transitions/utils';
 import useTheme from '../styles/useTheme';
@@ -99,7 +99,7 @@ const CollapseWrapperInner = styled('div', {
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
  */
 const Collapse = React.forwardRef(function Collapse(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiCollapse' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiCollapse' });
   const {
     addEndListener,
     children,

--- a/packages/mui-material/src/Container/Container.js
+++ b/packages/mui-material/src/Container/Container.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { createContainer } from '@mui/system';
 import capitalize from '../utils/capitalize';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 
 const Container = createContainer({
   createStyledComponent: styled('div', {
@@ -20,7 +20,7 @@ const Container = createContainer({
       ];
     },
   }),
-  useThemeProps: (inProps) => useThemeProps({ props: inProps, name: 'MuiContainer' }),
+  useDefaultProps: (inProps) => useDefaultProps({ props: inProps, name: 'MuiContainer' }),
 });
 
 Container.propTypes /* remove-proptypes */ = {

--- a/packages/mui-material/src/CssBaseline/CssBaseline.js
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import GlobalStyles from '../GlobalStyles';
 
 export const html = (theme, enableColorScheme) => ({
@@ -67,7 +67,7 @@ export const styles = (theme, enableColorScheme = false) => {
  * Kickstart an elegant, consistent, and simple baseline to build upon.
  */
 function CssBaseline(inProps) {
-  const props = useThemeProps({ props: inProps, name: 'MuiCssBaseline' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiCssBaseline' });
   const { children, enableColorScheme = false } = props;
   return (
     <React.Fragment>

--- a/packages/mui-material/src/DefaultPropsProvider/DefaultPropsProvider.spec.tsx
+++ b/packages/mui-material/src/DefaultPropsProvider/DefaultPropsProvider.spec.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import DefaultPropsProvider from '@mui/material/DefaultPropsProvider';
+
+function CustomComponent() {
+  return null;
+}
+
+<DefaultPropsProvider
+  value={{
+    MuiSelect: {
+      IconComponent: CustomComponent,
+    },
+  }}
+/>;
+
+<DefaultPropsProvider
+  value={{
+    // @ts-expect-error
+    Random: {},
+  }}
+/>;

--- a/packages/mui-material/src/DefaultPropsProvider/DefaultPropsProvider.tsx
+++ b/packages/mui-material/src/DefaultPropsProvider/DefaultPropsProvider.tsx
@@ -1,0 +1,39 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import SystemDefaultPropsProvider, {
+  useDefaultProps as useSystemDefaultProps,
+} from '@mui/system/DefaultPropsProvider';
+import type { ComponentsPropsList } from '../styles/props';
+
+function DefaultPropsProvider(
+  props: React.PropsWithChildren<{
+    value: { [P in keyof ComponentsPropsList]?: Partial<ComponentsPropsList[P]> };
+  }>,
+) {
+  return <SystemDefaultPropsProvider {...props} />;
+}
+
+DefaultPropsProvider.propTypes /* remove-proptypes */ = {
+  // ┌────────────────────────────── Warning ──────────────────────────────┐
+  // │ These PropTypes are generated from the TypeScript type definitions. │
+  // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
+  // └─────────────────────────────────────────────────────────────────────┘
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * @ignore
+   */
+  value: PropTypes.object.isRequired,
+} as any;
+
+export default DefaultPropsProvider;
+
+export function useDefaultProps<Props extends Record<string, any>>(params: {
+  props: Props;
+  name: string;
+}) {
+  return useSystemDefaultProps(params) as Props;
+}

--- a/packages/mui-material/src/DefaultPropsProvider/index.ts
+++ b/packages/mui-material/src/DefaultPropsProvider/index.ts
@@ -1,0 +1,1 @@
+export { default, useDefaultProps } from './DefaultPropsProvider';

--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -8,7 +8,7 @@ import capitalize from '../utils/capitalize';
 import Modal from '../Modal';
 import Fade from '../Fade';
 import Paper from '../Paper';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import dialogClasses, { getDialogUtilityClass } from './dialogClasses';
 import DialogContext from './DialogContext';
@@ -163,7 +163,7 @@ const DialogPaper = styled(Paper, {
  * Dialogs are overlaid modal paper based components with a backdrop.
  */
 const Dialog = React.forwardRef(function Dialog(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiDialog' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiDialog' });
   const theme = useTheme();
   const defaultTransitionDuration = {
     enter: theme.transitions.duration.enteringScreen,

--- a/packages/mui-material/src/DialogActions/DialogActions.js
+++ b/packages/mui-material/src/DialogActions/DialogActions.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getDialogActionsUtilityClass } from './dialogActionsClasses';
 
 const useUtilityClasses = (ownerState) => {
@@ -39,7 +39,7 @@ const DialogActionsRoot = styled('div', {
 }));
 
 const DialogActions = React.forwardRef(function DialogActions(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiDialogActions',
   });

--- a/packages/mui-material/src/DialogContent/DialogContent.js
+++ b/packages/mui-material/src/DialogContent/DialogContent.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getDialogContentUtilityClass } from './dialogContentClasses';
 import dialogTitleClasses from '../DialogTitle/dialogTitleClasses';
 
@@ -46,7 +46,7 @@ const DialogContentRoot = styled('div', {
 }));
 
 const DialogContent = React.forwardRef(function DialogContent(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiDialogContent',
   });

--- a/packages/mui-material/src/DialogContentText/DialogContentText.js
+++ b/packages/mui-material/src/DialogContentText/DialogContentText.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled, { rootShouldForwardProp } from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import Typography from '../Typography';
 import { getDialogContentTextUtilityClass } from './dialogContentTextClasses';
 
@@ -31,7 +31,7 @@ const DialogContentTextRoot = styled(Typography, {
 })({});
 
 const DialogContentText = React.forwardRef(function DialogContentText(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiDialogContentText' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiDialogContentText' });
   const { children, className, ...ownerState } = props;
   const classes = useUtilityClasses(ownerState);
 

--- a/packages/mui-material/src/DialogTitle/DialogTitle.js
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import Typography from '../Typography';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getDialogTitleUtilityClass } from './dialogTitleClasses';
 import DialogContext from '../Dialog/DialogContext';
 
@@ -29,7 +29,7 @@ const DialogTitleRoot = styled(Typography, {
 });
 
 const DialogTitle = React.forwardRef(function DialogTitle(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiDialogTitle',
   });

--- a/packages/mui-material/src/Divider/Divider.js
+++ b/packages/mui-material/src/Divider/Divider.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getDividerUtilityClass } from './dividerClasses';
 
 const useUtilityClasses = (ownerState) => {
@@ -168,7 +168,7 @@ const DividerWrapper = styled('span', {
 }));
 
 const Divider = React.forwardRef(function Divider(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiDivider' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiDivider' });
   const {
     absolute = false,
     children,

--- a/packages/mui-material/src/Drawer/Drawer.js
+++ b/packages/mui-material/src/Drawer/Drawer.js
@@ -10,7 +10,7 @@ import Slide from '../Slide';
 import Paper from '../Paper';
 import capitalize from '../utils/capitalize';
 import useTheme from '../styles/useTheme';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled, { rootShouldForwardProp } from '../styles/styled';
 import { getDrawerUtilityClass } from './drawerClasses';
 
@@ -147,7 +147,7 @@ export function getAnchor({ direction }, anchor) {
  * when `variant="temporary"` is set.
  */
 const Drawer = React.forwardRef(function Drawer(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiDrawer' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiDrawer' });
   const theme = useTheme();
   const isRtl = useRtl();
   const defaultTransitionDuration = {

--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import ButtonBase from '../ButtonBase';
 import capitalize from '../utils/capitalize';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import fabClasses, { getFabUtilityClass } from './fabClasses';
 import styled, { rootShouldForwardProp } from '../styles/styled';
 
@@ -138,7 +138,7 @@ const FabRoot = styled(ButtonBase, {
 );
 
 const Fab = React.forwardRef(function Fab(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiFab' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiFab' });
   const {
     children,
     className,

--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';
 import InputBase from '../InputBase';
 import styled, { rootShouldForwardProp } from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import filledInputClasses, { getFilledInputUtilityClass } from './filledInputClasses';
 import {
   rootOverridesResolver as inputBaseRootOverridesResolver,
@@ -206,7 +206,7 @@ const FilledInputInput = styled(InputBaseInput, {
 }));
 
 const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiFilledInput' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiFilledInput' });
 
   const {
     disableUnderline,

--- a/packages/mui-material/src/FormControl/FormControl.js
+++ b/packages/mui-material/src/FormControl/FormControl.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { isFilled, isAdornedStart } from '../InputBase/utils';
 import capitalize from '../utils/capitalize';
@@ -78,7 +78,7 @@ const FormControlRoot = styled('div', {
  * For instance, only one input can be focused at the same time, the state shouldn't be shared.
  */
 const FormControl = React.forwardRef(function FormControl(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiFormControl' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiFormControl' });
   const {
     children,
     className,

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.js
@@ -9,7 +9,7 @@ import Stack from '../Stack';
 import Typography from '../Typography';
 import capitalize from '../utils/capitalize';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import formControlLabelClasses, {
   getFormControlLabelUtilityClasses,
 } from './formControlLabelClasses';
@@ -91,7 +91,7 @@ const AsteriskComponent = styled('span', {
  * Use this component if you want to display an extra label.
  */
 const FormControlLabel = React.forwardRef(function FormControlLabel(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiFormControlLabel' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiFormControlLabel' });
   const {
     checked,
     className,

--- a/packages/mui-material/src/FormGroup/FormGroup.js
+++ b/packages/mui-material/src/FormGroup/FormGroup.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getFormGroupUtilityClass } from './formGroupClasses';
 import useFormControl from '../FormControl/useFormControl';
 import formControlState from '../FormControl/formControlState';
@@ -42,7 +42,7 @@ const FormGroupRoot = styled('div', {
  * For the `Radio`, you should be using the `RadioGroup` component instead of this one.
  */
 const FormGroup = React.forwardRef(function FormGroup(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiFormGroup',
   });

--- a/packages/mui-material/src/FormHelperText/FormHelperText.js
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.js
@@ -8,7 +8,7 @@ import useFormControl from '../FormControl/useFormControl';
 import styled from '../styles/styled';
 import capitalize from '../utils/capitalize';
 import formHelperTextClasses, { getFormHelperTextUtilityClasses } from './formHelperTextClasses';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 
 const useUtilityClasses = (ownerState) => {
   const { classes, contained, size, disabled, error, filled, focused, required } = ownerState;
@@ -65,7 +65,7 @@ const FormHelperTextRoot = styled('p', {
 }));
 
 const FormHelperText = React.forwardRef(function FormHelperText(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiFormHelperText' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiFormHelperText' });
   const {
     children,
     className,
@@ -103,7 +103,7 @@ const FormHelperText = React.forwardRef(function FormHelperText(inProps, ref) {
   const classes = useUtilityClasses(ownerState);
 
   return (
-    <FormHelperTextRoot
+    (<FormHelperTextRoot
       as={component}
       ownerState={ownerState}
       className={clsx(classes.root, className)}
@@ -112,11 +112,11 @@ const FormHelperText = React.forwardRef(function FormHelperText(inProps, ref) {
     >
       {children === ' ' ? (
         // notranslate needed while Google Translate will not fix zero-width space issue
-        <span className="notranslate">&#8203;</span>
+        (<span className="notranslate">​</span>)
       ) : (
         children
       )}
-    </FormHelperTextRoot>
+    </FormHelperTextRoot>)
   );
 });
 

--- a/packages/mui-material/src/FormLabel/FormLabel.js
+++ b/packages/mui-material/src/FormLabel/FormLabel.js
@@ -6,7 +6,7 @@ import composeClasses from '@mui/utils/composeClasses';
 import formControlState from '../FormControl/formControlState';
 import useFormControl from '../FormControl/useFormControl';
 import capitalize from '../utils/capitalize';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import formLabelClasses, { getFormLabelUtilityClasses } from './formLabelClasses';
 
@@ -66,7 +66,7 @@ const AsteriskComponent = styled('span', {
 }));
 
 const FormLabel = React.forwardRef(function FormLabel(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiFormLabel' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiFormLabel' });
   const {
     children,
     className,

--- a/packages/mui-material/src/Grid/Grid.js
+++ b/packages/mui-material/src/Grid/Grid.js
@@ -20,7 +20,7 @@ import { extendSxProp } from '@mui/system/styleFunctionSx';
 import composeClasses from '@mui/utils/composeClasses';
 import requirePropFactory from '../utils/requirePropFactory';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import useTheme from '../styles/useTheme';
 import GridContext from './GridContext';
 import gridClasses, { getGridUtilityClass } from './gridClasses';
@@ -402,7 +402,7 @@ const useUtilityClasses = (ownerState) => {
 };
 
 const Grid = React.forwardRef(function Grid(inProps, ref) {
-  const themeProps = useThemeProps({ props: inProps, name: 'MuiGrid' });
+  const themeProps = useDefaultProps({ props: inProps, name: 'MuiGrid' });
   const { breakpoints } = useTheme();
 
   const props = extendSxProp(themeProps);

--- a/packages/mui-material/src/Icon/Icon.js
+++ b/packages/mui-material/src/Icon/Icon.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import capitalize from '../utils/capitalize';
 import { getIconUtilityClass } from './iconClasses';
 
@@ -65,7 +65,7 @@ const IconRoot = styled('span', {
 }));
 
 const Icon = React.forwardRef(function Icon(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiIcon' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiIcon' });
   const {
     baseClassName = 'material-icons',
     className,

--- a/packages/mui-material/src/IconButton/IconButton.js
+++ b/packages/mui-material/src/IconButton/IconButton.js
@@ -6,7 +6,7 @@ import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import ButtonBase from '../ButtonBase';
 import capitalize from '../utils/capitalize';
 import iconButtonClasses, { getIconButtonUtilityClass } from './iconButtonClasses';
@@ -114,7 +114,7 @@ const IconButtonRoot = styled(ButtonBase, {
  * regarding the available icon options.
  */
 const IconButton = React.forwardRef(function IconButton(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiIconButton' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiIconButton' });
   const {
     edge = false,
     children,

--- a/packages/mui-material/src/ImageList/ImageList.js
+++ b/packages/mui-material/src/ImageList/ImageList.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getImageListUtilityClass } from './imageListClasses';
 import ImageListContext from './ImageListContext';
 
@@ -42,7 +42,7 @@ const ImageListRoot = styled('ul', {
 });
 
 const ImageList = React.forwardRef(function ImageList(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiImageList',
   });

--- a/packages/mui-material/src/ImageListItem/ImageListItem.js
+++ b/packages/mui-material/src/ImageListItem/ImageListItem.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { isFragment } from 'react-is';
 import ImageListContext from '../ImageList/ImageListContext';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import isMuiElement from '../utils/isMuiElement';
 import imageListItemClasses, { getImageListItemUtilityClass } from './imageListItemClasses';
 
@@ -62,7 +62,7 @@ const ImageListItemRoot = styled('li', {
 }));
 
 const ImageListItem = React.forwardRef(function ImageListItem(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiImageListItem',
   });

--- a/packages/mui-material/src/ImageListItemBar/ImageListItemBar.js
+++ b/packages/mui-material/src/ImageListItemBar/ImageListItemBar.js
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import capitalize from '../utils/capitalize';
 import { getImageListItemBarUtilityClass } from './imageListItemBarClasses';
 
@@ -138,7 +138,7 @@ const ImageListItemBarActionIcon = styled('div', {
 });
 
 const ImageListItemBar = React.forwardRef(function ImageListItemBar(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiImageListItemBar',
   });

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -6,7 +6,7 @@ import deepmerge from '@mui/utils/deepmerge';
 import refType from '@mui/utils/refType';
 import InputBase from '../InputBase';
 import styled, { rootShouldForwardProp } from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import inputClasses, { getInputUtilityClass } from './inputClasses';
 import {
   rootOverridesResolver as inputBaseRootOverridesResolver,
@@ -116,7 +116,7 @@ const InputInput = styled(InputBaseInput, {
 })({});
 
 const Input = React.forwardRef(function Input(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiInput' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiInput' });
   const {
     disableUnderline,
     components = {},

--- a/packages/mui-material/src/InputAdornment/InputAdornment.js
+++ b/packages/mui-material/src/InputAdornment/InputAdornment.js
@@ -9,7 +9,7 @@ import FormControlContext from '../FormControl/FormControlContext';
 import useFormControl from '../FormControl/useFormControl';
 import styled from '../styles/styled';
 import inputAdornmentClasses, { getInputAdornmentUtilityClass } from './inputAdornmentClasses';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 
 const overridesResolver = (props, styles) => {
   const { ownerState } = props;
@@ -70,7 +70,7 @@ const InputAdornmentRoot = styled('div', {
 }));
 
 const InputAdornment = React.forwardRef(function InputAdornment(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiInputAdornment' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiInputAdornment' });
   const {
     children,
     className,
@@ -113,7 +113,7 @@ const InputAdornment = React.forwardRef(function InputAdornment(inProps, ref) {
   const classes = useUtilityClasses(ownerState);
 
   return (
-    <FormControlContext.Provider value={null}>
+    (<FormControlContext.Provider value={null}>
       <InputAdornmentRoot
         as={component}
         ownerState={ownerState}
@@ -128,13 +128,13 @@ const InputAdornment = React.forwardRef(function InputAdornment(inProps, ref) {
             {/* To have the correct vertical alignment baseline */}
             {position === 'start' ? (
               /* notranslate needed while Google Translate will not fix zero-width space issue */
-              <span className="notranslate">&#8203;</span>
+              (<span className="notranslate">​</span>)
             ) : null}
             {children}
           </React.Fragment>
         )}
       </InputAdornmentRoot>
-    </FormControlContext.Provider>
+    </FormControlContext.Provider>)
   );
 });
 

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -12,7 +12,7 @@ import formControlState from '../FormControl/formControlState';
 import FormControlContext from '../FormControl/FormControlContext';
 import useFormControl from '../FormControl/useFormControl';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import capitalize from '../utils/capitalize';
 import useForkRef from '../utils/useForkRef';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
@@ -242,7 +242,7 @@ const inputGlobalStyles = (
  * It contains a load of style reset and some state logic.
  */
 const InputBase = React.forwardRef(function InputBase(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiInputBase' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiInputBase' });
   const {
     'aria-describedby': ariaDescribedby,
     autoComplete,

--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import formControlState from '../FormControl/formControlState';
 import useFormControl from '../FormControl/useFormControl';
 import FormLabel, { formLabelClasses } from '../FormLabel';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import capitalize from '../utils/capitalize';
 import styled, { rootShouldForwardProp } from '../styles/styled';
 import { getInputLabelUtilityClasses } from './inputLabelClasses';
@@ -122,7 +122,7 @@ const InputLabelRoot = styled(FormLabel, {
 }));
 
 const InputLabel = React.forwardRef(function InputLabel(inProps, ref) {
-  const props = useThemeProps({ name: 'MuiInputLabel', props: inProps });
+  const props = useDefaultProps({ name: 'MuiInputLabel', props: inProps });
   const {
     disableAnimation = false,
     margin,

--- a/packages/mui-material/src/LinearProgress/LinearProgress.js
+++ b/packages/mui-material/src/LinearProgress/LinearProgress.js
@@ -8,7 +8,7 @@ import { darken, lighten } from '@mui/system/colorManipulator';
 import { useRtl } from '@mui/system/RtlProvider';
 import capitalize from '../utils/capitalize';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getLinearProgressUtilityClass } from './linearProgressClasses';
 
 const TRANSITION_DURATION = 4; // seconds
@@ -267,7 +267,7 @@ const LinearProgressBar2 = styled('span', {
  * attribute to `true` on that region until it has finished loading.
  */
 const LinearProgress = React.forwardRef(function LinearProgress(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiLinearProgress' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiLinearProgress' });
   const {
     className,
     color = 'primary',

--- a/packages/mui-material/src/Link/Link.js
+++ b/packages/mui-material/src/Link/Link.js
@@ -6,7 +6,7 @@ import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';
 import composeClasses from '@mui/utils/composeClasses';
 import capitalize from '../utils/capitalize';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import useIsFocusVisible from '../utils/useIsFocusVisible';
 import useForkRef from '../utils/useForkRef';
 import Typography from '../Typography';
@@ -87,7 +87,7 @@ const LinkRoot = styled(Typography, {
 });
 
 const Link = React.forwardRef(function Link(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiLink',
   });

--- a/packages/mui-material/src/List/List.js
+++ b/packages/mui-material/src/List/List.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import ListContext from './ListContext';
 import { getListUtilityClass } from './listClasses';
 
@@ -46,7 +46,7 @@ const ListRoot = styled('ul', {
 }));
 
 const List = React.forwardRef(function List(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiList' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiList' });
   const {
     children,
     className,

--- a/packages/mui-material/src/ListItem/ListItem.js
+++ b/packages/mui-material/src/ListItem/ListItem.js
@@ -8,7 +8,7 @@ import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import { alpha } from '@mui/system/colorManipulator';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import ButtonBase from '../ButtonBase';
 import isMuiElement from '../utils/isMuiElement';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
@@ -173,7 +173,7 @@ const ListItemContainer = styled('li', {
  * Uses an additional container component if `ListItemSecondaryAction` is the last child.
  */
 const ListItem = React.forwardRef(function ListItem(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiListItem' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiListItem' });
   const {
     alignItems = 'center',
     autoFocus = false,

--- a/packages/mui-material/src/ListItemAvatar/ListItemAvatar.js
+++ b/packages/mui-material/src/ListItemAvatar/ListItemAvatar.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import ListContext from '../List/ListContext';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getListItemAvatarUtilityClass } from './listItemAvatarClasses';
 
 const useUtilityClasses = (ownerState) => {
@@ -38,7 +38,7 @@ const ListItemAvatarRoot = styled('div', {
  * A simple wrapper to apply `List` styles to an `Avatar`.
  */
 const ListItemAvatar = React.forwardRef(function ListItemAvatar(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiListItemAvatar',
   });

--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';
 import styled, { rootShouldForwardProp } from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import ButtonBase from '../ButtonBase';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
 import useForkRef from '../utils/useForkRef';
@@ -126,7 +126,7 @@ const ListItemButtonRoot = styled(ButtonBase, {
 }));
 
 const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiListItemButton' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiListItemButton' });
   const {
     alignItems = 'center',
     autoFocus = false,

--- a/packages/mui-material/src/ListItemIcon/ListItemIcon.js
+++ b/packages/mui-material/src/ListItemIcon/ListItemIcon.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getListItemIconUtilityClass } from './listItemIconClasses';
 import ListContext from '../List/ListContext';
 
@@ -40,7 +40,7 @@ const ListItemIconRoot = styled('div', {
  * A simple wrapper to apply `List` styles to an `Icon` or `SvgIcon`.
  */
 const ListItemIcon = React.forwardRef(function ListItemIcon(inProps, ref) {
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiListItemIcon',
   });

--- a/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.js
+++ b/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import ListContext from '../List/ListContext';
 import { getListItemSecondaryActionClassesUtilityClass } from './listItemSecondaryActionClasses';
 
@@ -40,7 +40,7 @@ const ListItemSecondaryActionRoot = styled('div', {
  * Must be used as the last child of ListItem to function properly.
  */
 const ListItemSecondaryAction = React.forwardRef(function ListItemSecondaryAction(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiListItemSecondaryAction' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiListItemSecondaryAction' });
   const { className, ...other } = props;
   const context = React.useContext(ListContext);
   const ownerState = { ...props, disableGutters: context.disableGutters };

--- a/packages/mui-material/src/ListItemText/ListItemText.js
+++ b/packages/mui-material/src/ListItemText/ListItemText.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import Typography from '../Typography';
 import ListContext from '../List/ListContext';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import listItemTextClasses, { getListItemTextUtilityClass } from './listItemTextClasses';
 
@@ -52,7 +52,7 @@ const ListItemTextRoot = styled('div', {
 }));
 
 const ListItemText = React.forwardRef(function ListItemText(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiListItemText' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiListItemText' });
   const {
     children,
     className,

--- a/packages/mui-material/src/ListSubheader/ListSubheader.js
+++ b/packages/mui-material/src/ListSubheader/ListSubheader.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import capitalize from '../utils/capitalize';
 import { getListSubheaderUtilityClass } from './listSubheaderClasses';
 
@@ -68,7 +68,7 @@ const ListSubheaderRoot = styled('li', {
 }));
 
 const ListSubheader = React.forwardRef(function ListSubheader(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiListSubheader' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiListSubheader' });
   const {
     className,
     color = 'default',

--- a/packages/mui-material/src/Menu/Menu.js
+++ b/packages/mui-material/src/Menu/Menu.js
@@ -10,7 +10,7 @@ import { useRtl } from '@mui/system/RtlProvider';
 import MenuList from '../MenuList';
 import Popover, { PopoverPaper } from '../Popover';
 import styled, { rootShouldForwardProp } from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getMenuUtilityClass } from './menuClasses';
 
 const RTL_ORIGIN = {
@@ -65,7 +65,7 @@ const MenuMenuList = styled(MenuList, {
 });
 
 const Menu = React.forwardRef(function Menu(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiMenu' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiMenu' });
 
   const {
     autoFocus = true,

--- a/packages/mui-material/src/MenuItem/MenuItem.js
+++ b/packages/mui-material/src/MenuItem/MenuItem.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';
 import styled, { rootShouldForwardProp } from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import ListContext from '../List/ListContext';
 import ButtonBase from '../ButtonBase';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
@@ -147,7 +147,7 @@ const MenuItemRoot = styled(ButtonBase, {
 }));
 
 const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiMenuItem' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiMenuItem' });
   const {
     autoFocus = false,
     component = 'li',

--- a/packages/mui-material/src/MobileStepper/MobileStepper.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.js
@@ -7,7 +7,7 @@ import composeClasses from '@mui/utils/composeClasses';
 import Paper from '../Paper';
 import capitalize from '../utils/capitalize';
 import LinearProgress from '../LinearProgress';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled, { slotShouldForwardProp } from '../styles/styled';
 import { getMobileStepperUtilityClass } from './mobileStepperClasses';
 
@@ -103,7 +103,7 @@ const MobileStepperProgress = styled(LinearProgress, {
 }));
 
 const MobileStepper = React.forwardRef(function MobileStepper(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiMobileStepper' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiMobileStepper' });
   const {
     activeStep = 0,
     backButton,

--- a/packages/mui-material/src/Modal/Modal.js
+++ b/packages/mui-material/src/Modal/Modal.js
@@ -10,7 +10,7 @@ import composeClasses from '@mui/utils/composeClasses';
 import FocusTrap from '../Unstable_TrapFocus';
 import Portal from '../Portal';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import Backdrop from '../Backdrop';
 import { getModalUtilityClass } from './modalClasses';
 
@@ -70,7 +70,7 @@ const ModalBackdrop = styled(Backdrop, {
  * This component shares many concepts with [react-overlays](https://react-bootstrap.github.io/react-overlays/#modals).
  */
 const Modal = React.forwardRef(function Modal(inProps, ref) {
-  const props = useThemeProps({ name: 'MuiModal', props: inProps });
+  const props = useDefaultProps({ name: 'MuiModal', props: inProps });
   const {
     BackdropComponent = ModalBackdrop,
     BackdropProps,

--- a/packages/mui-material/src/NativeSelect/NativeSelect.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.js
@@ -8,7 +8,7 @@ import formControlState from '../FormControl/formControlState';
 import useFormControl from '../FormControl/useFormControl';
 import ArrowDropDownIcon from '../internal/svg-icons/ArrowDropDown';
 import Input from '../Input';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getNativeSelectUtilityClasses } from './nativeSelectClasses';
 
 const useUtilityClasses = (ownerState) => {
@@ -26,7 +26,7 @@ const defaultInput = <Input />;
  * An alternative to `<Select native />` with a much smaller bundle size footprint.
  */
 const NativeSelect = React.forwardRef(function NativeSelect(inProps, ref) {
-  const props = useThemeProps({ name: 'MuiNativeSelect', props: inProps });
+  const props = useDefaultProps({ name: 'MuiNativeSelect', props: inProps });
   const {
     className,
     children,

--- a/packages/mui-material/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material/src/OutlinedInput/NotchedOutline.js
@@ -76,17 +76,17 @@ export default function NotchedOutline(props) {
     withLabel,
   };
   return (
-    <NotchedOutlineRoot aria-hidden className={className} ownerState={ownerState} {...other}>
+    (<NotchedOutlineRoot aria-hidden className={className} ownerState={ownerState} {...other}>
       <NotchedOutlineLegend ownerState={ownerState}>
         {/* Use the nominal use case of the legend, avoid rendering artefacts. */}
         {withLabel ? (
           <span>{label}</span>
         ) : (
           // notranslate needed while Google Translate will not fix zero-width space issue
-          <span className="notranslate">&#8203;</span>
+          (<span className="notranslate">​</span>)
         )}
       </NotchedOutlineLegend>
-    </NotchedOutlineRoot>
+    </NotchedOutlineRoot>)
   );
 }
 

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -14,7 +14,7 @@ import InputBase, {
   InputBaseRoot,
   InputBaseComponent as InputBaseInput,
 } from '../InputBase/InputBase';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 
 const useUtilityClasses = (ownerState) => {
   const { classes } = ownerState;
@@ -135,7 +135,7 @@ const OutlinedInputInput = styled(InputBaseInput, {
 }));
 
 const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiOutlinedInput' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiOutlinedInput' });
   const {
     components = {},
     fullWidth = false,

--- a/packages/mui-material/src/Pagination/Pagination.js
+++ b/packages/mui-material/src/Pagination/Pagination.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import integerPropType from '@mui/utils/integerPropType';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getPaginationUtilityClass } from './paginationClasses';
 import usePagination from '../usePagination';
 import PaginationItem from '../PaginationItem';
@@ -52,7 +52,7 @@ function defaultGetAriaLabel(type, page, selected) {
 }
 
 const Pagination = React.forwardRef(function Pagination(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiPagination' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiPagination' });
   const {
     boundaryCount = 1,
     className,

--- a/packages/mui-material/src/PaginationItem/PaginationItem.js
+++ b/packages/mui-material/src/PaginationItem/PaginationItem.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';
 import { useRtl } from '@mui/system/RtlProvider';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import paginationItemClasses, { getPaginationItemUtilityClass } from './paginationItemClasses';
 import ButtonBase from '../ButtonBase';
 import capitalize from '../utils/capitalize';
@@ -260,7 +260,7 @@ const PaginationItemPageIcon = styled('div', {
 }));
 
 const PaginationItem = React.forwardRef(function PaginationItem(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiPaginationItem' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiPaginationItem' });
   const {
     className,
     color = 'standard',

--- a/packages/mui-material/src/Paper/Paper.js
+++ b/packages/mui-material/src/Paper/Paper.js
@@ -8,7 +8,7 @@ import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';
 import styled from '../styles/styled';
 import getOverlayAlpha from '../styles/getOverlayAlpha';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import useTheme from '../styles/useTheme';
 import { getPaperUtilityClass } from './paperClasses';
 
@@ -66,7 +66,7 @@ const PaperRoot = styled('div', {
 }));
 
 const Paper = React.forwardRef(function Paper(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiPaper' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiPaper' });
 
   const {
     className,

--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -10,7 +10,7 @@ import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';
 import integerPropType from '@mui/utils/integerPropType';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import debounce from '../utils/debounce';
 import ownerDocument from '../utils/ownerDocument';
 import ownerWindow from '../utils/ownerWindow';
@@ -94,7 +94,7 @@ export const PopoverPaper = styled(PaperBase, {
 });
 
 const Popover = React.forwardRef(function Popover(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiPopover' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiPopover' });
   const {
     action,
     anchorEl,

--- a/packages/mui-material/src/Popper/Popper.tsx
+++ b/packages/mui-material/src/Popper/Popper.tsx
@@ -6,7 +6,7 @@ import refType from '@mui/utils/refType';
 import HTMLElementType from '@mui/utils/HTMLElementType';
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import { styled, Theme, useThemeProps } from '../styles';
+import { styled, Theme, useDefaultProps } from '../styles';
 
 export interface PopperProps extends Omit<BasePopperProps, 'direction'> {
   /**
@@ -56,7 +56,7 @@ const Popper = React.forwardRef(function Popper(
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
   const theme = useTheme<{ direction?: Direction }>();
-  const props = useThemeProps({
+  const props = useDefaultProps({
     props: inProps,
     name: 'MuiPopper',
   });

--- a/packages/mui-material/src/Radio/Radio.js
+++ b/packages/mui-material/src/Radio/Radio.js
@@ -6,7 +6,7 @@ import refType from '@mui/utils/refType';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';
 import SwitchBase from '../internal/SwitchBase';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import RadioButtonIcon from './RadioButtonIcon';
 import capitalize from '../utils/capitalize';
 import createChainedFunction from '../utils/createChainedFunction';
@@ -85,7 +85,7 @@ const defaultCheckedIcon = <RadioButtonIcon checked />;
 const defaultIcon = <RadioButtonIcon />;
 
 const Radio = React.forwardRef(function Radio(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiRadio' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiRadio' });
   const {
     checked: checkedProp,
     checkedIcon = defaultCheckedIcon,

--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -16,7 +16,7 @@ import {
 } from '../utils';
 import Star from '../internal/svg-icons/Star';
 import StarBorder from '../internal/svg-icons/StarBorder';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled, { slotShouldForwardProp } from '../styles/styled';
 import ratingClasses, { getRatingUtilityClass } from './ratingClasses';
 
@@ -296,7 +296,7 @@ function defaultLabelText(value) {
 }
 
 const Rating = React.forwardRef(function Rating(inProps, ref) {
-  const props = useThemeProps({ name: 'MuiRating', props: inProps });
+  const props = useDefaultProps({ name: 'MuiRating', props: inProps });
   const {
     className,
     defaultValue = null,

--- a/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.js
+++ b/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { html, body } from '../CssBaseline/CssBaseline';
 import { getScopedCssBaselineUtilityClass } from './scopedCssBaselineClasses';
@@ -45,7 +45,7 @@ const ScopedCssBaselineRoot = styled('div', {
 });
 
 const ScopedCssBaseline = React.forwardRef(function ScopedCssBaseline(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiScopedCssBaseline' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiScopedCssBaseline' });
   const { className, component = 'div', enableColorScheme, ...other } = props;
 
   const ownerState = {

--- a/packages/mui-material/src/Select/Select.js
+++ b/packages/mui-material/src/Select/Select.js
@@ -11,7 +11,7 @@ import Input from '../Input';
 import NativeSelectInput from '../NativeSelect/NativeSelectInput';
 import FilledInput from '../FilledInput';
 import OutlinedInput from '../OutlinedInput';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import useForkRef from '../utils/useForkRef';
 import styled, { rootShouldForwardProp } from '../styles/styled';
 
@@ -35,7 +35,7 @@ const StyledOutlinedInput = styled(OutlinedInput, styledRootConfig)('');
 const StyledFilledInput = styled(FilledInput, styledRootConfig)('');
 
 const Select = React.forwardRef(function Select(inProps, ref) {
-  const props = useThemeProps({ name: 'MuiSelect', props: inProps });
+  const props = useDefaultProps({ name: 'MuiSelect', props: inProps });
   const {
     autoWidth = false,
     children,

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -491,7 +491,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   const listboxId = useId();
 
   return (
-    <React.Fragment>
+    (<React.Fragment>
       <SelectSelect
         ref={handleDisplayRef}
         tabIndex={tabIndex}
@@ -516,7 +516,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         {/* So the vertical align positioning algorithm kicks in. */}
         {isEmpty(display) ? (
           // notranslate needed while Google Translate will not fix zero-width space issue
-          <span className="notranslate">&#8203;</span>
+          (<span className="notranslate">​</span>)
         ) : (
           display
         )}
@@ -571,7 +571,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       >
         {items}
       </Menu>
-    </React.Fragment>
+    </React.Fragment>)
   );
 });
 

--- a/packages/mui-material/src/Skeleton/Skeleton.js
+++ b/packages/mui-material/src/Skeleton/Skeleton.js
@@ -6,7 +6,7 @@ import { keyframes, css } from '@mui/system';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha, unstable_getUnit as getUnit, unstable_toUnitless as toUnitless } from '../styles';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { getSkeletonUtilityClass } from './skeletonClasses';
 
 const useUtilityClasses = (ownerState) => {
@@ -150,7 +150,7 @@ const SkeletonRoot = styled('span', {
 );
 
 const Skeleton = React.forwardRef(function Skeleton(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiSkeleton' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiSkeleton' });
   const {
     animation = 'pulse',
     className,

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -15,7 +15,7 @@ import capitalize from '../utils/capitalize';
 import BaseSliderValueLabel from './SliderValueLabel';
 import sliderClasses, { getSliderUtilityClass } from './sliderClasses';
 
-const useThemeProps = createUseThemeProps('MuiSlider');
+const useDefaultProps = createUseThemeProps('MuiSlider');
 
 function Identity(x) {
   return x;
@@ -531,7 +531,7 @@ const useUtilityClasses = (ownerState) => {
 const Forward = ({ children }) => children;
 
 const Slider = React.forwardRef(function Slider(inputProps, ref) {
-  const props = useThemeProps({ props: inputProps, name: 'MuiSlider' });
+  const props = useDefaultProps({ props: inputProps, name: 'MuiSlider' });
 
   const isRtl = useRtl();
 
@@ -717,7 +717,7 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
   });
 
   return (
-    <RootSlot {...rootProps}>
+    (<RootSlot {...rootProps}>
       <RailSlot {...railProps} />
       <TrackSlot {...trackProps} />
       {marks
@@ -781,7 +781,7 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
 
         return (
           /* TODO v6: Change component structure. It will help in avoiding the complicated React.cloneElement API added in SliderValueLabel component. Should be: Thumb -> Input, ValueLabel. Follow Joy UI's Slider structure. */
-          <ValueLabelComponent
+          (<ValueLabelComponent
             key={index}
             {...(!isHostComponent(ValueLabelComponent) && {
               valueLabelFormat,
@@ -821,10 +821,10 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
                 {...inputSliderProps}
               />
             </ThumbSlot>
-          </ValueLabelComponent>
+          </ValueLabelComponent>)
         );
       })}
-    </RootSlot>
+    </RootSlot>)
   );
 });
 

--- a/packages/mui-material/src/Snackbar/Snackbar.js
+++ b/packages/mui-material/src/Snackbar/Snackbar.js
@@ -7,7 +7,7 @@ import { ClickAwayListener } from '@mui/base/ClickAwayListener';
 import { useSnackbar } from '@mui/base/useSnackbar';
 import styled from '../styles/styled';
 import useTheme from '../styles/useTheme';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import capitalize from '../utils/capitalize';
 import Grow from '../Grow';
 import SnackbarContent from '../SnackbarContent';
@@ -75,7 +75,7 @@ const SnackbarRoot = styled('div', {
 });
 
 const Snackbar = React.forwardRef(function Snackbar(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiSnackbar' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiSnackbar' });
   const theme = useTheme();
   const defaultTransitionDuration = {
     enter: theme.transitions.duration.enteringScreen,

--- a/packages/mui-material/src/SnackbarContent/SnackbarContent.js
+++ b/packages/mui-material/src/SnackbarContent/SnackbarContent.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { emphasize } from '@mui/system/colorManipulator';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import Paper from '../Paper';
 import { getSnackbarContentUtilityClass } from './snackbarContentClasses';
 
@@ -69,7 +69,7 @@ const SnackbarContentAction = styled('div', {
 });
 
 const SnackbarContent = React.forwardRef(function SnackbarContent(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiSnackbarContent' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiSnackbarContent' });
   const { action, className, message, role = 'alert', ...other } = props;
   const ownerState = props;
   const classes = useUtilityClasses(ownerState);

--- a/packages/mui-material/src/SpeedDial/SpeedDial.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.js
@@ -7,7 +7,7 @@ import composeClasses from '@mui/utils/composeClasses';
 import useTimeout from '@mui/utils/useTimeout';
 import clamp from '@mui/utils/clamp';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import useTheme from '../styles/useTheme';
 import Zoom from '../Zoom';
 import Fab from '../Fab';
@@ -115,7 +115,7 @@ const SpeedDialActions = styled('div', {
 }));
 
 const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiSpeedDial' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiSpeedDial' });
   const theme = useTheme();
   const defaultTransitionDuration = {
     enter: theme.transitions.duration.enteringScreen,

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { emphasize } from '@mui/system/colorManipulator';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import Fab from '../Fab';
 import Tooltip from '../Tooltip';
 import capitalize from '../utils/capitalize';
@@ -110,7 +110,7 @@ const SpeedDialActionStaticTooltipLabel = styled('span', {
 }));
 
 const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiSpeedDialAction' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiSpeedDialAction' });
   const {
     className,
     delay = 0,

--- a/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.js
+++ b/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import AddIcon from '../internal/svg-icons/Add';
 import speedDialIconClasses, { getSpeedDialIconUtilityClass } from './speedDialIconClasses';
 
@@ -66,7 +66,7 @@ const SpeedDialIconRoot = styled('span', {
 }));
 
 const SpeedDialIcon = React.forwardRef(function SpeedDialIcon(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiSpeedDialIcon' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiSpeedDialIcon' });
   const { className, icon: iconProp, open, openIcon: openIconProp, ...other } = props;
 
   const ownerState = props;

--- a/packages/mui-material/src/Stack/Stack.js
+++ b/packages/mui-material/src/Stack/Stack.js
@@ -2,7 +2,7 @@
 import PropTypes from 'prop-types';
 import { createStack } from '@mui/system';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 
 const Stack = createStack({
   createStyledComponent: styled('div', {
@@ -10,7 +10,7 @@ const Stack = createStack({
     slot: 'Root',
     overridesResolver: (props, styles) => styles.root,
   }),
-  useThemeProps: (inProps) => useThemeProps({ props: inProps, name: 'MuiStack' }),
+  useDefaultProps: (inProps) => useDefaultProps({ props: inProps, name: 'MuiStack' }),
 });
 
 Stack.propTypes /* remove-proptypes */ = {

--- a/packages/mui-material/src/Step/Step.js
+++ b/packages/mui-material/src/Step/Step.js
@@ -6,7 +6,7 @@ import integerPropType from '@mui/utils/integerPropType';
 import composeClasses from '@mui/utils/composeClasses';
 import StepperContext from '../Stepper/StepperContext';
 import StepContext from './StepContext';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { getStepUtilityClass } from './stepClasses';
 
@@ -45,7 +45,7 @@ const StepRoot = styled('div', {
 }));
 
 const Step = React.forwardRef(function Step(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiStep' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiStep' });
   const {
     active: activeProp,
     children,

--- a/packages/mui-material/src/StepButton/StepButton.js
+++ b/packages/mui-material/src/StepButton/StepButton.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import ButtonBase from '../ButtonBase';
 import StepLabel from '../StepLabel';
 import isMuiElement from '../utils/isMuiElement';
@@ -51,7 +51,7 @@ const StepButtonRoot = styled(ButtonBase, {
 }));
 
 const StepButton = React.forwardRef(function StepButton(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiStepButton' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiStepButton' });
   const { children, className, icon, optional, ...other } = props;
 
   const { disabled, active } = React.useContext(StepContext);

--- a/packages/mui-material/src/StepConnector/StepConnector.js
+++ b/packages/mui-material/src/StepConnector/StepConnector.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import capitalize from '../utils/capitalize';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import StepperContext from '../Stepper/StepperContext';
 import StepContext from '../Step/StepContext';
 import { getStepConnectorUtilityClass } from './stepConnectorClasses';
@@ -81,7 +81,7 @@ const StepConnectorLine = styled('span', {
 });
 
 const StepConnector = React.forwardRef(function StepConnector(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiStepConnector' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiStepConnector' });
   const { className, ...other } = props;
 
   const { alternativeLabel, orientation = 'horizontal' } = React.useContext(StepperContext);

--- a/packages/mui-material/src/StepContent/StepContent.js
+++ b/packages/mui-material/src/StepContent/StepContent.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import Collapse from '../Collapse';
 import StepperContext from '../Stepper/StepperContext';
 import StepContext from '../Step/StepContext';
@@ -47,7 +47,7 @@ const StepContentTransition = styled(Collapse, {
 })({});
 
 const StepContent = React.forwardRef(function StepContent(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiStepContent' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiStepContent' });
   const {
     children,
     className,

--- a/packages/mui-material/src/StepIcon/StepIcon.js
+++ b/packages/mui-material/src/StepIcon/StepIcon.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import CheckCircle from '../internal/svg-icons/CheckCircle';
 import Warning from '../internal/svg-icons/Warning';
 import SvgIcon from '../SvgIcon';
@@ -53,7 +53,7 @@ const StepIconText = styled('text', {
 }));
 
 const StepIcon = React.forwardRef(function StepIcon(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiStepIcon' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiStepIcon' });
   const {
     active = false,
     className: classNameProp,

--- a/packages/mui-material/src/StepLabel/StepLabel.js
+++ b/packages/mui-material/src/StepLabel/StepLabel.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import StepIcon from '../StepIcon';
 import StepperContext from '../Stepper/StepperContext';
 import StepContext from '../Step/StepContext';
@@ -118,7 +118,7 @@ const StepLabelLabelContainer = styled('span', {
 }));
 
 const StepLabel = React.forwardRef(function StepLabel(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiStepLabel' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiStepLabel' });
   const {
     children,
     className,

--- a/packages/mui-material/src/Stepper/Stepper.js
+++ b/packages/mui-material/src/Stepper/Stepper.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import integerPropType from '@mui/utils/integerPropType';
 import composeClasses from '@mui/utils/composeClasses';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { getStepperUtilityClass } from './stepperClasses';
 import StepConnector from '../StepConnector';
@@ -48,7 +48,7 @@ const StepperRoot = styled('div', {
 const defaultConnector = <StepConnector />;
 
 const Stepper = React.forwardRef(function Stepper(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiStepper' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiStepper' });
   const {
     activeStep = 0,
     alternativeLabel = false,

--- a/packages/mui-material/src/SvgIcon/SvgIcon.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import capitalize from '../utils/capitalize';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { getSvgIconUtilityClass } from './svgIconClasses';
 
@@ -63,7 +63,7 @@ const SvgIconRoot = styled('svg', {
 }));
 
 const SvgIcon = React.forwardRef(function SvgIcon(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiSvgIcon' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiSvgIcon' });
   const {
     children,
     className,

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';
-import useThemeProps from '@mui/system/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import { NoSsr } from '@mui/base';
 import Drawer, { getAnchor, isHorizontal } from '../Drawer/Drawer';
 import useForkRef from '../utils/useForkRef';
@@ -135,7 +135,7 @@ function computeHasNativeHandler({ domTreeShapes, start, current, anchor }) {
 const iOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent);
 
 const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) {
-  const props = useThemeProps({ name: 'MuiSwipeableDrawer', props: inProps });
+  const props = useDefaultProps({ name: 'MuiSwipeableDrawer', props: inProps });
   const theme = useTheme();
   const transitionDurationDefault = {
     enter: theme.transitions.duration.enteringScreen,

--- a/packages/mui-material/src/Switch/Switch.js
+++ b/packages/mui-material/src/Switch/Switch.js
@@ -11,7 +11,7 @@ import SwitchBase from '../internal/SwitchBase';
 import { styled, createUseThemeProps } from '../zero-styled';
 import switchClasses, { getSwitchUtilityClass } from './switchClasses';
 
-const useThemeProps = createUseThemeProps('MuiSwitch');
+const useDefaultProps = createUseThemeProps('MuiSwitch');
 
 const useUtilityClasses = (ownerState) => {
   const { classes, edge, size, color, checked, disabled } = ownerState;
@@ -216,7 +216,7 @@ const SwitchThumb = styled('span', {
 }));
 
 const Switch = React.forwardRef(function Switch(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiSwitch' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiSwitch' });
   const { className, color = 'primary', edge = false, size = 'medium', sx, ...other } = props;
 
   const ownerState = {

--- a/packages/mui-material/src/Tab/Tab.js
+++ b/packages/mui-material/src/Tab/Tab.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import ButtonBase from '../ButtonBase';
 import capitalize from '../utils/capitalize';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import unsupportedProp from '../utils/unsupportedProp';
 import tabClasses, { getTabUtilityClass } from './tabClasses';
@@ -122,7 +122,7 @@ const TabRoot = styled(ButtonBase, {
 }));
 
 const Tab = React.forwardRef(function Tab(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTab' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTab' });
   const {
     className,
     disabled = false,

--- a/packages/mui-material/src/TabScrollButton/TabScrollButton.js
+++ b/packages/mui-material/src/TabScrollButton/TabScrollButton.js
@@ -9,7 +9,7 @@ import { useRtl } from '@mui/system/RtlProvider';
 import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '../internal/svg-icons/KeyboardArrowRight';
 import ButtonBase from '../ButtonBase';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import tabScrollButtonClasses, { getTabScrollButtonUtilityClass } from './tabScrollButtonClasses';
 
@@ -48,7 +48,7 @@ const TabScrollButtonRoot = styled(ButtonBase, {
 }));
 
 const TabScrollButton = React.forwardRef(function TabScrollButton(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTabScrollButton' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTabScrollButton' });
   const {
     className,
     slots = {},

--- a/packages/mui-material/src/Table/Table.js
+++ b/packages/mui-material/src/Table/Table.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import TableContext from './TableContext';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { getTableUtilityClass } from './tableClasses';
 
@@ -46,7 +46,7 @@ const TableRoot = styled('table', {
 const defaultComponent = 'table';
 
 const Table = React.forwardRef(function Table(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTable' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTable' });
   const {
     className,
     component = defaultComponent,

--- a/packages/mui-material/src/TableBody/TableBody.js
+++ b/packages/mui-material/src/TableBody/TableBody.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { getTableBodyUtilityClass } from './tableBodyClasses';
 
@@ -33,7 +33,7 @@ const tablelvl2 = {
 const defaultComponent = 'tbody';
 
 const TableBody = React.forwardRef(function TableBody(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTableBody' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTableBody' });
   const { className, component = defaultComponent, ...other } = props;
 
   const ownerState = {

--- a/packages/mui-material/src/TableCell/TableCell.js
+++ b/packages/mui-material/src/TableCell/TableCell.js
@@ -7,7 +7,7 @@ import { darken, alpha, lighten } from '@mui/system/colorManipulator';
 import capitalize from '../utils/capitalize';
 import TableContext from '../Table/TableContext';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import tableCellClasses, { getTableCellUtilityClass } from './tableCellClasses';
 
@@ -115,7 +115,7 @@ const TableCellRoot = styled('td', {
  * or otherwise a `<td>` element.
  */
 const TableCell = React.forwardRef(function TableCell(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTableCell' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTableCell' });
   const {
     align = 'inherit',
     className,

--- a/packages/mui-material/src/TableContainer/TableContainer.js
+++ b/packages/mui-material/src/TableContainer/TableContainer.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { getTableContainerUtilityClass } from './tableContainerClasses';
 
@@ -27,7 +27,7 @@ const TableContainerRoot = styled('div', {
 });
 
 const TableContainer = React.forwardRef(function TableContainer(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTableContainer' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTableContainer' });
   const { className, component = 'div', ...other } = props;
 
   const ownerState = {

--- a/packages/mui-material/src/TableFooter/TableFooter.js
+++ b/packages/mui-material/src/TableFooter/TableFooter.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { getTableFooterUtilityClass } from './tableFooterClasses';
 
@@ -33,7 +33,7 @@ const tablelvl2 = {
 const defaultComponent = 'tfoot';
 
 const TableFooter = React.forwardRef(function TableFooter(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTableFooter' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTableFooter' });
   const { className, component = defaultComponent, ...other } = props;
 
   const ownerState = {

--- a/packages/mui-material/src/TableHead/TableHead.js
+++ b/packages/mui-material/src/TableHead/TableHead.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { getTableHeadUtilityClass } from './tableHeadClasses';
 
@@ -33,7 +33,7 @@ const tablelvl2 = {
 const defaultComponent = 'thead';
 
 const TableHead = React.forwardRef(function TableHead(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTableHead' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTableHead' });
   const { className, component = defaultComponent, ...other } = props;
 
   const ownerState = {

--- a/packages/mui-material/src/TablePagination/TablePagination.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.js
@@ -7,7 +7,7 @@ import chainPropTypes from '@mui/utils/chainPropTypes';
 import { isHostComponent } from '@mui/base/utils';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import InputBase from '../InputBase';
 import MenuItem from '../MenuItem';
 import Select from '../Select';
@@ -139,7 +139,7 @@ const useUtilityClasses = (ownerState) => {
  * A `TableCell` based component for placing inside `TableFooter` for pagination.
  */
 const TablePagination = React.forwardRef(function TablePagination(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTablePagination' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTablePagination' });
   const {
     ActionsComponent = TablePaginationActions,
     backIconButtonProps,

--- a/packages/mui-material/src/TableRow/TableRow.js
+++ b/packages/mui-material/src/TableRow/TableRow.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import tableRowClasses, { getTableRowUtilityClass } from './tableRowClasses';
 
@@ -57,7 +57,7 @@ const defaultComponent = 'tr';
  * based on the material table element parent (head, body, etc).
  */
 const TableRow = React.forwardRef(function TableRow(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTableRow' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTableRow' });
   const {
     className,
     component = defaultComponent,

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.js
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.js
@@ -6,7 +6,7 @@ import * as React from 'react';
 import ButtonBase from '../ButtonBase';
 import ArrowDownwardIcon from '../internal/svg-icons/ArrowDownward';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import capitalize from '../utils/capitalize';
 import tableSortLabelClasses, { getTableSortLabelUtilityClass } from './tableSortLabelClasses';
 
@@ -82,7 +82,7 @@ const TableSortLabelIcon = styled('span', {
  * A button based label for placing inside `TableCell` for column sorting.
  */
 const TableSortLabel = React.forwardRef(function TableSortLabel(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTableSortLabel' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTableSortLabel' });
   const {
     active = false,
     children,

--- a/packages/mui-material/src/Tabs/Tabs.js
+++ b/packages/mui-material/src/Tabs/Tabs.js
@@ -8,7 +8,7 @@ import { useSlotProps } from '@mui/base/utils';
 import composeClasses from '@mui/utils/composeClasses';
 import { useRtl } from '@mui/system/RtlProvider';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import useTheme from '../styles/useTheme';
 import debounce from '../utils/debounce';
 import { getNormalizedScrollLeft, detectScrollType } from '../utils/scrollLeft';
@@ -230,7 +230,7 @@ const defaultIndicatorStyle = {};
 let warnedOnceTabPresent = false;
 
 const Tabs = React.forwardRef(function Tabs(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTabs' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTabs' });
   const theme = useTheme();
   const isRtl = useRtl();
   const {

--- a/packages/mui-material/src/TextField/TextField.js
+++ b/packages/mui-material/src/TextField/TextField.js
@@ -6,7 +6,7 @@ import composeClasses from '@mui/utils/composeClasses';
 import useId from '@mui/utils/useId';
 import refType from '@mui/utils/refType';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import Input from '../Input';
 import FilledInput from '../FilledInput';
 import OutlinedInput from '../OutlinedInput';
@@ -71,7 +71,7 @@ const TextFieldRoot = styled(FormControl, {
  * - using the underlying components directly as shown in the demos
  */
 const TextField = React.forwardRef(function TextField(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTextField' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTextField' });
   const {
     autoComplete,
     autoFocus = false,

--- a/packages/mui-material/src/ToggleButton/ToggleButton.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.js
@@ -8,7 +8,7 @@ import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '../styles';
 import ButtonBase from '../ButtonBase';
 import capitalize from '../utils/capitalize';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import toggleButtonClasses, { getToggleButtonUtilityClass } from './toggleButtonClasses';
 import ToggleButtonGroupContext from '../ToggleButtonGroup/ToggleButtonGroupContext';
@@ -121,7 +121,7 @@ const ToggleButton = React.forwardRef(function ToggleButton(inProps, ref) {
     { ...contextProps, selected: isValueSelected(inProps.value, contextValue) },
     inProps,
   );
-  const props = useThemeProps({ props: resolvedProps, name: 'MuiToggleButton' });
+  const props = useDefaultProps({ props: resolvedProps, name: 'MuiToggleButton' });
   const {
     children,
     className,

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import getValidReactChildren from '@mui/utils/getValidReactChildren';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import capitalize from '../utils/capitalize';
 import toggleButtonGroupClasses, {
   getToggleButtonGroupUtilityClass,
@@ -124,7 +124,7 @@ const ToggleButtonGroupRoot = styled('div', {
 }));
 
 const ToggleButtonGroup = React.forwardRef(function ToggleButtonGroup(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiToggleButtonGroup' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiToggleButtonGroup' });
   const {
     children,
     className,

--- a/packages/mui-material/src/Toolbar/Toolbar.js
+++ b/packages/mui-material/src/Toolbar/Toolbar.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import styled from '../styles/styled';
 import { getToolbarUtilityClass } from './toolbarClasses';
 
@@ -46,7 +46,7 @@ const ToolbarRoot = styled('div', {
 );
 
 const Toolbar = React.forwardRef(function Toolbar(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiToolbar' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiToolbar' });
   const {
     className,
     component = 'div',

--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -10,7 +10,7 @@ import { alpha } from '@mui/system/colorManipulator';
 import { useRtl } from '@mui/system/RtlProvider';
 import styled from '../styles/styled';
 import useTheme from '../styles/useTheme';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import capitalize from '../utils/capitalize';
 import Grow from '../Grow';
 import Popper from '../Popper';
@@ -234,7 +234,7 @@ function composeEventHandler(handler, eventHandler) {
 
 // TODO v6: Remove PopperComponent, PopperProps, TransitionComponent and TransitionProps.
 const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTooltip' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTooltip' });
   const {
     arrow = false,
     children: childrenProp,

--- a/packages/mui-material/src/Typography/Typography.js
+++ b/packages/mui-material/src/Typography/Typography.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { extendSxProp } from '@mui/system/styleFunctionSx';
 import composeClasses from '@mui/utils/composeClasses';
 import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 import capitalize from '../utils/capitalize';
 import { getTypographyUtilityClass } from './typographyClasses';
 
@@ -92,7 +92,7 @@ const transformDeprecatedColors = (color) => {
 };
 
 const Typography = React.forwardRef(function Typography(inProps, ref) {
-  const themeProps = useThemeProps({ props: inProps, name: 'MuiTypography' });
+  const themeProps = useDefaultProps({ props: inProps, name: 'MuiTypography' });
   const color = transformDeprecatedColors(themeProps.color);
   const props = extendSxProp({ ...themeProps, color });
 

--- a/packages/mui-material/src/Unstable_Grid2/Grid2.tsx
+++ b/packages/mui-material/src/Unstable_Grid2/Grid2.tsx
@@ -2,7 +2,7 @@
 import PropTypes from 'prop-types';
 import { createGrid as createGrid2 } from '@mui/system/Unstable_Grid';
 import { OverridableComponent } from '@mui/types';
-import { styled, useThemeProps } from '../styles';
+import { styled, useDefaultProps } from '../styles';
 import { Grid2TypeMap } from './Grid2Props';
 
 const Grid2 = createGrid2({
@@ -12,7 +12,7 @@ const Grid2 = createGrid2({
     overridesResolver: (props, styles) => styles.root,
   }),
   componentName: 'MuiGrid2',
-  useThemeProps: (inProps) => useThemeProps({ props: inProps, name: 'MuiGrid2' }),
+  useDefaultProps: (inProps) => useDefaultProps({ props: inProps, name: 'MuiGrid2' }),
 }) as OverridableComponent<Grid2TypeMap>;
 
 Grid2.propTypes /* remove-proptypes */ = {

--- a/packages/mui-material/src/styles/index.d.ts
+++ b/packages/mui-material/src/styles/index.d.ts
@@ -70,7 +70,7 @@ export {
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function experimental_sx(): any;
 export { default as useTheme } from './useTheme';
-export { default as useThemeProps } from './useThemeProps';
+export { default as useDefaultProps } from './useThemeProps';
 export * from './useThemeProps';
 export { default as styled } from './styled';
 /**

--- a/packages/mui-material/src/styles/index.js
+++ b/packages/mui-material/src/styles/index.js
@@ -33,7 +33,7 @@ export { getUnit as unstable_getUnit, toUnitless as unstable_toUnitless } from '
 export { default as responsiveFontSizes } from './responsiveFontSizes';
 export { duration, easing } from './createTransitions';
 export { default as useTheme } from './useTheme';
-export { default as useThemeProps } from './useThemeProps';
+export { default as useDefaultProps } from './useThemeProps';
 export { default as styled } from './styled';
 export { default as experimentalStyled } from './styled';
 export { default as ThemeProvider } from './ThemeProvider';

--- a/packages/mui-material/src/styles/shouldSkipGeneratingVar.ts
+++ b/packages/mui-material/src/styles/shouldSkipGeneratingVar.ts
@@ -1,7 +1,5 @@
 export default function shouldSkipGeneratingVar(keys: string[]) {
-  return (
-    !!keys[0].match(/(cssVarPrefix|typography|mixins|breakpoints|direction|transitions)/) ||
-    !!keys[0].match(/sxConfig$/) || // ends with sxConfig
-    (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/))
-  );
+  return (// ends with sxConfig
+  !!keys[0].match(/(cssVarPrefix|typography|mixins|breakpoints|direction|transitions)/) ||
+  !!keys[0].match(/sxConfig$/) || (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/)));
 }

--- a/packages/mui-material/src/styles/useThemeProps.d.ts
+++ b/packages/mui-material/src/styles/useThemeProps.d.ts
@@ -11,7 +11,7 @@ export type ThemedProps<Theme, Name extends keyof any> = Theme extends {
   ? Props
   : {};
 
-export default function useThemeProps<
+export default function useDefaultProps<
   Theme extends ThemeWithProps,
   Props,
   Name extends keyof any,

--- a/packages/mui-material/src/styles/useThemeProps.js
+++ b/packages/mui-material/src/styles/useThemeProps.js
@@ -3,6 +3,6 @@ import systemUseThemeProps from '@mui/system/useThemeProps';
 import defaultTheme from './defaultTheme';
 import THEME_ID from './identifier';
 
-export default function useThemeProps({ props, name }) {
+export default function useDefaultProps({ props, name }) {
   return systemUseThemeProps({ props, name, defaultTheme, themeId: THEME_ID });
 }

--- a/packages/mui-material/src/styles/useThemeProps.spec.ts
+++ b/packages/mui-material/src/styles/useThemeProps.spec.ts
@@ -1,8 +1,8 @@
-import { Theme, useThemeProps } from '@mui/material/styles';
+import { Theme, useDefaultProps } from '@mui/material/styles';
 import { SliderProps } from '@mui/material/Slider';
 
 function ThemedComponent() {
-  const props = useThemeProps<Theme, SliderProps, 'MuiSlider'>({
+  const props = useDefaultProps<Theme, SliderProps, 'MuiSlider'>({
     props: { color: 'primary' },
     name: 'MuiSlider',
   });

--- a/packages/mui-material/src/zero-styled/index.ts
+++ b/packages/mui-material/src/zero-styled/index.ts
@@ -1,8 +1,8 @@
-import useThemeProps from '../styles/useThemeProps';
+import { useDefaultProps } from "../DefaultPropsProvider";
 
 export { default as styled } from '../styles/styled';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function createUseThemeProps(name: string) {
-  return useThemeProps;
+  return useDefaultProps;
 }

--- a/packages/mui-system/src/DefaultPropsProvider/DefaultPropsProvider.tsx
+++ b/packages/mui-system/src/DefaultPropsProvider/DefaultPropsProvider.tsx
@@ -1,0 +1,61 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import resolveProps from '@mui/utils/resolveProps';
+
+const PropsContext = React.createContext<Record<string, any> | undefined>(undefined);
+
+function DefaultPropsProvider({
+  value,
+  children,
+}: React.PropsWithChildren<{ value: Record<string, any> | undefined }>) {
+  return <PropsContext.Provider value={value}>{children}</PropsContext.Provider>;
+}
+
+DefaultPropsProvider.propTypes /* remove-proptypes */ = {
+  // ┌────────────────────────────── Warning ──────────────────────────────┐
+  // │ These PropTypes are generated from the TypeScript type definitions. │
+  // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
+  // └─────────────────────────────────────────────────────────────────────┘
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * @ignore
+   */
+  value: PropTypes.object,
+} as any;
+
+function getThemeProps<
+  Theme extends {
+    components?: Record<string, { defaultProps?: any; styleOverrides?: any; variants?: any }>;
+  },
+  Props,
+  Name extends string,
+>(params: { props: Props; name: Name; theme?: Theme }): Props {
+  const { theme, name, props } = params;
+
+  if (!theme || !theme.components || !theme.components[name]) {
+    return props;
+  }
+  const config = theme.components[name];
+
+  if (config.defaultProps) {
+    // compatible with v5 signature
+    return resolveProps(config.defaultProps, props);
+  }
+
+  if (!config.styleOverrides && !config.variants) {
+    // v6 signature, no property 'defaultProps'
+    return resolveProps(config as any, props);
+  }
+  return props;
+}
+
+export function useDefaultProps<Props>({ props, name }: { props: Props; name: string }) {
+  const ctx = React.useContext(PropsContext);
+  return getThemeProps({ props, name, theme: { components: ctx } });
+}
+
+export default DefaultPropsProvider;

--- a/packages/mui-system/src/DefaultPropsProvider/index.ts
+++ b/packages/mui-system/src/DefaultPropsProvider/index.ts
@@ -1,0 +1,1 @@
+export { default, useDefaultProps } from './DefaultPropsProvider';

--- a/packages/mui-system/src/ThemeProvider/ThemeProvider.js
+++ b/packages/mui-system/src/ThemeProvider/ThemeProvider.js
@@ -9,6 +9,7 @@ import exactProp from '@mui/utils/exactProp';
 import { ThemeContext as StyledEngineThemeContext } from '@mui/styled-engine';
 import useThemeWithoutDefault from '../useThemeWithoutDefault';
 import RtlProvider from '../RtlProvider';
+import DefaultPropsProvider from '../DefaultPropsProvider';
 
 const EMPTY_THEME = {};
 
@@ -67,7 +68,9 @@ function ThemeProvider(props) {
   return (
     <MuiThemeProvider theme={privateTheme}>
       <StyledEngineThemeContext.Provider value={engineTheme}>
-        <RtlProvider value={rtlValue}>{children}</RtlProvider>
+        <RtlProvider value={rtlValue}>
+          <DefaultPropsProvider value={engineTheme?.components}>{children}</DefaultPropsProvider>
+        </RtlProvider>
       </StyledEngineThemeContext.Provider>
     </MuiThemeProvider>
   );

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
@@ -731,14 +731,16 @@ describe('createCssVarsProvider', () => {
       const { CssVarsProvider } = createCssVarsProvider({
         theme: createCssVarsTheme({
           colorSchemes: { light: { fontSize: 16 } },
-          components: 'any',
+          components: {
+            foo: 'bar',
+          },
         }),
         defaultColorScheme: 'light',
       });
       function Text() {
         const theme = useTheme();
 
-        return <div data-testid={`text`}>{theme.vars.components}</div>;
+        return <div data-testid={`text`}>{theme.vars.components?.foo}</div>;
       }
       render(
         <CssVarsProvider>
@@ -746,7 +748,7 @@ describe('createCssVarsProvider', () => {
         </CssVarsProvider>,
       );
 
-      expect(screen.getByTestId('text').textContent).not.to.equal('var(--components)');
+      expect(screen.getByTestId('text').textContent).not.to.equal('var(--components-foo)');
     });
 
     it('`defaultMode` is specified', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This new provider is for libraries, e.g. MUI X, that build on top of Material UI to adopt Pigment CSS integration while supporting Material UI v5.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
