### PR TITLE
[docs] Replace v6 "alpha" mentions with "beta"

### DIFF
--- a/docs/data/material/migration/migrating-to-v6/migrating-to-v6.md
+++ b/docs/data/material/migration/migrating-to-v6/migrating-to-v6.md
@@ -2,7 +2,7 @@
 
 <p class="description">This guide explains how and why to migrate from Material UI v5 to v6.</p>
 
-## Start using the alpha release
+## Start using the beta release
 
 In your `package.json` file, change the package version from `latest` to `next`.
 
@@ -20,8 +20,8 @@ Optionally, if you are using one of these packages, you can also change their ve
 - `@mui/styled-engine-sc`
 - `@mui/utils`
 
-Using `next` ensures your project always uses the latest v6 alpha release.
-Alternatively, you can also target and fix it to a specific version, for example, `6.0.0-alpha.0`.
+Using `next` ensures your project always uses the latest v6 beta release.
+Alternatively, you can also target and fix it to a specific version, for example, `6.0.0-beta.0`.
 
 ## Why you should migrate
 

--- a/docs/data/system/migration/migrating-to-v6/migrating-to-v6.md
+++ b/docs/data/system/migration/migrating-to-v6/migrating-to-v6.md
@@ -2,7 +2,7 @@
 
 <p class="description">This guide explains how and why to migrate from MUI System v5 to v6.</p>
 
-## Start using the alpha release
+## Start using the beta release
 
 In the `package.json` file, change the package version from `latest` to `next`.
 
@@ -11,8 +11,8 @@ In the `package.json` file, change the package version from `latest` to `next`.
 +"@mui/system": "next",
 ```
 
-Using `next` ensures your project always uses the latest v6 alpha release.
-Alternatively, you can also target and fix it to a specific version, for example, `6.0.0-alpha.0`.
+Using `next` ensures your project always uses the latest v6 beta release.
+Alternatively, you can also target and fix it to a specific version, for example, `6.0.0-beta.0`.
 
 ## Breaking changes
 


### PR DESCRIPTION
Replace v6 "alpha" mentions with "beta", preparing for the beta's release.
