### PR TITLE
[mui-utils] fix(utils/getScrollbarSize): fix get innerWidth in iframe

### DIFF
--- a/packages/mui-utils/src/getScrollbarSize/getScrollbarSize.ts
+++ b/packages/mui-utils/src/getScrollbarSize/getScrollbarSize.ts
@@ -3,5 +3,5 @@
 export default function getScrollbarSize(doc: Document): number {
   // https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth#usage_notes
   const documentWidth = doc.documentElement.clientWidth;
-  return Math.abs(window.innerWidth - documentWidth);
+  return Math.abs((doc.defaultView || window).innerWidth - documentWidth);
 }


### PR DESCRIPTION
Consider render mui components in iframe, get Window object should like node.ownerDocument.   
same as `packages/mui-utils/src/ownerWindow/ownerWindow.ts`