### PR TITLE
[test][material-ui] Remove unnecessary async act calls

### DIFF
--- a/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
@@ -133,7 +133,7 @@ describe('Joy <MenuItem />', () => {
 
       expect(handleKeyUp.callCount).to.equal(1);
 
-      act(() => {
+      await act(async () => {
         menuitem.blur();
       });
 

--- a/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
@@ -97,7 +97,7 @@ describe('Joy <MenuItem />', () => {
         const handler = spy();
         render(<MenuItem {...{ [handlerName]: handler }} />);
 
-        await act(async () => fireEvent[eventName](screen.getByRole('menuitem')));
+        fireEvent[eventName](screen.getByRole('menuitem'));
 
         expect(handler.callCount).to.equal(1);
       });
@@ -125,11 +125,11 @@ describe('Joy <MenuItem />', () => {
 
       expect(handleFocus.callCount).to.equal(1);
 
-      await act(async () => fireEvent.keyDown(menuitem));
+      fireEvent.keyDown(menuitem);
 
       expect(handleKeyDown.callCount).to.equal(1);
 
-      await act(async () => fireEvent.keyUp(menuitem));
+      fireEvent.keyUp(menuitem);
 
       expect(handleKeyUp.callCount).to.equal(1);
 

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -359,7 +359,7 @@ describe('<ButtonBase />', () => {
         const button = getByRole('button');
         await ripple.startTouch(button);
 
-        act(() => button.blur());
+        await act(async () => button.blur());
 
         expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(0);
         expect(
@@ -475,7 +475,7 @@ describe('<ButtonBase />', () => {
 
       it('should not crash when changes enableRipple from false to true', async () => {
         function App() {
-          /** @type {React.MutableRefObject<import('./ButtonBase').ButtonBaseActions | null>} */
+          /** @type {Re(act).MutableRefObject<import('./ButtonBase').ButtonBaseActions | null>} */
           const buttonRef = React.useRef(null);
           const [enableRipple, setRipple] = React.useState(false);
 
@@ -802,7 +802,7 @@ describe('<ButtonBase />', () => {
   });
 
   describe('event: focus', () => {
-    it('when disabled should be called onFocus', () => {
+    it('when disabled should be called onFocus', async () => {
       const onFocusSpy = spy();
       const { getByRole } = render(
         <ButtonBase component="div" disabled onFocus={onFocusSpy}>
@@ -810,14 +810,14 @@ describe('<ButtonBase />', () => {
         </ButtonBase>,
       );
 
-      act(() => {
+      await act(async () => {
         getByRole('button').focus();
       });
 
       expect(onFocusSpy.callCount).to.equal(1);
     });
 
-    it('has a focus-visible polyfill', function test() {
+    it('has a focus-visible polyfill', async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // JSDOM doesn't support :focus-visible
         this.skip();
@@ -829,7 +829,7 @@ describe('<ButtonBase />', () => {
 
       expect(button).not.to.have.class(classes.focusVisible);
 
-      act(() => {
+      await act(async () => {
         button.focus();
       });
 
@@ -1185,7 +1185,7 @@ describe('<ButtonBase />', () => {
       }
     });
 
-    it('should be able to focus visible the button', () => {
+    it('should be able to focus visible the button', async () => {
       /**
        * @type {React.RefObject<import('./ButtonBase').ButtonBaseActions>}
        */
@@ -1199,7 +1199,7 @@ describe('<ButtonBase />', () => {
       // @ts-ignore
       expect(typeof buttonActionsRef.current.focusVisible).to.equal('function');
 
-      act(() => {
+      await act(async () => {
         // @ts-ignore
         buttonActionsRef.current.focusVisible();
       });

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -202,47 +202,47 @@ describe('<ButtonBase />', () => {
       if (typeof Touch !== 'undefined') {
         const touch = new Touch({ identifier: 0, target: button, clientX: 0, clientY: 0 });
 
-        await act(async () => fireEvent.touchStart(button, { touches: [touch] }));
+        fireEvent.touchStart(button, { touches: [touch] });
         expect(onTouchStart.callCount).to.equal(1);
 
-        await act(async () => fireEvent.touchEnd(button, { touches: [touch] }));
+        fireEvent.touchEnd(button, { touches: [touch] });
         expect(onTouchEnd.callCount).to.equal(1);
       }
 
       if (canFireDragEvents) {
-        await act(async () => fireEvent.dragEnd(button));
+        fireEvent.dragEnd(button);
         expect(onDragEnd.callCount).to.equal(1);
       }
 
-      await act(async () => fireEvent.mouseDown(button));
+      fireEvent.mouseDown(button);
       expect(onMouseDown.callCount).to.equal(1);
 
-      await act(async () => fireEvent.mouseUp(button));
+      fireEvent.mouseUp(button);
       expect(onMouseUp.callCount).to.equal(1);
 
-      await act(async () => fireEvent.contextMenu(button));
+      fireEvent.contextMenu(button);
       expect(onContextMenu.callCount).to.equal(1);
 
       await user.click(button);
       expect(onClick.callCount).to.equal(1);
 
-      act(() => {
+      await act(async () => {
         button.focus();
       });
       expect(onFocus.callCount).to.equal(1);
 
-      await act(async () => fireEvent.keyDown(button));
+      fireEvent.keyDown(button);
       expect(onKeyDown.callCount).to.equal(1);
 
-      await act(async () => fireEvent.keyUp(button));
+      fireEvent.keyUp(button);
       expect(onKeyUp.callCount).to.equal(1);
 
-      act(() => {
+      await act(async () => {
         button.blur();
       });
       expect(onBlur.callCount).to.equal(1);
 
-      await act(async () => fireEvent.mouseLeave(button));
+      fireEvent.mouseLeave(button);
       expect(onMouseLeave.callCount).to.equal(1);
     });
   });
@@ -942,9 +942,7 @@ describe('<ButtonBase />', () => {
 
       await ripple.startFocus(button);
 
-      act(() => {
-        fireEvent.keyDown(button, { key: 'Enter' });
-      });
+      fireEvent.keyDown(button, { key: 'Enter' });
 
       expect(container.querySelectorAll('.ripple-visible')).to.have.lengthOf(1);
 
@@ -1007,7 +1005,7 @@ describe('<ButtonBase />', () => {
     });
 
     describe('keyboard accessibility for non interactive elements', () => {
-      it('does not call onClick when a spacebar is pressed on the element but prevents the default', () => {
+      it('does not call onClick when a spacebar is pressed on the element but prevents the default', async () => {
         const onKeyDown = spy();
         const onClickSpy = spy();
         const { getByRole } = render(
@@ -1017,11 +1015,12 @@ describe('<ButtonBase />', () => {
         );
         const button = getByRole('button');
 
-        act(() => {
+        await act(async () => {
           button.focus();
-          fireEvent.keyDown(button, {
-            key: ' ',
-          });
+        });
+
+        fireEvent.keyDown(button, {
+          key: ' ',
         });
 
         expect(onClickSpy.callCount).to.equal(0);
@@ -1029,7 +1028,7 @@ describe('<ButtonBase />', () => {
         expect(onKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
       });
 
-      it('does call onClick when a spacebar is released on the element', () => {
+      it('does call onClick when a spacebar is released on the element', async () => {
         const onClickSpy = spy();
         const { getByRole } = render(
           <ButtonBase onClick={onClickSpy} component="div">
@@ -1038,18 +1037,19 @@ describe('<ButtonBase />', () => {
         );
         const button = getByRole('button');
 
-        act(() => {
+        await act(async () => {
           button.focus();
-          fireEvent.keyUp(button, {
-            key: ' ',
-          });
+        });
+
+        fireEvent.keyUp(button, {
+          key: ' ',
         });
 
         expect(onClickSpy.callCount).to.equal(1);
         expect(onClickSpy.firstCall.args[0]).to.have.property('defaultPrevented', false);
       });
 
-      it('does not call onClick when a spacebar is released and the default is prevented', () => {
+      it('does not call onClick when a spacebar is released and the default is prevented', async () => {
         const onClickSpy = spy();
         const { getByRole } = render(
           <ButtonBase
@@ -1067,17 +1067,18 @@ describe('<ButtonBase />', () => {
         );
         const button = getByRole('button');
 
-        act(() => {
+        await act(async () => {
           button.focus();
-          fireEvent.keyUp(button, {
-            key: ' ',
-          });
+        });
+
+        fireEvent.keyUp(button, {
+          key: ' ',
         });
 
         expect(onClickSpy.callCount).to.equal(0);
       });
 
-      it('calls onClick when Enter is pressed on the element', () => {
+      it('calls onClick when Enter is pressed on the element', async () => {
         const onClickSpy = spy();
         const { getByRole } = render(
           <ButtonBase onClick={onClickSpy} component="div">
@@ -1086,11 +1087,12 @@ describe('<ButtonBase />', () => {
         );
         const button = getByRole('button');
 
-        act(() => {
+        await act(async () => {
           button.focus();
-          fireEvent.keyDown(button, {
-            key: 'Enter',
-          });
+        });
+
+        fireEvent.keyDown(button, {
+          key: 'Enter',
         });
 
         expect(onClickSpy.calledOnce).to.equal(true);
@@ -1131,7 +1133,7 @@ describe('<ButtonBase />', () => {
         expect(onClickSpy.callCount).to.equal(0);
       });
 
-      it('prevents default with an anchor and empty href', () => {
+      it('prevents default with an anchor and empty href', async () => {
         const onClickSpy = spy();
         const { getByRole } = render(
           <ButtonBase component="a" onClick={onClickSpy}>
@@ -1140,16 +1142,17 @@ describe('<ButtonBase />', () => {
         );
         const button = getByRole('button');
 
-        act(() => {
+        await act(async () => {
           button.focus();
-          fireEvent.keyDown(button, { key: 'Enter' });
         });
+
+        fireEvent.keyDown(button, { key: 'Enter' });
 
         expect(onClickSpy.calledOnce).to.equal(true);
         expect(onClickSpy.firstCall.args[0]).to.have.property('defaultPrevented', true);
       });
 
-      it('should ignore anchors with href', () => {
+      it('should ignore anchors with href', async () => {
         const onClick = spy();
         const onKeyDown = spy();
         const { getByText } = render(
@@ -1159,11 +1162,12 @@ describe('<ButtonBase />', () => {
         );
         const button = getByText('Hello');
 
-        act(() => {
+        await act(async () => {
           button.focus();
-          fireEvent.keyDown(button, {
-            key: 'Enter',
-          });
+        });
+
+        fireEvent.keyDown(button, {
+          key: 'Enter',
         });
 
         expect(onClick.callCount).to.equal(0);

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -475,7 +475,7 @@ describe('<ButtonBase />', () => {
 
       it('should not crash when changes enableRipple from false to true', async () => {
         function App() {
-          /** @type {Re(act).MutableRefObject<import('./ButtonBase').ButtonBaseActions | null>} */
+          /** @type {React.MutableRefObject<import('./ButtonBase').ButtonBaseActions | null>} */
           const buttonRef = React.useRef(null);
           const [enableRipple, setRipple] = React.useState(false);
 

--- a/packages/mui-material/src/ListItemButton/ListItemButton.test.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.test.js
@@ -68,8 +68,9 @@ describe('<ListItemButton />', () => {
       );
       const button = getByRole('button');
 
+      fireEvent.keyDown(document.activeElement || document.body, { key: 'Tab' });
+
       act(() => {
-        fireEvent.keyDown(document.activeElement || document.body, { key: 'Tab' });
         button.focus();
       });
 

--- a/packages/mui-material/src/ListItemButton/ListItemButton.test.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.test.js
@@ -62,7 +62,7 @@ describe('<ListItemButton />', () => {
       }
     });
 
-    it('should merge the class names', () => {
+    it('should merge the class names', async () => {
       const { getByRole } = render(
         <ListItemButton focusVisibleClassName="focusVisibleClassName" />,
       );
@@ -70,7 +70,7 @@ describe('<ListItemButton />', () => {
 
       fireEvent.keyDown(document.activeElement || document.body, { key: 'Tab' });
 
-      act(() => {
+      await act(async () => {
         button.focus();
       });
 

--- a/packages/mui-material/src/MenuItem/MenuItem.test.js
+++ b/packages/mui-material/src/MenuItem/MenuItem.test.js
@@ -91,11 +91,11 @@ describe('<MenuItem />', () => {
 
       expect(handleFocus.callCount).to.equal(1);
 
-      await act(async () => fireEvent.keyDown(menuitem));
+      fireEvent.keyDown(menuitem);
 
       expect(handleKeyDown.callCount).to.equal(1);
 
-      await act(async () => fireEvent.keyUp(menuitem));
+      fireEvent.keyUp(menuitem);
 
       expect(handleKeyUp.callCount).to.equal(1);
 

--- a/packages/mui-material/src/Popper/Popper.test.js
+++ b/packages/mui-material/src/Popper/Popper.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
+import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { ThemeProvider } from '@mui/system';
 import createTheme from '@mui/system/createTheme';
 import Grow from '@mui/material/Grow';
@@ -114,9 +114,7 @@ describe('<Popper />', () => {
       );
       expect(screen.getByTestId('placement')).to.have.text('bottom');
 
-      await act(async () => {
-        await popperRef.current.setOptions({ placement: 'top' });
-      });
+      await popperRef.current.setOptions({ placement: 'top' });
 
       expect(screen.getByTestId('placement')).to.have.text('bottom');
     });

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -146,14 +146,14 @@ describe('<Select />', () => {
   });
 
   [' ', 'ArrowUp', 'ArrowDown', 'Enter'].forEach((key) => {
-    it(`should open menu when pressed ${key} key on select`, () => {
+    it(`should open menu when pressed ${key} key on select`, async () => {
       render(
         <Select value="">
           <MenuItem value="">none</MenuItem>
         </Select>,
       );
       const trigger = screen.getByRole('combobox');
-      act(() => {
+      await act(async () => {
         trigger.focus();
       });
 
@@ -165,7 +165,7 @@ describe('<Select />', () => {
     });
   });
 
-  it('should pass "name" as part of the event.target for onBlur', () => {
+  it('should pass "name" as part of the event.target for onBlur', async () => {
     const handleBlur = stub().callsFake((event) => event.target.name);
     const { getByRole } = render(
       <Select onBlur={handleBlur} name="blur-testing" value="">
@@ -173,11 +173,8 @@ describe('<Select />', () => {
       </Select>,
     );
     const button = getByRole('combobox');
-    act(() => {
+    await act(async () => {
       button.focus();
-    });
-
-    act(() => {
       button.blur();
     });
 
@@ -185,7 +182,7 @@ describe('<Select />', () => {
     expect(handleBlur.firstCall.returnValue).to.equal('blur-testing');
   });
 
-  it('should call onClose when the backdrop is clicked', () => {
+  it('should call onClose when the backdrop is clicked', async () => {
     const handleClose = spy();
     const { getByTestId } = render(
       <Select
@@ -198,7 +195,7 @@ describe('<Select />', () => {
       </Select>,
     );
 
-    act(() => {
+    await act(async () => {
       getByTestId('backdrop').click();
     });
 
@@ -244,7 +241,7 @@ describe('<Select />', () => {
   });
 
   describe('prop: onChange', () => {
-    it('should get selected element from arguments', () => {
+    it('should get selected element from arguments', async () => {
       const onChangeHandler = spy();
       const { getAllByRole, getByRole } = render(
         <Select onChange={onChangeHandler} value="0">
@@ -254,7 +251,7 @@ describe('<Select />', () => {
         </Select>,
       );
       fireEvent.mouseDown(getByRole('combobox'));
-      act(() => {
+      await act(async () => {
         getAllByRole('option')[1].click();
       });
 
@@ -263,7 +260,7 @@ describe('<Select />', () => {
       expect(React.isValidElement(selected)).to.equal(true);
     });
 
-    it('should call onChange before onClose', () => {
+    it('should call onChange before onClose', async () => {
       const eventLog = [];
       const onChangeHandler = spy(() => eventLog.push('CHANGE_EVENT'));
       const onCloseHandler = spy(() => eventLog.push('CLOSE_EVENT'));
@@ -275,14 +272,14 @@ describe('<Select />', () => {
       );
 
       fireEvent.mouseDown(getByRole('combobox'));
-      act(() => {
+      await act(async () => {
         getAllByRole('option')[1].click();
       });
 
       expect(eventLog).to.deep.equal(['CHANGE_EVENT', 'CLOSE_EVENT']);
     });
 
-    it('should not be called if selected element has the current value (value did not change)', () => {
+    it('should not be called if selected element has the current value (value did not change)', async () => {
       const onChangeHandler = spy();
       const { getAllByRole, getByRole } = render(
         <Select onChange={onChangeHandler} value="1">
@@ -292,7 +289,7 @@ describe('<Select />', () => {
         </Select>,
       );
       fireEvent.mouseDown(getByRole('combobox'));
-      act(() => {
+      await act(async () => {
         getAllByRole('option')[1].click();
       });
 
@@ -480,10 +477,10 @@ describe('<Select />', () => {
       expect(getByRole('combobox', { hidden: true })).to.have.attribute('aria-controls', listboxId);
     });
 
-    specify('the listbox is focusable', () => {
+    specify('the listbox is focusable', async () => {
       const { getByRole } = render(<Select open value="" />);
 
-      act(() => {
+      await act(async () => {
         getByRole('listbox').focus();
       });
 
@@ -530,11 +527,9 @@ describe('<Select />', () => {
         const options = getAllByRole('option');
         expect(options[1]).to.have.attribute('tabindex', '0');
 
-        act(() => {
-          fireEvent.keyDown(options[1], { key: 'ArrowDown' });
-          fireEvent.keyDown(options[2], { key: 'ArrowDown' });
-          fireEvent.keyDown(options[4], { key: 'Enter' });
-        });
+        fireEvent.keyDown(options[1], { key: 'ArrowDown' });
+        fireEvent.keyDown(options[2], { key: 'ArrowDown' });
+        fireEvent.keyDown(options[4], { key: 'Enter' });
 
         expect(options[4]).to.have.attribute('aria-selected', 'true');
       });
@@ -556,11 +551,9 @@ describe('<Select />', () => {
           const options = getAllByRole('option');
           expect(options[2]).to.have.attribute('tabindex', '0');
 
-          act(() => {
-            fireEvent.keyDown(options[2], { key: 'ArrowDown' });
-            fireEvent.keyDown(options[3], { key: 'ArrowDown' });
-            fireEvent.keyDown(options[5], { key: 'Enter' });
-          });
+          fireEvent.keyDown(options[2], { key: 'ArrowDown' });
+          fireEvent.keyDown(options[3], { key: 'ArrowDown' });
+          fireEvent.keyDown(options[5], { key: 'Enter' });
 
           expect(options[5]).to.have.attribute('aria-selected', 'true');
         });
@@ -583,11 +576,9 @@ describe('<Select />', () => {
           const options = getAllByRole('option');
           expect(options[1]).to.have.attribute('tabindex', '0');
 
-          act(() => {
-            fireEvent.keyDown(options[1], { key: 'ArrowDown' });
-            fireEvent.keyDown(options[2], { key: 'ArrowDown' });
-            fireEvent.keyDown(options[4], { key: 'Enter' });
-          });
+          fireEvent.keyDown(options[1], { key: 'ArrowDown' });
+          fireEvent.keyDown(options[2], { key: 'ArrowDown' });
+          fireEvent.keyDown(options[4], { key: 'Enter' });
 
           expect(options[4]).to.have.attribute('aria-selected', 'true');
         });
@@ -611,11 +602,9 @@ describe('<Select />', () => {
             const options = getAllByRole('option');
             expect(options[1]).to.have.attribute('tabindex', '0');
 
-            act(() => {
-              fireEvent.keyDown(options[1], { key: 'ArrowDown' });
-              fireEvent.keyDown(options[2], { key: 'ArrowDown' });
-              fireEvent.keyDown(options[4], { key: 'Enter' });
-            });
+            fireEvent.keyDown(options[1], { key: 'ArrowDown' });
+            fireEvent.keyDown(options[2], { key: 'ArrowDown' });
+            fireEvent.keyDown(options[4], { key: 'Enter' });
 
             expect(options[4]).to.have.attribute('aria-selected', 'true');
           });
@@ -691,11 +680,9 @@ describe('<Select />', () => {
         const options = getAllByRole('option');
         expect(options[2]).to.have.attribute('tabindex', '0');
 
-        act(() => {
-          fireEvent.keyDown(options[2], { key: 'ArrowDown' });
-          fireEvent.keyDown(options[3], { key: 'ArrowDown' });
-          fireEvent.keyDown(options[5], { key: 'Enter' });
-        });
+        fireEvent.keyDown(options[2], { key: 'ArrowDown' });
+        fireEvent.keyDown(options[3], { key: 'ArrowDown' });
+        fireEvent.keyDown(options[5], { key: 'Enter' });
 
         expect(options[5]).to.have.attribute('aria-selected', 'true');
       });
@@ -785,7 +772,7 @@ describe('<Select />', () => {
   });
 
   describe('prop: readOnly', () => {
-    it('should not trigger any event with readOnly', () => {
+    it('should not trigger any event with readOnly', async () => {
       render(
         <Select readOnly value="10">
           <MenuItem value={10}>Ten</MenuItem>
@@ -793,7 +780,7 @@ describe('<Select />', () => {
         </Select>,
       );
       const trigger = screen.getByRole('combobox');
-      act(() => {
+      await act(async () => {
         trigger.focus();
       });
 
@@ -941,7 +928,7 @@ describe('<Select />', () => {
   });
 
   describe('prop: open (controlled)', () => {
-    it('should not focus on close controlled select', () => {
+    it('should not focus on close controlled select', async () => {
       function ControlledWrapper() {
         const [open, setOpen] = React.useState(false);
 
@@ -963,7 +950,7 @@ describe('<Select />', () => {
       }
       const { container, getByRole } = render(<ControlledWrapper />);
       const openSelect = container.querySelector('#open-select');
-      act(() => {
+      await act(async () => {
         openSelect.focus();
       });
       fireEvent.click(openSelect);
@@ -976,7 +963,7 @@ describe('<Select />', () => {
       expect(openSelect).toHaveFocus();
     });
 
-    it('should allow to control closing by passing onClose props', () => {
+    it('should allow to control closing by passing onClose props', async () => {
       function ControlledWrapper() {
         const [open, setOpen] = React.useState(false);
 
@@ -997,7 +984,7 @@ describe('<Select />', () => {
       fireEvent.mouseDown(getByRole('combobox'));
       expect(getByRole('listbox')).not.to.equal(null);
 
-      act(() => {
+      await act(async () => {
         getByRole('option').click();
       });
       // react-transition-group uses one extra commit for exit to completely remove
@@ -1200,7 +1187,7 @@ describe('<Select />', () => {
     });
 
     describe('prop: onChange', () => {
-      it('should call onChange when clicking an item', () => {
+      it('should call onChange when clicking an item', async () => {
         function ControlledSelectInput(props) {
           const { onChange } = props;
           const [values, clickedValue] = React.useReducer((currentValues, valueClicked) => {
@@ -1240,7 +1227,7 @@ describe('<Select />', () => {
         expect(onChange.callCount).to.equal(1);
         expect(onChange.firstCall.returnValue).to.deep.equal({ name: 'age', value: [30] });
 
-        act(() => {
+        await act(async () => {
           options[0].click();
         });
 
@@ -1333,11 +1320,11 @@ describe('<Select />', () => {
 
     // TODO: This might be confusing a prop called input!Ref can imperatively
     // focus a button. This implies <input type="button" /> is still used.
-    it('should be able focus the trigger imperatively', () => {
+    it('should be able focus the trigger imperatively', async () => {
       const ref = React.createRef();
       const { getByRole } = render(<Select inputRef={ref} value="" />);
 
-      act(() => {
+      await act(async () => {
         ref.current.focus();
       });
 
@@ -1574,7 +1561,7 @@ describe('<Select />', () => {
   });
 
   describe('form submission', () => {
-    it('includes Select value in formData only if the `name` attribute is provided', function test() {
+    it('includes Select value in formData only if the `name` attribute is provided', async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // FormData is not available in JSDOM
         this.skip();
@@ -1603,7 +1590,7 @@ describe('<Select />', () => {
       );
 
       const button = getByText('Submit');
-      act(() => {
+      await act(async () => {
         button.click();
       });
     });

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -116,14 +116,15 @@ describe('<Select />', () => {
     );
     const trigger = getByRole('combobox');
 
-    await act(async () => fireEvent.mouseDown(trigger));
+    fireEvent.mouseDown(trigger);
 
     expect(handleBlur.callCount).to.equal(0);
     expect(getByRole('listbox')).not.to.equal(null);
 
+    const options = getAllByRole('option');
+    fireEvent.mouseDown(options[0]);
+
     await act(async () => {
-      const options = getAllByRole('option');
-      fireEvent.mouseDown(options[0]);
       options[0].click();
     });
 

--- a/packages/mui-material/src/SpeedDial/SpeedDial.test.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.test.js
@@ -123,11 +123,15 @@ describe('<SpeedDial />', () => {
         </SpeedDial>,
       );
       const buttonWrapper = getByRole('button', { expanded: true });
+
+      fireEvent.keyDown(document.body, { key: 'TAB' });
+
       await act(async () => {
-        fireEvent.keyDown(document.body, { key: 'TAB' });
         buttonWrapper.focus();
-        fireEvent.keyDown(buttonWrapper, { key: ' ' });
       });
+
+      fireEvent.keyDown(buttonWrapper, { key: ' ' });
+
       expect(handleKeyDown.callCount).to.equal(1);
       expect(handleKeyDown.args[0][0]).to.have.property('key', ' ');
     });
@@ -190,7 +194,7 @@ describe('<SpeedDial />', () => {
       expect(handleOpen.callCount).to.equal(1);
       const actions = getAllByRole('menuitem');
       expect(actions.length).to.equal(2);
-      await act(async () => fireEvent.keyDown(fab, { key: 'ArrowUp' }));
+      fireEvent.keyDown(fab, { key: 'ArrowUp' });
       expect(document.activeElement).to.equal(actions[0]);
       expect(fab).to.have.attribute('aria-expanded', 'true');
     });
@@ -218,11 +222,11 @@ describe('<SpeedDial />', () => {
 
       expect(fab).to.have.attribute('aria-expanded', 'true');
 
-      await act(async () => fireEvent.keyDown(fab, { key: 'ArrowUp' }));
+      fireEvent.keyDown(fab, { key: 'ArrowUp' });
       clock.runAll();
       expect(queryByRole('tooltip')).not.to.equal(null);
 
-      await act(async () => fireDiscreteEvent.keyDown(actions[0], { key: 'Escape' }));
+      fireDiscreteEvent.keyDown(actions[0], { key: 'Escape' });
       clock.runAll();
 
       expect(queryByRole('tooltip')).to.equal(null);
@@ -312,13 +316,13 @@ describe('<SpeedDial />', () => {
 
     it('considers arrow keys with the same initial orientation', async () => {
       await renderSpeedDial();
-      await act(async () => fireEvent.keyDown(fabButton, { key: 'left' }));
+      fireEvent.keyDown(fabButton, { key: 'left' });
       expect(isActionFocused(0)).to.equal(true);
-      await act(async () => fireEvent.keyDown(getActionButton(0), { key: 'up' }));
+      fireEvent.keyDown(getActionButton(0), { key: 'up' });
       expect(isActionFocused(0)).to.equal(true);
-      await act(async () => fireEvent.keyDown(getActionButton(0), { key: 'left' }));
+      fireEvent.keyDown(getActionButton(0), { key: 'left' });
       expect(isActionFocused(1)).to.equal(true);
-      await act(async () => fireEvent.keyDown(getActionButton(1), { key: 'right' }));
+      fireEvent.keyDown(getActionButton(1), { key: 'right' });
       expect(isActionFocused(0)).to.equal(true);
     });
 
@@ -333,7 +337,7 @@ describe('<SpeedDial />', () => {
 
           await renderSpeedDial(dialDirection);
 
-          await act(async () => fireEvent.keyDown(fabButton, { key: firstKey }));
+          fireEvent.keyDown(fabButton, { key: firstKey });
           expect(isActionFocused(firstFocusedAction)).to.equal(
             true,
             `focused action initial ${firstKey} should be ${firstFocusedAction}`,

--- a/packages/mui-material/src/SpeedDial/SpeedDial.test.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.test.js
@@ -349,7 +349,6 @@ describe('<SpeedDial />', () => {
             const expectedFocusedAction = foci[i];
             const combinationUntilNot = [firstKey, ...combination.slice(0, i + 1)];
 
-            // eslint-disable-next-line no-await-in-loop
             fireEvent.keyDown(getActionButton(previousFocusedAction), {
               key: arrowKey,
             });

--- a/packages/mui-material/src/SpeedDial/SpeedDial.test.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.test.js
@@ -350,11 +350,9 @@ describe('<SpeedDial />', () => {
             const combinationUntilNot = [firstKey, ...combination.slice(0, i + 1)];
 
             // eslint-disable-next-line no-await-in-loop
-            await act(async () =>
-              fireEvent.keyDown(getActionButton(previousFocusedAction), {
-                key: arrowKey,
-              }),
-            );
+            fireEvent.keyDown(getActionButton(previousFocusedAction), {
+              key: arrowKey,
+            });
             expect(isActionFocused(expectedFocusedAction)).to.equal(
               true,
               `focused action after ${combinationUntilNot.join(

--- a/packages/mui-material/src/Tabs/Tabs.test.js
+++ b/packages/mui-material/src/Tabs/Tabs.test.js
@@ -933,7 +933,7 @@ describe('<Tabs />', () => {
               firstTab.focus();
             });
 
-            await act(async () => fireEvent.keyDown(firstTab, { key: previousItemKey }));
+            fireEvent.keyDown(firstTab, { key: previousItemKey });
 
             expect(lastTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(0);
@@ -963,7 +963,7 @@ describe('<Tabs />', () => {
               firstTab.focus();
             });
 
-            await act(async () => fireEvent.keyDown(firstTab, { key: previousItemKey }));
+            fireEvent.keyDown(firstTab, { key: previousItemKey });
 
             expect(lastTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(1);
@@ -993,7 +993,7 @@ describe('<Tabs />', () => {
               secondTab.focus();
             });
 
-            await act(async () => fireEvent.keyDown(secondTab, { key: previousItemKey }));
+            fireEvent.keyDown(secondTab, { key: previousItemKey });
 
             expect(firstTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(0);
@@ -1023,7 +1023,7 @@ describe('<Tabs />', () => {
               secondTab.focus();
             });
 
-            await act(async () => fireEvent.keyDown(secondTab, { key: previousItemKey }));
+            fireEvent.keyDown(secondTab, { key: previousItemKey });
 
             expect(firstTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(1);
@@ -1052,7 +1052,7 @@ describe('<Tabs />', () => {
               lastTab.focus();
             });
 
-            await act(async () => fireEvent.keyDown(lastTab, { key: previousItemKey }));
+            fireEvent.keyDown(lastTab, { key: previousItemKey });
 
             expect(firstTab).toHaveFocus();
             expect(handleKeyDown.callCount).to.equal(1);
@@ -1082,7 +1082,7 @@ describe('<Tabs />', () => {
               lastTab.focus();
             });
 
-            await act(async () => fireEvent.keyDown(lastTab, { key: nextItemKey }));
+            fireEvent.keyDown(lastTab, { key: nextItemKey });
 
             expect(firstTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(0);
@@ -1112,7 +1112,7 @@ describe('<Tabs />', () => {
               lastTab.focus();
             });
 
-            await act(async () => fireEvent.keyDown(lastTab, { key: nextItemKey }));
+            fireEvent.keyDown(lastTab, { key: nextItemKey });
 
             expect(firstTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(1);
@@ -1142,7 +1142,7 @@ describe('<Tabs />', () => {
               secondTab.focus();
             });
 
-            await act(async () => fireEvent.keyDown(secondTab, { key: nextItemKey }));
+            fireEvent.keyDown(secondTab, { key: nextItemKey });
 
             expect(lastTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(0);
@@ -1172,7 +1172,7 @@ describe('<Tabs />', () => {
               secondTab.focus();
             });
 
-            await act(async () => fireEvent.keyDown(secondTab, { key: nextItemKey }));
+            fireEvent.keyDown(secondTab, { key: nextItemKey });
 
             expect(lastTab).toHaveFocus();
             expect(handleChange.callCount).to.equal(1);
@@ -1201,7 +1201,7 @@ describe('<Tabs />', () => {
               firstTab.focus();
             });
 
-            await act(async () => fireEvent.keyDown(firstTab, { key: nextItemKey }));
+            fireEvent.keyDown(firstTab, { key: nextItemKey });
 
             expect(lastTab).toHaveFocus();
             expect(handleKeyDown.callCount).to.equal(1);
@@ -1228,7 +1228,7 @@ describe('<Tabs />', () => {
             lastTab.focus();
           });
 
-          await act(async () => fireEvent.keyDown(lastTab, { key: 'Home' }));
+          fireEvent.keyDown(lastTab, { key: 'Home' });
 
           expect(firstTab).toHaveFocus();
           expect(handleChange.callCount).to.equal(0);
@@ -1251,7 +1251,7 @@ describe('<Tabs />', () => {
             lastTab.focus();
           });
 
-          await act(async () => fireEvent.keyDown(lastTab, { key: 'Home' }));
+          fireEvent.keyDown(lastTab, { key: 'Home' });
 
           expect(firstTab).toHaveFocus();
           expect(handleChange.callCount).to.equal(1);
@@ -1274,7 +1274,7 @@ describe('<Tabs />', () => {
             lastTab.focus();
           });
 
-          await act(async () => fireEvent.keyDown(lastTab, { key: 'Home' }));
+          fireEvent.keyDown(lastTab, { key: 'Home' });
 
           expect(secondTab).toHaveFocus();
           expect(handleKeyDown.callCount).to.equal(1);
@@ -1298,7 +1298,7 @@ describe('<Tabs />', () => {
             firstTab.focus();
           });
 
-          await act(async () => fireEvent.keyDown(firstTab, { key: 'End' }));
+          fireEvent.keyDown(firstTab, { key: 'End' });
 
           expect(lastTab).toHaveFocus();
           expect(handleChange.callCount).to.equal(0);
@@ -1321,7 +1321,7 @@ describe('<Tabs />', () => {
             firstTab.focus();
           });
 
-          await act(async () => fireEvent.keyDown(firstTab, { key: 'End' }));
+          fireEvent.keyDown(firstTab, { key: 'End' });
 
           expect(lastTab).toHaveFocus();
           expect(handleChange.callCount).to.equal(1);
@@ -1344,7 +1344,7 @@ describe('<Tabs />', () => {
             firstTab.focus();
           });
 
-          await act(async () => fireEvent.keyDown(firstTab, { key: 'End' }));
+          fireEvent.keyDown(firstTab, { key: 'End' });
 
           expect(secondTab).toHaveFocus();
           expect(handleKeyDown.callCount).to.equal(1);

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -414,7 +414,7 @@ describe('<Tooltip />', () => {
       expect(screen.queryByRole('tooltip')).to.equal(null);
     });
 
-    it('should open on long press', () => {
+    it('should open on long press', async () => {
       const enterTouchDelay = 700;
       const enterDelay = 100;
       const leaveTouchDelay = 1500;
@@ -436,7 +436,7 @@ describe('<Tooltip />', () => {
       expect(screen.getByRole('tooltip')).toBeVisible();
 
       fireEvent.touchEnd(screen.getByRole('button'));
-      act(() => {
+      await act(async () => {
         screen.getByRole('button').blur();
       });
       clock.tick(leaveTouchDelay);
@@ -530,7 +530,7 @@ describe('<Tooltip />', () => {
       expect(screen.getByRole('tooltip')).toBeVisible();
     });
 
-    it('should use hysteresis with the enterDelay', () => {
+    it('should use hysteresis with the enterDelay', async () => {
       render(
         <Tooltip
           title="Hello World"
@@ -553,7 +553,7 @@ describe('<Tooltip />', () => {
 
       expect(screen.getByRole('tooltip')).toBeVisible();
 
-      act(() => {
+      await act(async () => {
         document.activeElement.blur();
       });
       clock.tick(5);
@@ -565,14 +565,14 @@ describe('<Tooltip />', () => {
       // Bypass `enterDelay` wait, use `enterNextDelay`.
       expect(screen.queryByRole('tooltip')).to.equal(null);
 
-      act(() => {
+      await act(async () => {
         clock.tick(30);
       });
 
       expect(screen.getByRole('tooltip')).toBeVisible();
     });
 
-    it('should take the leaveDelay into account', () => {
+    it('should take the leaveDelay into account', async () => {
       const leaveDelay = 111;
       const enterDelay = 0;
       const transitionTimeout = 10;
@@ -595,7 +595,7 @@ describe('<Tooltip />', () => {
 
       expect(screen.getByRole('tooltip')).toBeVisible();
 
-      act(() => {
+      await act(async () => {
         screen.getByRole('button').blur();
       });
 
@@ -632,7 +632,7 @@ describe('<Tooltip />', () => {
       });
     });
 
-    it(`should be transparent for the focus and blur event`, function test() {
+    it(`should be transparent for the focus and blur event`, async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // JSDOM doesn't support :focus-visible
         this.skip();
@@ -649,14 +649,14 @@ describe('<Tooltip />', () => {
       );
       const button = screen.getByRole('button');
 
-      act(() => {
+      await act(async () => {
         button.focus();
       });
 
       expect(handleBlur.callCount).to.equal(0);
       expect(handleFocus.callCount).to.equal(1);
 
-      act(() => {
+      await act(async () => {
         button.blur();
       });
 
@@ -890,7 +890,7 @@ describe('<Tooltip />', () => {
       }
     });
 
-    it('ignores base focus', () => {
+    it('ignores base focus', async () => {
       render(
         <Tooltip enterDelay={0} title="Some information">
           <button />
@@ -900,7 +900,7 @@ describe('<Tooltip />', () => {
 
       expect(screen.queryByRole('tooltip')).to.equal(null);
 
-      act(() => {
+      await act(async () => {
         screen.getByRole('button').focus();
       });
 
@@ -928,7 +928,7 @@ describe('<Tooltip />', () => {
       expect(eventLog).to.deep.equal(['focus', 'open']);
     });
 
-    it('closes on blur', () => {
+    it('closes on blur', async () => {
       const eventLog = [];
       const transitionTimeout = 0;
       render(
@@ -945,10 +945,10 @@ describe('<Tooltip />', () => {
       );
       const button = screen.getByRole('button');
 
-      act(() => {
+      await act(async () => {
         button.focus();
       });
-      act(() => {
+      await act(async () => {
         button.blur();
       });
       clock.tick(transitionTimeout);
@@ -958,7 +958,7 @@ describe('<Tooltip />', () => {
     });
 
     // https://github.com/mui/material-ui/issues/19883
-    it('should not prevent event handlers of children', () => {
+    it('should not prevent event handlers of children', async () => {
       const handleFocus = spy((event) => event.currentTarget);
       // Tooltip should not assume that event handlers of children are attached to the
       // outermost host
@@ -977,7 +977,7 @@ describe('<Tooltip />', () => {
       );
       const input = screen.getByRole('textbox');
 
-      act(() => {
+      await act(async () => {
         input.focus();
       });
 
@@ -987,7 +987,7 @@ describe('<Tooltip />', () => {
     });
 
     // https://github.com/mui/mui-x/issues/12248
-    it('should support event handlers with extra parameters', () => {
+    it('should support event handlers with extra parameters', async () => {
       const handleFocus = spy((event, extra) => extra);
       const handleBlur = spy((event, ...params) => params);
 
@@ -1010,14 +1010,14 @@ describe('<Tooltip />', () => {
       );
       const input = screen.getByRole('textbox');
 
-      act(() => {
+      await act(async () => {
         input.focus();
       });
 
       expect(handleFocus.callCount).to.equal(1);
       expect(handleFocus.returnValues[0]).to.equal('focus');
 
-      act(() => {
+      await act(async () => {
         input.blur();
       });
 

--- a/packages/mui-material/test/integration/Menu.test.js
+++ b/packages/mui-material/test/integration/Menu.test.js
@@ -330,9 +330,8 @@ describe('<Menu /> integration', () => {
     await act(async () => {
       button.focus();
       button.click();
+      getByTestId('Backdrop').click();
     });
-
-    await act(async () => getByTestId('Backdrop').click());
 
     expect(getByRole('menu', { hidden: true })).toBeInaccessible();
   });

--- a/packages/mui-material/test/integration/Menu.test.js
+++ b/packages/mui-material/test/integration/Menu.test.js
@@ -105,22 +105,22 @@ describe('<Menu /> integration', () => {
     });
     const menuitems = getAllByRole('menuitem');
 
-    await act(async () => fireEvent.keyDown(menuitems[0], { key: 'ArrowDown' }));
+    fireEvent.keyDown(menuitems[0], { key: 'ArrowDown' });
     expect(menuitems[1]).toHaveFocus();
 
-    await act(async () => fireEvent.keyDown(menuitems[1], { key: 'ArrowUp' }));
+    fireEvent.keyDown(menuitems[1], { key: 'ArrowUp' });
     expect(menuitems[0]).toHaveFocus();
 
-    await act(async () => fireEvent.keyDown(menuitems[0], { key: 'ArrowUp' }));
+    fireEvent.keyDown(menuitems[0], { key: 'ArrowUp' });
     expect(menuitems[2]).toHaveFocus();
 
-    await act(async () => fireEvent.keyDown(menuitems[2], { key: 'Home' }));
+    fireEvent.keyDown(menuitems[2], { key: 'Home' });
     expect(menuitems[0]).toHaveFocus();
 
-    await act(async () => fireEvent.keyDown(menuitems[0], { key: 'End' }));
+    fireEvent.keyDown(menuitems[0], { key: 'End' });
     expect(menuitems[2]).toHaveFocus();
 
-    await act(async () => fireEvent.keyDown(menuitems[2], { key: 'ArrowRight' }));
+    fireEvent.keyDown(menuitems[2], { key: 'ArrowRight' });
     expect(menuitems[2], 'no change on unassociated keys').toHaveFocus();
   });
 
@@ -318,7 +318,7 @@ describe('<Menu /> integration', () => {
     });
 
     // react-transition-group uses one commit per state transition so we need to wait a bit
-    await act(async () => fireEvent.keyDown(screen.getAllByRole('menuitem')[0], { key: 'Tab' }));
+    fireEvent.keyDown(screen.getAllByRole('menuitem')[0], { key: 'Tab' });
     clock.tick(0);
 
     expect(screen.getByRole('menu', { hidden: true })).toBeInaccessible();


### PR DESCRIPTION
We're working on adopting [`eslint-plugin-testing-library`](https://github.com/testing-library/eslint-plugin-testing-library/tree/main) ([issue](https://github.com/mui/mui-public/issues/173)) and it errors when it finds unnecessary `act` calls wrapping Testing Library helpers like `fireEvent`, because these helpers already call `act` for us.

This PR removes unnecessary `act` calls from several test suites, making the code follow the "rules" of Testing Library and thus removing the ESLint errors. Also adds `await` / `async` to `act` calls in the modified files as recommended in the React [docs](https://react.dev/reference/react/act#await-act-async-actfn).

Context: https://github.com/mui/material-ui/pull/41061#discussion_r1677741979

(Thanks @Janpot for the tip!)