### PR TITLE
[core] Remove react-test-renderer

### DIFF
--- a/packages/mui-base/src/Menu/Menu.test.tsx
+++ b/packages/mui-base/src/Menu/Menu.test.tsx
@@ -53,7 +53,7 @@ describe('<Menu />', () => {
         expectedClassName: menuClasses.listbox,
       },
     },
-    skip: ['reactTestRenderer', 'componentProp', 'slotsProp'],
+    skip: ['componentProp', 'slotsProp'],
   }));
 
   describe('after initialization', () => {

--- a/packages/mui-base/src/MenuButton/MenuButton.test.tsx
+++ b/packages/mui-base/src/MenuButton/MenuButton.test.tsx
@@ -37,7 +37,7 @@ describe('<MenuButton />', () => {
         testWithElement: null,
       },
     },
-    skip: ['componentProp', 'reactTestRenderer'],
+    skip: ['componentProp'],
   }));
 
   describe('prop: disabled', () => {

--- a/packages/mui-base/src/MenuItem/MenuItem.test.tsx
+++ b/packages/mui-base/src/MenuItem/MenuItem.test.tsx
@@ -37,9 +37,6 @@ describe('<MenuItem />', () => {
         expectedClassName: menuItemClasses.root,
       },
     },
-    skip: [
-      'componentProp',
-      'reactTestRenderer', // Need to be wrapped in MenuContext
-    ],
+    skip: ['componentProp'],
   }));
 });

--- a/packages/mui-base/src/Modal/Modal.test.tsx
+++ b/packages/mui-base/src/Modal/Modal.test.tsx
@@ -29,10 +29,7 @@ describe('<Modal />', () => {
           expectedClassName: classes.root,
         },
       },
-      skip: [
-        'componentProp',
-        'reactTestRenderer', // portal https://github.com/facebook/react/issues/11565
-      ],
+      skip: ['componentProp'],
     }),
   );
 

--- a/packages/mui-base/src/Option/Option.test.tsx
+++ b/packages/mui-base/src/Option/Option.test.tsx
@@ -38,9 +38,6 @@ describe('<Option />', () => {
         expectedClassName: optionClasses.root,
       },
     },
-    skip: [
-      'componentProp',
-      'reactTestRenderer', // Need to be wrapped in SelectContext
-    ],
+    skip: ['componentProp'],
   }));
 });

--- a/packages/mui-base/src/Popper/Popper.test.tsx
+++ b/packages/mui-base/src/Popper/Popper.test.tsx
@@ -17,11 +17,7 @@ describe('<Popper />', () => {
     inheritComponent: 'div',
     render,
     refInstanceof: window.HTMLDivElement,
-    skip: [
-      // https://github.com/facebook/react/issues/11565
-      'reactTestRenderer',
-      'componentProp',
-    ],
+    skip: ['componentProp'],
     slots: {
       root: {
         expectedClassName: popperClasses.root,

--- a/packages/mui-base/src/Select/Select.test.tsx
+++ b/packages/mui-base/src/Select/Select.test.tsx
@@ -59,7 +59,7 @@ describe('<Select />', () => {
         testWithElement: 'span',
       },
     },
-    skip: ['componentProp', 'reactTestRenderer'],
+    skip: ['componentProp'],
   }));
 
   describe('selected option rendering', () => {

--- a/packages/mui-base/src/Tab/Tab.test.tsx
+++ b/packages/mui-base/src/Tab/Tab.test.tsx
@@ -44,9 +44,6 @@ describe('<Tab />', () => {
         expectedClassName: tabClasses.root,
       },
     },
-    skip: [
-      'reactTestRenderer', // Need to be wrapped with TabsContext
-      'componentProp',
-    ],
+    skip: ['componentProp'],
   }));
 });

--- a/packages/mui-base/src/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-base/src/TabPanel/TabPanel.test.tsx
@@ -37,9 +37,6 @@ describe('<TabPanel />', () => {
         expectedClassName: tabPanelClasses.root,
       },
     },
