### PR TITLE
[material-ui][joy-ui] Remove warning from `getInitColorSchemeScript`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           # fetch all tags which are required for `pnpm release:changelog`
           fetch-depth: 0
       - name: Set up pnpm
-        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+        uses: pnpm/action-setup@v4
       - name: Use Node.js 18.x
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -5,8 +5,8 @@ import { ServerStyleSheets as JSSServerStyleSheets } from '@mui/styles';
 import { ServerStyleSheet } from 'styled-components';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import GlobalStyles from '@mui/material/GlobalStyles';
-import { getInitColorSchemeScript as getMuiInitColorSchemeScript } from '@mui/material/styles';
-import { getInitColorSchemeScript as getJoyInitColorSchemeScript } from '@mui/joy/styles';
+import MuiInitColorSchemeScript from '@mui/material/InitColorSchemeScript';
+import JoyInitColorSchemeScript from '@mui/joy/InitColorSchemeScript';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import createEmotionCache from 'docs/src/createEmotionCache';
 import { getMetaThemeColor } from '@mui/docs/branding';
@@ -173,8 +173,8 @@ export default class MyDocument extends Document {
           />
         </Head>
         <body>
-          {getMuiInitColorSchemeScript({ defaultMode: 'system' })}
-          {getJoyInitColorSchemeScript({ defaultMode: 'system' })}
+          <MuiInitColorSchemeScript defaultMode="system" />
+          <JoyInitColorSchemeScript defaultMode="system" />
           <Main />
           <script
             // eslint-disable-next-line react/no-danger

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -5,8 +5,8 @@ import { ServerStyleSheets as JSSServerStyleSheets } from '@mui/styles';
 import { ServerStyleSheet } from 'styled-components';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import GlobalStyles from '@mui/material/GlobalStyles';
-import MuiInitColorSchemeScript from '@mui/material/InitColorSchemeScript';
-import JoyInitColorSchemeScript from '@mui/joy/InitColorSchemeScript';
+import { getInitColorSchemeScript as getMuiInitColorSchemeScript } from '@mui/material/styles';
+import { getInitColorSchemeScript as getJoyInitColorSchemeScript } from '@mui/joy/styles';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import createEmotionCache from 'docs/src/createEmotionCache';
 import { getMetaThemeColor } from '@mui/docs/branding';
@@ -173,8 +173,8 @@ export default class MyDocument extends Document {
           />
         </Head>
         <body>
-          <MuiInitColorSchemeScript defaultMode="system" />
-          <JoyInitColorSchemeScript defaultMode="system" />
+          {getMuiInitColorSchemeScript({ defaultMode: 'system' })}
+          {getJoyInitColorSchemeScript({ defaultMode: 'system' })}
           <Main />
           <script
             // eslint-disable-next-line react/no-danger

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -9,11 +9,10 @@ import type { SupportedColorScheme } from './types';
 import THEME_ID from './identifier';
 import { defaultConfig } from '../InitColorSchemeScript/InitColorSchemeScript';
 
-const {
-  CssVarsProvider,
-  useColorScheme,
-  getInitColorSchemeScript: deprecatedGetInitColorSchemeScript,
-} = createCssVarsProvider<SupportedColorScheme, typeof THEME_ID>({
+const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssVarsProvider<
+  SupportedColorScheme,
+  typeof THEME_ID
+>({
   themeId: THEME_ID,
   theme: defaultTheme,
   attribute: defaultConfig.attribute,
@@ -24,23 +23,5 @@ const {
     dark: defaultConfig.defaultDarkColorScheme,
   },
 });
-
-let warnedInitScriptOnce = false;
-
-const getInitColorSchemeScript: typeof deprecatedGetInitColorSchemeScript = (params) => {
-  if (!warnedInitScriptOnce) {
-    console.warn(
-      [
-        'MUI: The getInitColorSchemeScript function has been deprecated.',
-        '',
-        "You should use `import InitColorSchemeScript from '@mui/joy/InitColorSchemeScript'`",
-        'and replace the function call with `<InitColorSchemeScript />` instead.',
-      ].join('\n'),
-    );
-
-    warnedInitScriptOnce = true;
-  }
-  return deprecatedGetInitColorSchemeScript(params);
-};
 
 export { CssVarsProvider, useColorScheme, getInitColorSchemeScript };

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -24,4 +24,19 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
   },
 });
 
-export { CssVarsProvider, useColorScheme, getInitColorSchemeScript };
+export {
+  CssVarsProvider,
+  useColorScheme,
+  /**
+   * @deprecated use `InitColorSchemeScript` instead
+   *
+   * ```diff
+   * - import { getInitColorSchemeScript } from '@mui/joy/styles';
+   * + import InitColorSchemeScript from '@mui/joy/InitColorSchemeScript';
+   *
+   * - getInitColorSchemeScript();
+   * + <InitColorSchemeScript />;
+   * ```
+   */
+  getInitColorSchemeScript,
+};

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -9,10 +9,11 @@ import type { SupportedColorScheme } from './types';
 import THEME_ID from './identifier';
 import { defaultConfig } from '../InitColorSchemeScript/InitColorSchemeScript';
 
-const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssVarsProvider<
-  SupportedColorScheme,
-  typeof THEME_ID
->({
+const {
+  CssVarsProvider,
+  useColorScheme,
+  getInitColorSchemeScript: getInitColorSchemeScriptSystem,
+} = createCssVarsProvider<SupportedColorScheme, typeof THEME_ID>({
   themeId: THEME_ID,
   theme: defaultTheme,
   attribute: defaultConfig.attribute,
@@ -24,19 +25,17 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
   },
 });
 
-export {
-  CssVarsProvider,
-  useColorScheme,
-  /**
-   * @deprecated use `InitColorSchemeScript` instead
-   *
-   * ```diff
-   * - import { getInitColorSchemeScript } from '@mui/joy/styles';
-   * + import InitColorSchemeScript from '@mui/joy/InitColorSchemeScript';
-   *
-   * - getInitColorSchemeScript();
-   * + <InitColorSchemeScript />;
-   * ```
-   */
-  getInitColorSchemeScript,
-};
+/**
+ * @deprecated use `InitColorSchemeScript` instead
+ *
+ * ```diff
+ * - import { getInitColorSchemeScript } from '@mui/joy/styles';
+ * + import InitColorSchemeScript from '@mui/joy/InitColorSchemeScript';
+ *
+ * - getInitColorSchemeScript();
+ * + <InitColorSchemeScript />;
+ * ```
+ */
+export const getInitColorSchemeScript = getInitColorSchemeScriptSystem;
+
+export { CssVarsProvider, useColorScheme };

--- a/packages/mui-material/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-material/src/styles/CssVarsProvider.tsx
@@ -16,10 +16,11 @@ import { defaultConfig } from '../InitColorSchemeScript/InitColorSchemeScript';
 
 const defaultTheme = experimental_extendTheme();
 
-const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssVarsProvider<
-  SupportedColorScheme,
-  typeof THEME_ID
->({
+const {
+  CssVarsProvider,
+  useColorScheme,
+  getInitColorSchemeScript: getInitColorSchemeScriptSystem,
+} = createCssVarsProvider<SupportedColorScheme, typeof THEME_ID>({
   themeId: THEME_ID,
   theme: defaultTheme,
   attribute: defaultConfig.attribute,
@@ -44,19 +45,16 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
   excludeVariablesFromRoot,
 });
 
-export {
-  useColorScheme,
-  /**
-   * @deprecated use `InitColorSchemeScript` instead
-   *
-   * ```diff
-   * - import { getInitColorSchemeScript } from '@mui/material/styles';
-   * + import InitColorSchemeScript from '@mui/material/InitColorSchemeScript';
-   *
-   * - getInitColorSchemeScript();
-   * + <InitColorSchemeScript />;
-   * ```
-   */
-  getInitColorSchemeScript,
-  CssVarsProvider as Experimental_CssVarsProvider,
-};
+/**
+ * @deprecated Use `InitColorSchemeScript` instead
+ * ```diff
+ * - import { getInitColorSchemeScript } from '@mui/material/styles';
+ * + import InitColorSchemeScript from '@mui/material/InitColorSchemeScript';
+ *
+ * - getInitColorSchemeScript();
+ * + <InitColorSchemeScript />;
+ * ```
+ */
+export const getInitColorSchemeScript = getInitColorSchemeScriptSystem;
+
+export { useColorScheme, CssVarsProvider as Experimental_CssVarsProvider };

--- a/packages/mui-material/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-material/src/styles/CssVarsProvider.tsx
@@ -46,6 +46,17 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
 
 export {
   useColorScheme,
+  /**
+   * @deprecated use `InitColorSchemeScript` instead
+   *
+   * ```diff
+   * - import { getInitColorSchemeScript } from '@mui/material/styles';
+   * + import InitColorSchemeScript from '@mui/material/InitColorSchemeScript';
+   *
+   * - getInitColorSchemeScript();
+   * + <InitColorSchemeScript />;
+   * ```
+   */
   getInitColorSchemeScript,
   CssVarsProvider as Experimental_CssVarsProvider,
 };

--- a/packages/mui-material/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-material/src/styles/CssVarsProvider.tsx
@@ -16,11 +16,10 @@ import { defaultConfig } from '../InitColorSchemeScript/InitColorSchemeScript';
 
 const defaultTheme = experimental_extendTheme();
 
-const {
-  CssVarsProvider,
-  useColorScheme,
-  getInitColorSchemeScript: deprecatedGetInitColorSchemeScript,
-} = createCssVarsProvider<SupportedColorScheme, typeof THEME_ID>({
+const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssVarsProvider<
+  SupportedColorScheme,
+  typeof THEME_ID
+>({
   themeId: THEME_ID,
   theme: defaultTheme,
   attribute: defaultConfig.attribute,
@@ -44,25 +43,6 @@ const {
   },
   excludeVariablesFromRoot,
 });
-
-let warnedInitScriptOnce = false;
-
-// TODO: remove in v7
-const getInitColorSchemeScript: typeof deprecatedGetInitColorSchemeScript = (params) => {
-  if (!warnedInitScriptOnce) {
-    console.warn(
-      [
-        'MUI: The getInitColorSchemeScript function has been deprecated.',
-        '',
-        "You should use `import InitColorSchemeScript from '@mui/material/InitColorSchemeScript'`",
-        'and replace the function call with `<InitColorSchemeScript />` instead.',
-      ].join('\n'),
-    );
-
-    warnedInitScriptOnce = true;
-  }
-  return deprecatedGetInitColorSchemeScript(params);
-};
 
 export {
   useColorScheme,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->\

From https://github.com/mui/material-ui/pull/42829#issuecomment-2206165783

Updated the docs to fallback to `getInitColorSchemeScript` in v5 (MUI X needs this).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
