### PR TITLE
[material-ui][Card] Add position:relative to CardMedia

### DIFF
--- a/packages/mui-material/src/CardMedia/CardMedia.js
+++ b/packages/mui-material/src/CardMedia/CardMedia.js
@@ -28,6 +28,7 @@ const CardMediaRoot = styled('div', {
     return [styles.root, isMediaComponent && styles.media, isImageComponent && styles.img];
   },
 })({
+  position: 'relative', // Ensure relative positioning
   display: 'block',
   backgroundSize: 'cover',
   backgroundRepeat: 'no-repeat',
@@ -47,6 +48,7 @@ const CardMediaRoot = styled('div', {
     },
   ],
 });
+
 
 const MEDIA_COMPONENTS = ['video', 'audio', 'picture', 'iframe', 'img'];
 const IMAGE_COMPONENTS = ['picture', 'img'];


### PR DESCRIPTION
### what the pr does?
the pr is fixing the card media component preveiously the image used in card component was displayed above other card components but now the background image is behind the card contents 
### what i did to do this?
made the positive of card media component relative and made other components overlay over the background image of the card by simply using z-index property

### how to check the correction

this would be long step 
step 1 )clone my repository 
step 2)try using the card component 
step 3)now apply image to card and see the fix