-    skip: [
-      'reactTestRenderer', // Need to be wrapped with TabsContext
-      'componentProp',
-    ],
+    skip: ['componentProp'],
   }));
 });

--- a/packages/mui-base/src/TabsList/TabsList.test.tsx
+++ b/packages/mui-base/src/TabsList/TabsList.test.tsx
@@ -35,10 +35,7 @@ describe('<TabsList />', () => {
         expectedClassName: tabsListClasses.root,
       },
     },
-    skip: [
-      'reactTestRenderer', // Need to be wrapped with TabsContext
-      'componentProp',
-    ],
+    skip: ['componentProp'],
   }));
 
   describe('accessibility attributes', () => {

--- a/packages/mui-base/src/Unstable_Popup/Popup.test.tsx
+++ b/packages/mui-base/src/Unstable_Popup/Popup.test.tsx
@@ -58,11 +58,7 @@ describe('<Popup />', () => {
       return result;
     },
     refInstanceof: window.HTMLDivElement,
-    skip: [
-      // https://github.com/facebook/react/issues/11565
-      'reactTestRenderer',
-      'componentProp',
-    ],
+    skip: ['componentProp'],
     slots: {
       root: {
         expectedClassName: popupClasses.root,

--- a/packages/mui-base/test/describeConformanceUnstyled.tsx
+++ b/packages/mui-base/test/describeConformanceUnstyled.tsx
@@ -10,7 +10,6 @@ import {
   describeRef,
   randomStringValue,
   testComponentProp,
-  testReactTestRenderer,
 } from '@mui-internal/test-utils';
 import { ClassNameConfigurator } from '@mui/base/utils';
 
@@ -405,7 +404,6 @@ const fullSuite = {
   slotPropsCallbacks: testSlotPropsCallbacks,
   mergeClassName: testClassName,
   propsSpread: testPropForwarding,
-  reactTestRenderer: testReactTestRenderer,
   refForwarding: describeRef,
   ownerStatePropagation: testOwnerStatePropagation,
   disableClassGeneration: testDisablingClassGeneration,

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
@@ -50,12 +50,7 @@ describe('Joy <Autocomplete />', () => {
     muiName: 'JoyAutocomplete',
     testDeepOverrides: { slotName: 'popupIndicator', slotClassName: classes.popupIndicator },
     testVariantProps: { size: 'lg' },
-    skip: [
-      'componentsProp',
-      'classesRoot',
-      // https://github.com/facebook/react/issues/11565
-      'reactTestRenderer',
-    ],
+    skip: ['componentsProp', 'classesRoot'],
     slots: {
       root: {
         expectedClassName: classes.root,

--- a/packages/mui-joy/src/Drawer/Drawer.test.tsx
+++ b/packages/mui-joy/src/Drawer/Drawer.test.tsx
@@ -31,7 +31,6 @@ describe('<Drawer />', () => {
         'componentsProp', // TODO isRTL is leaking, why do we even have it in the first place?
         'themeDefaultProps', // portal, can't determine the root
         'themeStyleOverrides', // portal, can't determine the root
-        'reactTestRenderer', // portal https://github.com/facebook/react/issues/11565
       ],
     }),
   );

--- a/packages/mui-joy/src/Menu/Menu.test.tsx
+++ b/packages/mui-joy/src/Menu/Menu.test.tsx
@@ -42,7 +42,6 @@ describe('Joy <Menu />', () => {
       'classesRoot',
       'componentProp',
       'componentsProp',
-      'reactTestRenderer', // react-transition-group issue
       'themeDefaultProps', // portal, can't determine the root
     ],
   }));

--- a/packages/mui-joy/src/MenuButton/MenuButton.test.tsx
+++ b/packages/mui-joy/src/MenuButton/MenuButton.test.tsx
@@ -32,7 +32,7 @@ describe('<MenuButton />', () => {
     slots: {
       root: { expectedClassName: classes.root },
     },
-    skip: ['reactTestRenderer', 'componentsProp', 'classesRoot'],
+    skip: ['componentsProp', 'classesRoot'],
     testRootOverrides: { slotName: 'root', slotClassName: classes.root },
     testVariantProps: { variant: 'soft' },
     ThemeProvider,

--- a/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
@@ -42,7 +42,7 @@ describe('Joy <MenuItem />', () => {
     muiName: 'JoyMenuItem',
     testVariantProps: { variant: 'solid' },
     testCustomVariant: true,
-    skip: ['propsSpread', 'componentsProp', 'classesRoot', 'reactTestRenderer'],
+    skip: ['propsSpread', 'componentsProp', 'classesRoot'],
     slots: {
       root: {
         expectedClassName: classes.root,

--- a/packages/mui-joy/src/Modal/Modal.test.tsx
+++ b/packages/mui-joy/src/Modal/Modal.test.tsx
@@ -33,7 +33,6 @@ describe('<Modal />', () => {
         'componentsProp', // TODO isRTL is leaking, why do we even have it in the first place?
         'themeDefaultProps', // portal, can't determine the root
         'themeStyleOverrides', // portal, can't determine the root
-        'reactTestRenderer', // portal https://github.com/facebook/react/issues/11565
       ],
     }),
   );

--- a/packages/mui-joy/src/Select/Select.test.tsx
+++ b/packages/mui-joy/src/Select/Select.test.tsx
@@ -49,14 +49,7 @@ describe('Joy <Select />', () => {
       startDecorator: { expectedClassName: classes.startDecorator },
       endDecorator: { expectedClassName: classes.endDecorator },
     },
-    skip: [
-      'classesRoot',
-      'propsSpread',
-      'componentProp',
-      'componentsProp',
-      // https://github.com/facebook/react/issues/11565
-      'reactTestRenderer',
-    ],
+    skip: ['classesRoot', 'propsSpread', 'componentProp', 'componentsProp'],
   }));
 
   it('should be able to mount the component', () => {

--- a/packages/mui-joy/src/Tab/Tab.test.tsx
+++ b/packages/mui-joy/src/Tab/Tab.test.tsx
@@ -37,7 +37,7 @@ describe('Joy <Tab />', () => {
     refInstanceof: window.HTMLButtonElement,
     testVariantProps: { variant: 'solid' },
     testCustomVariant: true,
-    skip: ['componentsProp', 'classesRoot', 'reactTestRenderer'],
+    skip: ['componentsProp', 'classesRoot'],
     slots: {
       root: {
         expectedClassName: classes.root,

--- a/packages/mui-joy/src/TabList/TabList.test.tsx
+++ b/packages/mui-joy/src/TabList/TabList.test.tsx
@@ -25,7 +25,7 @@ describe('Joy <TabList />', () => {
     muiName: 'JoyTabList',
     refInstanceof: window.HTMLDivElement,
     testVariantProps: { variant: 'solid' },
-    skip: ['componentsProp', 'classesRoot', 'reactTestRenderer'],
+    skip: ['componentsProp', 'classesRoot'],
     slots: {
       root: {
         expectedClassName: classes.root,

--- a/packages/mui-joy/src/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-joy/src/TabPanel/TabPanel.test.tsx
@@ -25,7 +25,7 @@ describe('Joy <TabPanel />', () => {
     refInstanceof: window.HTMLDivElement,
     testVariantProps: { size: 'sm' },
     testCustomVariant: true,
-    skip: ['componentsProp', 'classesRoot', 'reactTestRenderer'],
+    skip: ['componentsProp', 'classesRoot'],
     slots: {
       root: {
         expectedClassName: classes.root,

--- a/packages/mui-joy/src/Table/Table.test.tsx
+++ b/packages/mui-joy/src/Table/Table.test.tsx
@@ -25,7 +25,6 @@ describe('<Table />', () => {
       'componentProp',
       'mergeClassName',
       'propsSpread',
-      'reactTestRenderer',
       'refForwarding',
     ],
     slots: {

--- a/packages/mui-joy/src/Tabs/Tabs.test.tsx
+++ b/packages/mui-joy/src/Tabs/Tabs.test.tsx
@@ -18,7 +18,7 @@ describe('Joy <Tabs />', () => {
     refInstanceof: window.HTMLDivElement,
     testVariantProps: { variant: 'solid' },
     testCustomVariant: true,
-    skip: ['componentsProp', 'classesRoot', 'reactTestRenderer'],
+    skip: ['componentsProp', 'classesRoot'],
     slots: {
       root: {
         expectedClassName: classes.root,

--- a/packages/mui-joy/src/Tooltip/Tooltip.test.tsx
+++ b/packages/mui-joy/src/Tooltip/Tooltip.test.tsx
@@ -50,8 +50,6 @@ describe('<Tooltip />', () => {
         'componentProp',
         'componentsProp',
         'themeVariants',
-        // react-transition-group issue
-        'reactTestRenderer',
         // Props are spread to root and children
         // We cannot use the standard propsSpread test which relies on data-testid only on the root
         'propsSpread',

--- a/packages/mui-lab/src/TabList/TabList.test.js
+++ b/packages/mui-lab/src/TabList/TabList.test.js
@@ -20,14 +20,12 @@ describe('<TabList />', () => {
      */
     render: (node) => render(<TabContext value="0">{node}</TabContext>),
     refInstanceof: window.HTMLDivElement,
-    // TODO: no idea why reactTestRenderer fails
     skip: [
       'componentsProp',
       'themeDefaultProps',
       'themeStyleOverrides',
       'themeVariants',
       'rootClass',
-      'reactTestRenderer',
     ],
   }));
 

--- a/packages/mui-lab/src/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-lab/src/TabPanel/TabPanel.test.tsx
@@ -14,13 +14,7 @@ describe('<TabPanel />', () => {
     render: (node) => render(<TabContext value="0">{node}</TabContext>),
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiTabPanel',
-    skip: [
-      'componentProp',
-      'componentsProp',
-      'reactTestRenderer',
-      'themeDefaultProps',
-      'themeVariants',
-    ],
+    skip: ['componentProp', 'componentsProp', 'themeDefaultProps', 'themeVariants'],
   }));
 
   it('renders a [role="tabpanel"]', () => {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -70,7 +70,6 @@ describe('<Autocomplete />', () => {
         'componentProp',
         'componentsProp',
         'slotsProp',
-        'reactTestRenderer',
         'slotPropsCallback', // not supported yet
       ],
     }),

--- a/packages/mui-material/src/Backdrop/Backdrop.test.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.test.js
@@ -25,8 +25,6 @@ describe('<Backdrop />', () => {
     skip: [
       'componentProp',
       'componentsProp',
-      // react-transition-group issue
-      'reactTestRenderer',
       'slotPropsCallback', // not supported yet
     ],
   }));

--- a/packages/mui-material/src/Dialog/Dialog.test.js
+++ b/packages/mui-material/src/Dialog/Dialog.test.js
@@ -48,13 +48,7 @@ describe('<Dialog />', () => {
       testVariantProps: { variant: 'foo' },
       testDeepOverrides: { slotName: 'paper', slotClassName: classes.paper },
       refInstanceof: window.HTMLDivElement,
-      skip: [
-        'componentProp',
-        'componentsProp',
-        'themeVariants',
-        // react-transition-group issue
-        'reactTestRenderer',
-      ],
+      skip: ['componentProp', 'componentsProp', 'themeVariants'],
     }),
   );
 

--- a/packages/mui-material/src/Drawer/Drawer.test.js
+++ b/packages/mui-material/src/Drawer/Drawer.test.js
@@ -22,13 +22,7 @@ describe('<Drawer />', () => {
       testVariantProps: { variant: 'persistent' },
       testDeepOverrides: { slotName: 'paper', slotClassName: classes.paper },
       refInstanceof: window.HTMLDivElement,
-      skip: [
-        'componentProp',
-        'componentsProp',
-        'themeVariants',
-        // react-transition-group issue
-        'reactTestRenderer',
-      ],
+      skip: ['componentProp', 'componentsProp', 'themeVariants'],
     }),
   );
 

--- a/packages/mui-material/src/Fade/Fade.test.js
+++ b/packages/mui-material/src/Fade/Fade.test.js
@@ -26,9 +26,6 @@ describe('<Fade />', () => {
       'themeDefaultProps',
       'themeStyleOverrides',
       'themeVariants',
-      // TODO: really?
-      // react-transition-group issue
-      'reactTestRenderer',
     ],
   }));
 

--- a/packages/mui-material/src/Grow/Grow.test.js
+++ b/packages/mui-material/src/Grow/Grow.test.js
@@ -31,8 +31,6 @@ describe('<Grow />', () => {
         'themeDefaultProps',
         'themeStyleOverrides',
         'themeVariants',
-        // react-transition-group issue
-        'reactTestRenderer',
       ],
     }),
   );

--- a/packages/mui-material/src/Menu/Menu.test.js
+++ b/packages/mui-material/src/Menu/Menu.test.js
@@ -37,7 +37,6 @@ describe('<Menu />', () => {
       'rootClass', // portal, can't determine the root
       'componentProp',
       'componentsProp',
-      'reactTestRenderer', // react-transition-group issue
       'themeDefaultProps', // portal, can't determine the root
     ],
   }));

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -43,7 +43,6 @@ describe('<Modal />', () => {
         'componentsProp', // TODO isRTL is leaking, why do we even have it in the first place?
         'themeDefaultProps', // portal, can't determine the root
         'themeStyleOverrides', // portal, can't determine the root
-        'reactTestRenderer', // portal https://github.com/facebook/react/issues/11565
         'slotPropsCallback', // not supported yet
       ],
     }),

--- a/packages/mui-material/src/Popover/Popover.test.js
+++ b/packages/mui-material/src/Popover/Popover.test.js
@@ -71,7 +71,6 @@ describe('<Popover />', () => {
       'themeDefaultProps', // portal, can't determine the root
       'themeStyleOverrides', // portal, can't determine the root
       'themeVariants',
-      'reactTestRenderer', // react-transition-group issue
       'slotPropsCallback', // not supported yet
     ],
   }));

--- a/packages/mui-material/src/Popper/Popper.test.js
+++ b/packages/mui-material/src/Popper/Popper.test.js
@@ -37,8 +37,6 @@ describe('<Popper />', () => {
       'themeDefaultProps',
       'themeStyleOverrides',
       'themeVariants',
-      // https://github.com/facebook/react/issues/11565
-      'reactTestRenderer',
       'slotPropsCallback', // not supported yet
     ],
   }));

--- a/packages/mui-material/src/Slide/Slide.test.js
+++ b/packages/mui-material/src/Slide/Slide.test.js
@@ -33,8 +33,6 @@ describe('<Slide />', () => {
         'themeDefaultProps',
         'themeStyleOverrides',
         'themeVariants',
-        // react-transition-group issue
-        'reactTestRenderer',
       ],
     }),
   );

--- a/packages/mui-material/src/Snackbar/Snackbar.test.js
+++ b/packages/mui-material/src/Snackbar/Snackbar.test.js
@@ -30,13 +30,7 @@ describe('<Snackbar />', () => {
     render,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiSnackbar',
-    skip: [
-      'componentProp',
-      'componentsProp',
-      'themeVariants',
-      // react-transition-group issue
-      'reactTestRenderer',
-    ],
+    skip: ['componentProp', 'componentsProp', 'themeVariants'],
   }));
 
   describe('prop: onClose', () => {

--- a/packages/mui-material/src/SpeedDial/SpeedDial.test.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.test.js
@@ -38,7 +38,6 @@ describe('<SpeedDial />', () => {
     skip: [
       'componentProp', // react-transition-group issue
       'componentsProp',
-      'reactTestRenderer',
     ],
   }));
 

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
@@ -20,7 +20,7 @@ describe('<SpeedDialAction />', () => {
       muiName: 'MuiSpeedDialAction',
       testRootOverrides: { slotName: 'fab' },
       testVariantProps: { tooltipPlacement: 'right' },
-      skip: ['componentProp', 'reactTestRenderer', 'componentsProp'],
+      skip: ['componentProp', 'componentsProp'],
     }),
   );
 

--- a/packages/mui-material/src/StepContent/StepContent.test.js
+++ b/packages/mui-material/src/StepContent/StepContent.test.js
@@ -23,7 +23,7 @@ describe('<StepContent />', () => {
       );
       return { container: container.firstChild.firstChild, ...other };
     },
-    skip: ['componentProp', 'componentsProp', 'themeVariants', 'reactTestRenderer'],
+    skip: ['componentProp', 'componentsProp', 'themeVariants'],
   }));
 
   it('renders children inside an Collapse component', () => {

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -67,14 +67,7 @@ describe('<SwipeableDrawer />', () => {
     classes: {},
     inheritComponent: Drawer,
     refInstanceof: window.HTMLDivElement,
-    skip: [
-      'componentProp',
-      'themeDefaultProps',
-      'themeStyleOverrides',
-      'themeVariants',
-      // https://github.com/facebook/react/issues/11565
-      'reactTestRenderer',
-    ],
+    skip: ['componentProp', 'themeDefaultProps', 'themeStyleOverrides', 'themeVariants'],
   }));
 
   it('should render a Drawer and a SwipeArea', () => {

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -58,8 +58,6 @@ describe('<Tooltip />', () => {
         'componentProp',
         'componentsProp',
         'themeVariants',
-        // react-transition-group issue
-        'reactTestRenderer',
         'slotPropsCallback', // not supported yet
       ],
     }),

--- a/packages/mui-material/src/Zoom/Zoom.test.js
+++ b/packages/mui-material/src/Zoom/Zoom.test.js
@@ -25,8 +25,6 @@ describe('<Zoom />', () => {
         'themeDefaultProps',
         'themeStyleOverrides',
         'themeVariants',
-        // react-transition-group issue
-        'reactTestRenderer',
       ],
     }),
   );

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -36,7 +36,6 @@
     "mocha": "^10.3.0",
     "playwright": "^1.42.1",
     "prop-types": "^15.8.1",
-    "react-test-renderer": "^18.2.0",
     "sinon": "^15.2.0"
   },
   "devDependencies": {
@@ -46,7 +45,6 @@
     "@types/prop-types": "^15.7.11",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
-    "@types/react-test-renderer": "^18.0.7",
     "@types/sinon": "^10.0.20",
     "typescript": "^5.3.3"
   },

--- a/packages/test-utils/src/describeConformance.tsx
+++ b/packages/test-utils/src/describeConformance.tsx
@@ -1,7 +1,6 @@
 /* eslint-env mocha */
 import * as React from 'react';
 import { expect } from 'chai';
-import ReactTestRenderer from 'react-test-renderer';
 import createDescribe from './createDescribe';
 import { MuiRenderResult } from './createRenderer';
 
@@ -231,22 +230,6 @@ export function testRootClass(element: React.ReactElement, getOptions: () => Con
       // Test that `classes` does not spread to DOM
       expect(document.querySelectorAll('[classes]').length).to.equal(0);
     }
-  });
-}
-
-/**
- * Tests that the component can be rendered with react-test-renderer.
- * This is important for snapshot testing with Jest (even if we don't encourage it).
- */
-export function testReactTestRenderer(element: React.ReactElement) {
-  it('should render without errors in ReactTestRenderer', () => {
-    ReactTestRenderer.act(() => {
-      ReactTestRenderer.create(element, {
-        createNodeMock: (node) => {
-          return document.createElement(node.type as keyof HTMLElementTagNameMap);
-        },
-      });
-    });
   });
 }
 
@@ -993,7 +976,6 @@ const fullSuite = {
   propsSpread: testPropsSpread,
   refForwarding: describeRef,
   rootClass: testRootClass,
-  reactTestRenderer: testReactTestRenderer,
   slotPropsProp: testSlotPropsProp,
   slotPropsCallback: testSlotPropsCallback,
   slotsProp: testSlotsProp,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2237,9 +2237,6 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
-      react-test-renderer:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
       sinon:
         specifier: ^15.2.0
         version: 15.2.0
@@ -2262,9 +2259,6 @@ importers:
       '@types/react-dom':
         specifier: 18.2.19
         version: 18.2.19
-      '@types/react-test-renderer':
-        specifier: ^18.0.7
-        version: 18.0.7
       '@types/sinon':
         specifier: ^10.0.20
         version: 10.0.20
@@ -5092,9 +5086,6 @@ packages:
 
   '@types/react-swipeable-views@0.13.5':
     resolution: {integrity: sha512-ni6WjO7gBq2xB2Y/ZiRdQOgjGOxIik5ow2s7xKieDq8DxsXTdV46jJslSBVK2yoIJHf6mG3uqNTwxwgzbXRRzg==}
-
-  '@types/react-test-renderer@18.0.7':
-    resolution: {integrity: sha512-1+ANPOWc6rB3IkSnElhjv6VLlKg2dSv/OWClUyZimbLsQyBn8Js9Vtdsi3UICJ2rIQ3k2la06dkB+C92QfhKmg==}
 
   '@types/react-transition-group@4.4.10':
     resolution: {integrity: sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==}
@@ -10677,11 +10668,6 @@ packages:
     peerDependencies:
       react: ^15.3.0 || ^16.0.0 || ^17.0.0
 
-  react-test-renderer@18.2.0:
-    resolution: {integrity: sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==}
-    peerDependencies:
-      react: ^18.2.0
-
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -15912,10 +15898,6 @@ snapshots:
       '@types/react-swipeable-views': 0.13.5
 
   '@types/react-swipeable-views@0.13.5':
-    dependencies:
-      '@types/react': 18.2.55
-
-  '@types/react-test-renderer@18.0.7':
     dependencies:
       '@types/react': 18.2.55
 
@@ -22758,13 +22740,6 @@ snapshots:
       react-swipeable-views-core: 0.14.0
       react-swipeable-views-utils: 0.14.0(react@18.2.0)
       warning: 4.0.3
-
-  react-test-renderer@18.2.0(react@18.2.0):
-    dependencies:
-      react: 18.2.0
-      react-is: 18.2.0
-      react-shallow-renderer: 16.15.0(react@18.2.0)
-      scheduler: 0.23.0
 
   react-transition-group@4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -68,7 +68,7 @@
     },
     {
       "groupName": "React",
-      "matchPackageNames": ["react", "react-dom", "react-is", "react-test-renderer"]
+      "matchPackageNames": ["react", "react-dom", "react-is"]
     },
     {
       "groupName": "typescript-eslint",

--- a/scripts/useReactVersion.mjs
+++ b/scripts/useReactVersion.mjs
@@ -17,7 +17,7 @@ import { getWorkspaceRoot } from './utils.mjs';
 const exec = promisify(childProcess.exec);
 
 // packages published from the react monorepo using the same version
-const reactPackageNames = ['react', 'react-dom', 'react-is', 'react-test-renderer', 'scheduler'];
+const reactPackageNames = ['react', 'react-dom', 'react-is', 'scheduler'];
 const devDependenciesPackageNames = ['@testing-library/react'];
 
 // if we need to support more versions we will need to add new mapping here


### PR DESCRIPTION
Cherry pick of https://github.com/mui/material-ui/pull/42784

To land support for React 18.3.1 in v5, we're backporting the changes we did on `next` (v6) to `master`.