### PR TITLE
Docs improvements

### DIFF
--- a/docs/data/base/components/button/button.md
+++ b/docs/data/base/components/button/button.md
@@ -97,7 +97,7 @@ Hooks _do not_ support [slot props](#custom-structure), but they do support [cus
 Hooks give you the most room for customization, but require more work to implement.
 With hooks, you can take full control over how your component is rendered, and define all the custom props and CSS classes you need.
 
-You may not need to use hooks unless you find that you're limited by the customization options of their component counterparts—for instance, if your component requires significantly different [structure](#anatomy).
+You may not need to use hooks unless you find that you're limited by the customization options of their component counterparts—for instance, if your component requires a significantly different [structure](#anatomy).
 :::
 
 The following demo shows how to build the same buttons as those found in the [Component](#component) section above, but with the `useButton` hook:

--- a/docs/data/base/components/form-control/form-control.md
+++ b/docs/data/base/components/form-control/form-control.md
@@ -72,7 +72,7 @@ Hooks _do not_ support [slot props](#custom-structure), but they do support [cus
 Hooks give you the most room for customization, but require more work to implement.
 With hooks, you can take full control over how your component is rendered, and define all the custom props and CSS classes you need.
 
-You may not need to use hooks unless you find that you're limited by the customization options of their component counterparts—for instance, if your component requires significantly different [structure](#anatomy).
+You may not need to use hooks unless you find that you're limited by the customization options of their component counterparts—for instance, if your component requires a significantly different [structure](#anatomy).
 :::
 
 The demo below shows how to integrate this hook with its component counterpart:

--- a/docs/data/base/components/modal/modal.md
+++ b/docs/data/base/components/modal/modal.md
@@ -148,7 +148,7 @@ Hooks _do not_ support [slot props](#custom-structure), but they do support [cus
 Hooks give you the most room for customization but require more work to implement.
 With hooks, you can take full control over how your component is rendered, and define all the custom props and CSS classes you need.
 
-You may not need to use hooks unless you find that you're limited by the customization options of their component counterparts—for instance, if your component requires significantly different [structure](#anatomy).
+You may not need to use hooks unless you find that you're limited by the customization options of their component counterparts—for instance, if your component requires a significantly different [structure](#anatomy).
 :::
 
 The following demo shows how to build the same Modal as the one found in the [Component](#component) section above, but with the `useModal` hook:


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.

