### PR TITLE
[core] Expose missing screen methods from Testing Library

### DIFF
--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -14,6 +14,8 @@ import {
   prettyDOM,
   within,
   RenderResult,
+  screen as rtlScreen,
+  Screen,
 } from '@testing-library/react/pure';
 import { userEvent } from '@testing-library/user-event';
 import { useFakeTimers } from 'sinon';
@@ -735,6 +737,8 @@ function act<T>(callback: () => void | T | Promise<T>) {
   return traceSync('act', () => rtlAct(callback));
 }
 
+const bodyBoundQueries = within(document.body, { ...queries, ...customQueries });
+
 export * from '@testing-library/react/pure';
 export { act, cleanup, fireEvent };
-export const screen = within(document.body, { ...queries, ...customQueries });
+export const screen: Screen = { ...rtlScreen, ...bodyBoundQueries };


### PR DESCRIPTION
I found myself missing [`screen.debug()`](https://testing-library.com/docs/dom-testing-library/api-debugging/#screendebug) and [`screen.logTestingPlaygroundURL()`](https://testing-library.com/docs/dom-testing-library/api-debugging/#screenlogtestingplaygroundurl) while writing tests using `@testing-library/react`. These methods are not available because we don't export the `screen` object from `@testing-library/react` in `packages-internal/test-utils`, we create our own `screen` object with queries bound to it. See https://github.com/mui/material-ui/blob/68381cf3b76d5752b5565e50be788dd912ee5a53/packages-internal/test-utils/src/createRenderer.tsx#L740

This PR exposes all original methods coming from the `screen` object from `@testing-library/react`.

This is useful so devs can write:

```js
screen.debug()
```

instead of needing to destructure the `render` result:

```js
const { debug } = render(...);

debug()
```

Note that using `screen` instead of destructuring the `render` result is the [recommended](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/prefer-screen-queries.md) way of writing queries by Testing Library.

