### PR TITLE
[code-infra] Export `rtlUserEvent` from `@mui/internal-test-utils`

### DIFF
--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -17,7 +17,7 @@ import {
   screen as rtlScreen,
   Screen,
 } from '@testing-library/react/pure';
-import { userEvent } from '@testing-library/user-event';
+import { userEvent as rtlUserEvent } from '@testing-library/user-event';
 import { useFakeTimers } from 'sinon';
 
 interface Interaction {
@@ -271,7 +271,7 @@ interface ServerRenderConfiguration extends RenderConfiguration {
 export type RenderOptions = Partial<RenderConfiguration>;
 
 export interface MuiRenderResult extends RenderResult<typeof queries & typeof customQueries> {
-  user: ReturnType<typeof userEvent.setup>;
+  user: ReturnType<typeof rtlUserEvent.setup>;
   forceUpdate(): void;
   /**
    * convenience helper. Better than repeating all props.
@@ -300,7 +300,7 @@ function render(
   );
   const result: MuiRenderResult = {
     ...testingLibraryRenderResult,
-    user: userEvent.setup(),
+    user: rtlUserEvent.setup(),
     forceUpdate() {
       traceSync('forceUpdate', () =>
         testingLibraryRenderResult.rerender(
@@ -740,5 +740,5 @@ function act<T>(callback: () => void | T | Promise<T>) {
 const bodyBoundQueries = within(document.body, { ...queries, ...customQueries });
 
 export * from '@testing-library/react/pure';
-export { act, cleanup, fireEvent };
+export { act, cleanup, fireEvent, rtlUserEvent };
 export const screen: Screen = { ...rtlScreen, ...bodyBoundQueries };


### PR DESCRIPTION
Export `userEvent` from `@testting-library/user-event` from `@mui/internal-test-utils` (createRenderer) to allow for external setup before rendering.
The need for this has been brought to light after seeing this:
https://github.com/mui/mui-x/pull/13860/files#diff-8aa6298bf92e4f4db9af052e311cc939fc5ff10e9387b1a51479c71a92230661