### PR TITLE
[docs] Remove stringify theme import

### DIFF
--- a/docs/data/material/migration/migrating-to-v6/migrating-to-pigment-css.md
+++ b/docs/data/material/migration/migrating-to-v6/migrating-to-pigment-css.md
@@ -171,7 +171,7 @@ Integrating Pigment CSS with Material UI requires you to configure the theme t
 Add the following code to your [Next.js](#nextjs) or [Vite](#vite) config file:
 
 ```diff
-+ import { extendTheme, stringifyTheme } from '@mui/material';
++ import { extendTheme } from '@mui/material';
 
 + const pigmentConfig = {
 +   theme: extendTheme(),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The `stringifyTheme` is used internally, I forgot to remove it from the docs.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
