### PR TITLE
[material-ui][docs] Polish out data table demo

### DIFF
--- a/docs/data/material/components/table/DataTable.js
+++ b/docs/data/material/components/table/DataTable.js
@@ -46,6 +46,7 @@ export default function DataTable() {
         }}
         pageSizeOptions={[5, 10]}
         checkboxSelection
+        sx={{ overflow: 'clip' }}
       />
     </div>
   );

--- a/docs/data/material/components/table/DataTable.tsx
+++ b/docs/data/material/components/table/DataTable.tsx
@@ -46,6 +46,7 @@ export default function DataTable() {
         }}
         pageSizeOptions={[5, 10]}
         checkboxSelection
+        sx={{ overflow: 'clip' }}
       />
     </div>
   );

--- a/docs/data/material/components/table/DataTable.tsx.preview
+++ b/docs/data/material/components/table/DataTable.tsx.preview
@@ -8,4 +8,5 @@
   }}
   pageSizeOptions={[5, 10]}
   checkboxSelection
+  sx={{ overflow: 'clip' }}
 />

--- a/docs/data/material/components/table/table.md
+++ b/docs/data/material/components/table/table.md
@@ -33,7 +33,7 @@ This constraint makes building rich data tables challenging.
 The [`DataGrid` component](/x/react-data-grid/) is designed for use-cases that are focused on handling large amounts of tabular data.
 While it comes with a more rigid structure, in exchange, you gain more powerful features.
 
-{{"demo": "DataTable.js", "bg": "inline"}}
+{{"demo": "DataTable.js", "bg": "outlined"}}
 
 ## Dense table
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


Found some [issues](https://github.com/mui/mui-x/issues/13981) earlier today with some `DataGrid` demos, and fixed it in Material UI. Basically changed the demo container and added `overflow:'clip'` to fix the cropped corners.


👉 https://deploy-preview-43072--material-ui.netlify.app/material-ui/react-table/#data-table