### PR TITLE
[base-ui] Fix React spread key warning in test

### DIFF
--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.test.js
@@ -263,7 +263,12 @@ describe('useAutocomplete', () => {
           {groupedOptions.length > 0 ? (
             <ul {...getListboxProps()}>
               {groupedOptions.map((option, index) => {
-                return <li {...getOptionProps({ option, index })}>{option}</li>;
+                const { key, ...optionProps } = getOptionProps({ option, index });
+                return (
+                  <li key={key} {...optionProps}>
+                    {option}
+                  </li>
+                );
               })}
             </ul>
           ) : null}


### PR DESCRIPTION
Cherry-pick of https://github.com/mui/material-ui/pull/42744

To land support for React 18.3.1 in v5, we're backporting the changes we did on `next` (v6) to `master`.