### PR TITLE
[material-ui][Chip] set chip's paddingRight to 0 when the label is empty, so the icon can be right in the center

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -342,28 +342,28 @@ const ChipLabel = styled('span', {
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   paddingLeft: 12,
-  paddingRight: ownerState.label ? 12 : 0,
+  paddingRight: ownerState?.label ? 12 : 0,
   whiteSpace: 'nowrap',
   variants: [
     {
       props: { variant: 'outlined' },
       style: {
         paddingLeft: 11,
-        paddingRight: ownerState.label ? 11 : 0,
+        paddingRight: ownerState?.label ? 11 : 0,
       },
     },
     {
       props: { size: 'small' },
       style: {
         paddingLeft: 8,
-        paddingRight: ownerState.label ? 8 : 0,
+        paddingRight: ownerState?.label ? 8 : 0,
       },
     },
     {
       props: { size: 'small', variant: 'outlined' },
       style: {
         paddingLeft: 7,
-        paddingRight: ownerState.label ? 7 : 0,
+        paddingRight: ownerState?.label ? 7 : 0,
       },
     },
   ],

--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -338,36 +338,36 @@ const ChipLabel = styled('span', {
 
     return [styles.label, styles[`label${capitalize(size)}`]];
   },
-})({
+})(({ ownerState }) => ({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   paddingLeft: 12,
-  paddingRight: 12,
+  paddingRight: ownerState.label ? 12 : 0,
   whiteSpace: 'nowrap',
   variants: [
     {
       props: { variant: 'outlined' },
       style: {
         paddingLeft: 11,
-        paddingRight: 11,
+        paddingRight: ownerState.label ? 11 : 0,
       },
     },
     {
       props: { size: 'small' },
       style: {
         paddingLeft: 8,
-        paddingRight: 8,
+        paddingRight: ownerState.label ? 8 : 0,
       },
     },
     {
       props: { size: 'small', variant: 'outlined' },
       style: {
         paddingLeft: 7,
-        paddingRight: 7,
+        paddingRight: ownerState.label ? 7 : 0,
       },
     },
   ],
-});
+}));
 
 function isDeleteKeyboardEvent(keyboardEvent) {
   return keyboardEvent.key === 'Backspace' || keyboardEvent.key === 'Delete';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**BEFORE**
<img width="65" alt="350960150-c3a95922-2bfa-4049-a79a-1562f03d026d" src="https://github.com/user-attachments/assets/44b076fa-780b-4712-8f17-c4591b1d188f">

**AFTER**
<img width="80" alt="Screenshot 2024-07-24 at 22 09 55" src="https://github.com/user-attachments/assets/480651a2-599d-4e3f-bb69-7abf00aa590e">

