### PR TITLE
[codemod] Fix Divider props codemod

### DIFF
--- a/packages/mui-codemod/src/deprecations/divider-props/divider-props.js
+++ b/packages/mui-codemod/src/deprecations/divider-props/divider-props.js
@@ -12,43 +12,52 @@ export default function transformer(file, api, options) {
   const printOptions = options.printOptions;
 
   findComponentJSX(j, { root, componentName: 'Divider' }, (elementPath) => {
-    const hasLightProp =
-      elementPath.node.openingElement.attributes.findIndex(
-        (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'light',
-      ) !== -1;
+    const lightProp = elementPath.node.openingElement.attributes.find(
+      (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'light',
+    );
 
-    if (hasLightProp) {
-      elementPath.node.openingElement.attributes =
-        elementPath.node.openingElement.attributes.filter((attr) => {
-          if (attr.type === 'JSXAttribute' && attr.name.name === 'light') {
-            return false;
-          }
-          return true;
-        });
+    if (!lightProp) {
+      return;
+    }
 
-      const sxIndex = elementPath.node.openingElement.attributes.findIndex(
-        (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'sx',
-      );
-      if (sxIndex === -1) {
-        appendAttribute(j, {
-          target: elementPath.node,
-          attributeName: 'sx',
-          expression: j.objectExpression([
-            j.objectProperty(j.identifier('opacity'), j.literal('0.6')),
-          ]),
-        });
-      } else {
-        const opacityIndex = elementPath.node.openingElement.attributes[
-          sxIndex
-        ].value.expression.properties.findIndex((key) => key.key.name === 'opacity');
-
-        if (opacityIndex === -1) {
-          assignObject(j, {
-            target: elementPath.node.openingElement.attributes[sxIndex],
-            key: 'opacity',
-            expression: j.literal('0.6'),
-          });
+    elementPath.node.openingElement.attributes = elementPath.node.openingElement.attributes.filter(
+      (attr) => {
+        if (attr.type === 'JSXAttribute' && attr.name.name === 'light') {
+          return false;
         }
+        return true;
+      },
+    );
+
+    const isLightPropTruthy =
+      !!lightProp.value?.expression.value || lightProp.value?.expression.value === undefined;
+
+    if (!isLightPropTruthy) {
+      return;
+    }
+
+    const sxIndex = elementPath.node.openingElement.attributes.findIndex(
+      (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'sx',
+    );
+    if (sxIndex === -1) {
+      appendAttribute(j, {
+        target: elementPath.node,
+        attributeName: 'sx',
+        expression: j.objectExpression([
+          j.objectProperty(j.identifier('opacity'), j.literal('0.6')),
+        ]),
+      });
+    } else {
+      const opacityIndex = elementPath.node.openingElement.attributes[
+        sxIndex
+      ].value.expression.properties.findIndex((key) => key.key.name === 'opacity');
+
+      if (opacityIndex === -1) {
+        assignObject(j, {
+          target: elementPath.node.openingElement.attributes[sxIndex],
+          key: 'opacity',
+          expression: j.literal('0.6'),
+        });
       }
     }
   });
@@ -58,35 +67,40 @@ export default function transformer(file, api, options) {
       (key) => key.key.name === 'defaultProps',
     );
 
-    const hasLightProp =
-      defaultPropsObject.value.properties.findIndex((prop) => prop.key.name === 'light') !== -1;
+    const lightProp = defaultPropsObject.value.properties.find((prop) => prop.key.name === 'light');
 
-    if (hasLightProp) {
-      defaultPropsObject.value.properties = defaultPropsObject.value.properties.filter(
-        (prop) => !['light'].includes(prop?.key?.name),
+    if (!lightProp) {
+      return;
+    }
+
+    defaultPropsObject.value.properties = defaultPropsObject.value.properties.filter(
+      (prop) => !['light'].includes(prop?.key?.name),
+    );
+
+    const isLightPropTruthy = !!lightProp.value?.value || lightProp.value?.value === undefined;
+
+    if (!isLightPropTruthy) {
+      return;
+    }
+
+    const sxIndex = defaultPropsObject.value.properties.findIndex((prop) => prop.key.name === 'sx');
+
+    if (sxIndex === -1) {
+      defaultPropsObject.value.properties.push(
+        j.objectProperty(
+          j.identifier('sx'),
+          j.objectExpression([j.objectProperty(j.identifier('opacity'), j.literal('0.6'))]),
+        ),
+      );
+    } else {
+      const opacityIndex = defaultPropsObject.value.properties[sxIndex].value.properties.findIndex(
+        (key) => key.key.name === 'opacity',
       );
 
-      const sxIndex = defaultPropsObject.value.properties.findIndex(
-        (prop) => prop.key.name === 'sx',
-      );
-
-      if (sxIndex === -1) {
-        defaultPropsObject.value.properties.push(
-          j.objectProperty(
-            j.identifier('sx'),
-            j.objectExpression([j.objectProperty(j.identifier('opacity'), j.literal('0.6'))]),
-          ),
+      if (opacityIndex === -1) {
+        defaultPropsObject.value.properties[sxIndex].value.properties.push(
+          j.objectProperty(j.identifier('opacity'), j.literal('0.6')),
         );
-      } else {
-        const opacityIndex = defaultPropsObject.value.properties[
-          sxIndex
-        ].value.properties.findIndex((key) => key.key.name === 'opacity');
-
-        if (opacityIndex === -1) {
-          defaultPropsObject.value.properties[sxIndex].value.properties.push(
-            j.objectProperty(j.identifier('opacity'), j.literal('0.6')),
-          );
-        }
       }
     }
   });

--- a/packages/mui-codemod/src/deprecations/divider-props/divider-props.js
+++ b/packages/mui-codemod/src/deprecations/divider-props/divider-props.js
@@ -29,8 +29,7 @@ export default function transformer(file, api, options) {
       },
     );
 
-    const isLightPropTruthy =
-      !!lightProp.value?.expression.value || lightProp.value?.expression.value === undefined;
+    const isLightPropTruthy = lightProp.value?.expression.value !== false;
 
     if (!isLightPropTruthy) {
       return;
@@ -77,7 +76,7 @@ export default function transformer(file, api, options) {
       (prop) => !['light'].includes(prop?.key?.name),
     );
 
-    const isLightPropTruthy = !!lightProp.value?.value || lightProp.value?.value === undefined;
+    const isLightPropTruthy = lightProp.value?.value !== false;
 
     if (!isLightPropTruthy) {
       return;

--- a/packages/mui-codemod/src/deprecations/divider-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/divider-props/test-cases/expected.js
@@ -7,12 +7,8 @@ import { Divider as MyDivider } from '@mui/material';
 <MyDivider className="test" sx={{
   opacity: "0.6"
 }} />;
-<Divider className="test" sx={{
-  opacity: "0.6"
-}} />;
-<MyDivider className="test" sx={{
-  opacity: "0.6"
-}} />;
+<Divider className="test" />;
+<MyDivider className="test" />;
 <Divider className="test" sx={{
   opacity: "0.6"
 }} />;

--- a/packages/mui-codemod/src/deprecations/divider-props/test-cases/theme.actual.js
+++ b/packages/mui-codemod/src/deprecations/divider-props/test-cases/theme.actual.js
@@ -1,6 +1,21 @@
 fn({
   MuiDivider: {
     defaultProps: {
+      light: false,
+    },
+  },
+});
+fn({
+  MuiDivider: {
+    defaultProps: {
+      light: false,
+      className: 'my-class',
+    },
+  },
+});
+fn({
+  MuiDivider: {
+    defaultProps: {
       light: true,
     },
   },
@@ -21,7 +36,6 @@ fn({
     },
   },
 });
-
 fn({
   MuiDivider: {
     defaultProps: {
@@ -33,7 +47,6 @@ fn({
     },
   },
 });
-
 fn({
   MuiDivider: {
     defaultProps: {
@@ -45,7 +58,6 @@ fn({
     },
   },
 });
-
 fn({
   MuiDivider: {
     defaultProps: {

--- a/packages/mui-codemod/src/deprecations/divider-props/test-cases/theme.expected.js
+++ b/packages/mui-codemod/src/deprecations/divider-props/test-cases/theme.expected.js
@@ -1,5 +1,17 @@
 fn({
   MuiDivider: {
+    defaultProps: {},
+  },
+});
+fn({
+  MuiDivider: {
+    defaultProps: {
+      className: 'my-class'
+    },
+  },
+});
+fn({
+  MuiDivider: {
     defaultProps: {
       sx: {
         opacity: "0.6"
@@ -27,7 +39,6 @@ fn({
     },
   },
 });
-
 fn({
   MuiDivider: {
     defaultProps: {
@@ -39,7 +50,6 @@ fn({
     },
   },
 });
-
 fn({
   MuiDivider: {
     defaultProps: {
@@ -52,7 +62,6 @@ fn({
     },
   },
 });
-
 fn({
   MuiDivider: {
     defaultProps: {


### PR DESCRIPTION
The `divider-props` codemod (introduced in https://github.com/mui/material-ui/pull/40947) removes the `light` prop and adds `sx={{ opacity: 0.6 }}` if no `opacity` is already passed to the `sx` prop.

I noticed that the codemod adds the `opacity` even when `light={false}`, which seems wrong:

```js
// input
<Divider light={false} />;

// output
<Divider sx={{ opacity: "0.6" }} />;
```

The correct output should be:

```js
<Divider />;
```

This PR fixes the codemod and adds some tests cases to also cover the presence of `light: false` in the `MuiDivider.defaultProps` of the `theme` object.

---

@sai6855 let me know if my reasoning is correct.