### PR TITLE
[docs-infra] Remove `display: flex` from `SectionTitle`

### DIFF
--- a/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
+++ b/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
@@ -174,8 +174,6 @@ const Root = styled('div')(
         boxShadow: 'none',
         fontWeight: 'inherit',
         position: 'relative',
-        display: 'flex',
-        alignItems: 'center',
         userSelect: 'text',
       },
       '& .anchor-icon': {


### PR DESCRIPTION
Created from: https://github.com/mui/mui-x/pull/13543#discussion_r1680797191

## Example in MUI Core
### Before
https://next.mui.com/material-ui/migration/v5-style-changes/#%E2%9C%85-update-makestyles-import

### After
https://deploy-preview-42979--material-ui.netlify.app/material-ui/migration/v5-style-changes/#%E2%9C%85-update-makestyles-import

| Before | After |
| --- | --- |
| <img width="312" alt="Screenshot 2024-07-17 at 13 40 32" src="https://github.com/user-attachments/assets/b6ae22fa-46a7-43df-8d7c-2eb9852aedc2"> | <img width="304" alt="Screenshot 2024-07-17 at 13 40 00" src="https://github.com/user-attachments/assets/683ad36b-1b1a-4dc6-b32e-d4fbb7b458d9"> |