### PR TITLE
[joy-ui][Autocomplete] Fix React spread key warning

### DIFF
--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -409,13 +409,14 @@ const Autocomplete = React.forwardRef(function Autocomplete(
       selectedOptions = renderTags(value as Array<unknown>, getCustomizedTagProps, ownerState);
     } else {
       selectedOptions = (value as Array<unknown>).map((option, index) => {
+        const { key: endDecoratorKey, ...endDecoratorProps } = getCustomizedTagProps({ index });
         return (
           <Chip
             key={index}
             size={size}
             variant="soft"
             color="neutral"
-            endDecorator={<ChipDelete {...getCustomizedTagProps({ index })} />}
+            endDecorator={<ChipDelete key={endDecoratorKey} {...endDecoratorProps} />}
             sx={{ minWidth: 0 }}
           >
             {getOptionLabel(option)}


### PR DESCRIPTION
Cherry-pick of https://github.com/mui/material-ui/pull/42741

To land support for React 18.3.1 in v5, we're backporting the changes we did on `next` (v6) to `master`.