### PR TITLE
[material-ui][CssBaseline] Remove `enableColorScheme` prop from CssBaseline 

### DIFF
--- a/docs/data/material/components/css-baseline/css-baseline.md
+++ b/docs/data/material/components/css-baseline/css-baseline.md
@@ -93,6 +93,17 @@ const theme = createTheme({
 
 Be aware, however, that using this utility (and customizing `-webkit-scrollbar`) forces macOS to always show the scrollbar.
 
+### Color scheme
+
+This API is introduced in @mui/material (v5.1.0) for switching between `"light"` and `"dark"` modes of native components such as scrollbar, using the `color-scheme` CSS property.
+To enable it, you can set `enableColorScheme=true` as follows:
+
+```jsx
+<ScopedCssBaseline enableColorScheme >
+  {/* The rest of your application using color-scheme*/}
+</ScopedCssBaseline>
+```
+
 ### Typography
 
 - No base font-size is declared on the `<html>`, but 16px is assumed (the browser default).

--- a/docs/data/material/components/css-baseline/css-baseline.md
+++ b/docs/data/material/components/css-baseline/css-baseline.md
@@ -93,21 +93,6 @@ const theme = createTheme({
 
 Be aware, however, that using this utility (and customizing `-webkit-scrollbar`) forces macOS to always show the scrollbar.
 
-### Color scheme
-
-This API is introduced in @mui/material (v5.1.0) for switching between `"light"` and `"dark"` modes of native components such as scrollbar, using the `color-scheme` CSS property.
-To enable it, you can set `enableColorScheme=true` as follows:
-
-```jsx
-<CssBaseline enableColorScheme />
-
-// or
-
-<ScopedCssBaseline enableColorScheme >
-  {/* The rest of your application using color-scheme*/}
-</ScopedCssBaseline>
-```
-
 ### Typography
 
 - No base font-size is declared on the `<html>`, but 16px is assumed (the browser default).

--- a/docs/pages/material-ui/api/css-baseline.json
+++ b/docs/pages/material-ui/api/css-baseline.json
@@ -1,8 +1,5 @@
 {
-  "props": {
-    "children": { "type": { "name": "node" } },
-    "enableColorScheme": { "type": { "name": "bool" }, "default": "false" }
-  },
+  "props": { "children": { "type": { "name": "node" } } },
   "name": "CssBaseline",
   "imports": [
     "import CssBaseline from '@mui/material/CssBaseline';",

--- a/docs/translations/api-docs/css-baseline/css-baseline.json
+++ b/docs/translations/api-docs/css-baseline/css-baseline.json
@@ -1,10 +1,5 @@
 {
   "componentDescription": "Kickstart an elegant, consistent, and simple baseline to build upon.",
-  "propDescriptions": {
-    "children": { "description": "You can wrap a node." },
-    "enableColorScheme": {
-      "description": "Enable <code>color-scheme</code> CSS property to use <code>theme.palette.mode</code>. For more details, check out <a href=\"https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme\">https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme</a> For browser support, check out <a href=\"https://caniuse.com/?search=color-scheme\">https://caniuse.com/?search=color-scheme</a>"
-    }
-  },
+  "propDescriptions": { "children": { "description": "You can wrap a node." } },
   "classDescriptions": {}
 }

--- a/packages/mui-docs/src/branding/brandingTheme.ts
+++ b/packages/mui-docs/src/branding/brandingTheme.ts
@@ -1386,7 +1386,6 @@ export function getThemedComponents(): ThemeOptions {
         },
       },
       MuiCssBaseline: {
-        defaultProps: {},
         styleOverrides: {
           html: {
             overflowY: 'scroll',

--- a/packages/mui-docs/src/branding/brandingTheme.ts
+++ b/packages/mui-docs/src/branding/brandingTheme.ts
@@ -1386,9 +1386,7 @@ export function getThemedComponents(): ThemeOptions {
         },
       },
       MuiCssBaseline: {
-        defaultProps: {
-          enableColorScheme: true,
-        },
+        defaultProps: {},
         styleOverrides: {
           html: {
             overflowY: 'scroll',

--- a/packages/mui-material/src/CssBaseline/CssBaseline.d.ts
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.d.ts
@@ -6,13 +6,6 @@ export interface CssBaselineProps extends StyledComponentProps<never> {
    * You can wrap a node.
    */
   children?: React.ReactNode;
-  /**
-   * Enable `color-scheme` CSS property to use `theme.palette.mode`.
-   * For more details, check out https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
-   * For browser support, check out https://caniuse.com/?search=color-scheme
-   * @default false
-   */
-  enableColorScheme?: boolean;
 }
 
 /**

--- a/packages/mui-material/src/CssBaseline/CssBaseline.js
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.js
@@ -7,7 +7,7 @@ import { useDefaultProps } from '../DefaultPropsProvider';
 // to determine if the global styles are static or dynamic
 const isDynamicSupport = typeof globalCss({}) === 'function';
 
-export const html = (theme, enableColorScheme) => ({
+export const html = (theme) => ({
   WebkitFontSmoothing: 'antialiased', // Antialiasing.
   MozOsxFontSmoothing: 'grayscale', // Antialiasing.
   // Change from `box-sizing: content-box` so that `width`
@@ -16,7 +16,7 @@ export const html = (theme, enableColorScheme) => ({
   // Fix font resize problem in iOS
   WebkitTextSizeAdjust: '100%',
   // When used under CssVarsProvider, colorScheme should not be applied dynamically because it will generate the stylesheet twice for server-rendered applications.
-  ...(enableColorScheme && !theme.vars && { colorScheme: theme.palette.mode }),
+  ...(!theme.vars && { colorScheme: theme.palette.mode }),
 });
 
 export const body = (theme) => ({
@@ -29,9 +29,9 @@ export const body = (theme) => ({
   },
 });
 
-export const styles = (theme, enableColorScheme = false) => {
+export const styles = (theme) => {
   const colorSchemeStyles = {};
-  if (enableColorScheme && theme.colorSchemes) {
+  if (theme.colorSchemes) {
     Object.entries(theme.colorSchemes).forEach(([key, scheme]) => {
       const selector = theme.getColorSchemeSelector(key);
       if (selector.startsWith('@')) {
@@ -50,7 +50,7 @@ export const styles = (theme, enableColorScheme = false) => {
     });
   }
   let defaultStyles = {
-    html: html(theme, enableColorScheme),
+    html: html(theme),
     '*, *::before, *::after': {
       boxSizing: 'inherit',
     },
@@ -80,7 +80,7 @@ export const styles = (theme, enableColorScheme = false) => {
 // `ecs` stands for enableColorScheme. This is internal logic to make it work with Pigment CSS, so shorter is better.
 const SELECTOR = 'mui-ecs';
 const staticStyles = (theme) => {
-  const result = styles(theme, false);
+  const result = styles(theme);
   const baseStyles = Array.isArray(result) ? result[0] : result;
   if (!theme.vars && baseStyles) {
     baseStyles.html[`:root:has(${SELECTOR})`] = { colorScheme: theme.palette.mode };
@@ -109,9 +109,7 @@ const staticStyles = (theme) => {
 };
 
 const GlobalStyles = globalCss(
-  isDynamicSupport
-    ? ({ theme, enableColorScheme }) => styles(theme, enableColorScheme)
-    : ({ theme }) => staticStyles(theme),
+  isDynamicSupport ? ({ theme }) => styles(theme) : ({ theme }) => staticStyles(theme),
 );
 
 /**
@@ -119,16 +117,14 @@ const GlobalStyles = globalCss(
  */
 function CssBaseline(inProps) {
   const props = useDefaultProps({ props: inProps, name: 'MuiCssBaseline' });
-  const { children, enableColorScheme = false } = props;
+  const { children } = props;
   return (
     <React.Fragment>
       {/* Emotion */}
-      {isDynamicSupport && <GlobalStyles enableColorScheme={enableColorScheme} />}
+      {isDynamicSupport && <GlobalStyles />}
 
       {/* Pigment CSS */}
-      {!isDynamicSupport && !enableColorScheme && (
-        <span className={SELECTOR} style={{ display: 'none' }} />
-      )}
+      {!isDynamicSupport && <span className={SELECTOR} style={{ display: 'none' }} />}
 
       {children}
     </React.Fragment>
@@ -144,13 +140,6 @@ CssBaseline.propTypes /* remove-proptypes */ = {
    * You can wrap a node.
    */
   children: PropTypes.node,
-  /**
-   * Enable `color-scheme` CSS property to use `theme.palette.mode`.
-   * For more details, check out https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
-   * For browser support, check out https://caniuse.com/?search=color-scheme
-   * @default false
-   */
-  enableColorScheme: PropTypes.bool,
 };
 
 export default CssBaseline;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

issue: [[material-ui] Remove enableColorScheme prop from CssBaseline #42695](https://github.com/mui/material-ui/issues/42695)

- [x] removed associated codes.
- [x] use `pnpm proptypes && pnpm docs:api` to update doc.
- [x] remove relative content from `css-baseline.md`.
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
