### PR TITLE
[docs] Make `DemoSandbox` agnostic of `productId`

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -638,7 +638,7 @@ export default function Demo(props) {
           key={demoKey}
           style={demoSandboxedStyle}
           iframe={demoOptions.iframe}
-          productId={demoData.productId}
+          usesCssVarsTheme={demoData.productId === 'joy-ui'}
           name={demoName}
           onResetDemoClick={resetDemo}
         >

--- a/docs/src/modules/components/DemoSandbox.js
+++ b/docs/src/modules/components/DemoSandbox.js
@@ -21,7 +21,7 @@ const iframeDefaultJoyTheme = extendTheme({
 });
 
 function FramedDemo(props) {
-  const { children, document, productId } = props;
+  const { children, document, usesCssVarsTheme } = props;
 
   const theme = useTheme();
   React.useEffect(() => {
@@ -51,15 +51,14 @@ function FramedDemo(props) {
 
   const getWindow = React.useCallback(() => document.defaultView, [document]);
 
-  const Wrapper = productId === 'joy-ui' ? CssVarsProvider : React.Fragment;
-  const wrapperProps =
-    productId === 'joy-ui'
-      ? {
-          documentNode: document,
-          colorSchemeNode: document.documentElement,
-          theme: iframeDefaultJoyTheme,
-        }
-      : {};
+  const Wrapper = usesCssVarsTheme ? CssVarsProvider : React.Fragment;
+  const wrapperProps = usesCssVarsTheme
+    ? {
+        documentNode: document,
+        colorSchemeNode: document.documentElement,
+        theme: iframeDefaultJoyTheme,
+      }
+    : {};
 
   return (
     <StylesProvider jss={jss} sheetsManager={sheetsManager}>
@@ -81,7 +80,7 @@ function FramedDemo(props) {
 FramedDemo.propTypes = {
   children: PropTypes.node,
   document: PropTypes.object.isRequired,
-  productId: PropTypes.string,
+  usesCssVarsTheme: PropTypes.bool,
 };
 
 const Iframe = styled('iframe')(({ theme }) => ({
@@ -93,7 +92,7 @@ const Iframe = styled('iframe')(({ theme }) => ({
 }));
 
 function DemoIframe(props) {
-  const { children, name, productId, ...other } = props;
+  const { children, name, usesCssVarsTheme, ...other } = props;
   /**
    * @type {import('react').Ref<HTMLIFrameElement>}
    */
@@ -123,7 +122,7 @@ function DemoIframe(props) {
       <Iframe onLoad={onLoad} ref={frameRef} title={`${name} demo`} {...other} />
       {iframeLoaded !== false
         ? ReactDOM.createPortal(
-            <FramedDemo document={document} productId={productId}>
+            <FramedDemo document={document} usesCssVarsTheme={usesCssVarsTheme}>
               {children}
             </FramedDemo>,
             document.body,
@@ -136,7 +135,7 @@ function DemoIframe(props) {
 DemoIframe.propTypes = {
   children: PropTypes.node.isRequired,
   name: PropTypes.string.isRequired,
-  productId: PropTypes.string,
+  usesCssVarsTheme: PropTypes.bool,
 };
 
 // Use the default Material UI theme for the demos
@@ -169,7 +168,6 @@ function getTheme(outerTheme) {
   return resultTheme;
 }
 
-// TODO: Let demos decide whether they need JSS
 const jss = create({
   plugins: [...jssPreset().plugins, rtl()],
   insertionPoint:
@@ -186,11 +184,11 @@ function DemoSandbox(props) {
     iframe = false,
     name,
     onResetDemoClick,
-    productId,
+    usesCssVarsTheme,
     ...other
   } = props;
   const Sandbox = iframe ? DemoIframe : React.Fragment;
-  const sandboxProps = iframe ? { name, productId, ...other } : {};
+  const sandboxProps = iframe ? { name, usesCssVarsTheme, ...other } : {};
 
   const t = useTranslate();
 
@@ -199,7 +197,7 @@ function DemoSandbox(props) {
 
   return (
     <DemoErrorBoundary name={name} onResetDemoClick={onResetDemoClick} t={t}>
-      {productId === 'joy-ui' ? (
+      {usesCssVarsTheme ? (
         children
       ) : (
         <StylesProvider jss={jss}>
@@ -215,7 +213,7 @@ DemoSandbox.propTypes = {
   iframe: PropTypes.bool,
   name: PropTypes.string.isRequired,
   onResetDemoClick: PropTypes.func.isRequired,
-  productId: PropTypes.string,
+  usesCssVarsTheme: PropTypes.bool,
 };
 
 export default React.memo(DemoSandbox);


### PR DESCRIPTION
Add `usesCssVarsTheme` to replace `productId` to avoid [the hack](https://github.com/mui/mui-toolpad/blob/9580e0b48fab49b509842efa5a17bbbc191af761/docs/src/components/landing-core/ToolpadDashboardLayout.tsx#L201) in https://github.com/mui/mui-toolpad/pull/3830