### PR TITLE
[core] Add pigment and base ui scopes to envinfo

### DIFF
--- a/packages/mui-envinfo/envinfo.js
+++ b/packages/mui-envinfo/envinfo.js
@@ -8,6 +8,8 @@ envinfo
       npmPackages: `{${[
         '@mui/*',
         '@toolpad/*',
+        '@pigment-css/*',
+        '@base_ui/*',
         // Peer dependencies
         'react',
         'react-dom',


### PR DESCRIPTION
See https://github.com/mui/material-ui/pull/41942#discussion_r1684519580. This will help support ticket for Base UI, Pigment CSS and downstream dependents.

_Aside: Any reason why `@base_ui` scope is with an underscore? Feels a bit unusual for npm package naming and different to what we've been doing before with no obvious benefit. I personally find it to work particularly badly with underlines in urls (github, npm, docs,...)_
