### PR TITLE
[nextjs] Remove @mui/material as peer dependency

### DIFF
--- a/packages/mui-material-nextjs/package.json
+++ b/packages/mui-material-nextjs/package.json
@@ -50,7 +50,6 @@
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.4",
     "@emotion/server": "^11.11.0",
-    "@mui/material": "workspace:*",
     "@types/react": "^17.0.0 || ^18.0.0",
     "next": "^13.0.0 || ^14.0.0",
     "react": "^17.0.0 || ^18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1801,9 +1801,6 @@ importers:
       '@babel/runtime':
         specifier: ^7.24.8
         version: 7.24.8
-      '@mui/material':
-        specifier: workspace:*
-        version: link:../mui-material/build
     devDependencies:
       '@emotion/cache':
         specifier: ^11.11.0


### PR DESCRIPTION
Fixes #43001

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
