### PR TITLE
[material-ui][breadcrumbs] add support to override onClick handler for slot elements.

### DIFF
--- a/docs/data/material/components/breadcrumbs/CondensedWithMenu.js
+++ b/docs/data/material/components/breadcrumbs/CondensedWithMenu.js
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import Button from '@mui/material/Button';
+import Link from '@mui/material/Link';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+
+export default function CondensedWithMenu() {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event) => {
+    if (event) {
+      setAnchorEl(event.currentTarget);
+    }
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <React.Fragment>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="with-menu-demo-breadcrumbs"
+      >
+        <MenuItem onClick={handleClose}>Breadcrumb 2</MenuItem>
+        <MenuItem onClick={handleClose}>Breadcrumb 3</MenuItem>
+        <MenuItem onClick={handleClose}>Breadcrumb 4</MenuItem>
+      </Menu>
+      <Breadcrumbs aria-label="breadcrumbs">
+        <Link color="primary" href="#condensed-with-menu">
+          Breadcrumb 1
+        </Link>
+        <Button
+          size="small"
+          onClick={handleClick}
+          variant="outlined"
+          color="primary"
+        >
+          •••
+        </Button>
+        <Link color="primary" href="#condensed-with-menu">
+          Breadcrumb 5
+        </Link>
+        <Link color="primary" href="#condensed-with-menu">
+          Breadcrumb 6
+        </Link>
+      </Breadcrumbs>
+    </React.Fragment>
+  );
+}

--- a/docs/data/material/components/breadcrumbs/CondensedWithMenu.tsx
+++ b/docs/data/material/components/breadcrumbs/CondensedWithMenu.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import Button from '@mui/material/Button';
+import Link from '@mui/material/Link';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+
+export default function CondensedWithMenu() {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement> | null) => {
+    if (event) {
+      setAnchorEl(event.currentTarget);
+    }
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <React.Fragment>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="with-menu-demo-breadcrumbs"
+      >
+        <MenuItem onClick={handleClose}>Breadcrumb 2</MenuItem>
+        <MenuItem onClick={handleClose}>Breadcrumb 3</MenuItem>
+        <MenuItem onClick={handleClose}>Breadcrumb 4</MenuItem>
+      </Menu>
+      <Breadcrumbs aria-label="breadcrumbs">
+        <Link color="primary" href="#condensed-with-menu">
+          Breadcrumb 1
+        </Link>
+        <Button
+          size="small"
+          onClick={handleClick}
+          variant="outlined"
+          color="primary"
+        >
+          •••
+        </Button>
+        <Link color="primary" href="#condensed-with-menu">
+          Breadcrumb 5
+        </Link>
+        <Link color="primary" href="#condensed-with-menu">
+          Breadcrumb 6
+        </Link>
+      </Breadcrumbs>
+    </React.Fragment>
+  );
+}

--- a/docs/data/material/components/breadcrumbs/breadcrumbs.md
+++ b/docs/data/material/components/breadcrumbs/breadcrumbs.md
@@ -36,6 +36,12 @@ In the following examples, we are using two string separators and an SVG icon.
 
 {{"demo": "CollapsedBreadcrumbs.js"}}
 
+## Condensed with menu
+
+As an alternative, consider adding a Menu component to display the condensed links in a dropdown list:
+
+{{"demo": "CondensedWithMenu.js"}}
+
 ## Customization
 
 Here is an example of customizing the component.

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
@@ -152,7 +152,7 @@ const Breadcrumbs = React.forwardRef(function Breadcrumbs(inProps, ref) {
         key="ellipsis"
         slots={{ CollapsedIcon: slots.CollapsedIcon }}
         slotProps={{ collapsedIcon: collapsedIconSlotProps }}
-        onClick={handleClickExpand}
+        onClick={collapsedIconSlotProps.onClick || handleClickExpand}
       />,
       ...allItems.slice(allItems.length - itemsAfterCollapse, allItems.length),
     ];


### PR DESCRIPTION
Fixes #42597


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
