### PR TITLE
[material-ui][docs] Fix type error in virtualized table demo

### DIFF
--- a/docs/data/material/components/table/ReactVirtualizedTable.js
+++ b/docs/data/material/components/table/ReactVirtualizedTable.js
@@ -64,8 +64,8 @@ const VirtuosoTableComponents = {
   Table: (props) => (
     <Table {...props} sx={{ borderCollapse: 'separate', tableLayout: 'fixed' }} />
   ),
-  TableHead,
-  TableRow: ({ item: _item, ...props }) => <TableRow {...props} />,
+  TableHead: React.forwardRef((props, ref) => <TableHead {...props} ref={ref} />),
+  TableRow,
   TableBody: React.forwardRef((props, ref) => <TableBody {...props} ref={ref} />),
 };
 

--- a/docs/data/material/components/table/ReactVirtualizedTable.tsx
+++ b/docs/data/material/components/table/ReactVirtualizedTable.tsx
@@ -89,8 +89,10 @@ const VirtuosoTableComponents: TableComponents<Data> = {
   Table: (props) => (
     <Table {...props} sx={{ borderCollapse: 'separate', tableLayout: 'fixed' }} />
   ),
-  TableHead,
-  TableRow: ({ item: _item, ...props }) => <TableRow {...props} />,
+  TableHead: React.forwardRef<HTMLTableSectionElement>((props, ref) => (
+    <TableHead {...props} ref={ref} />
+  )),
+  TableRow,
   TableBody: React.forwardRef<HTMLTableSectionElement>((props, ref) => (
     <TableBody {...props} ref={ref} />
   )),


### PR DESCRIPTION
Cherry-pick of https://github.com/mui/material-ui/pull/42757

To land support for React 18.3.1 in v5, we're backporting the changes we did on `next` (v6) to `master`.