### PR TITLE
[website] Copyedit Docs and Product menu taglines

### DIFF
--- a/docs/src/components/header/HeaderNavBar.tsx
+++ b/docs/src/components/header/HeaderNavBar.tsx
@@ -304,7 +304,7 @@ export default function HeaderNavBar() {
                         icon={<IconImage name="product-toolpad" />}
                         name="Toolpad"
                         chip={<Chip label="Beta" size="small" color="primary" variant="outlined" />}
-                        description="Low-code admin builder for Material UI apps."
+                        description="Self-hosted, low-code internal tool builder."
                       />
                     </li>
                     <li>

--- a/docs/src/components/header/HeaderNavBar.tsx
+++ b/docs/src/components/header/HeaderNavBar.tsx
@@ -304,7 +304,7 @@ export default function HeaderNavBar() {
                         icon={<IconImage name="product-toolpad" />}
                         name="Toolpad"
                         chip={<Chip label="Beta" size="small" color="primary" variant="outlined" />}
-                        description="Low-code admin builder."
+                        description="Low-code admin builder for Material UI apps."
                       />
                     </li>
                     <li>
@@ -313,7 +313,7 @@ export default function HeaderNavBar() {
                         href={ROUTES.productTemplates}
                         icon={<IconImage name="product-templates" />}
                         name="Templates"
-                        description="Fully built, out-of-the-box, templates for your application."
+                        description="Fully built templates for your application."
                       />
                     </li>
                     <li>

--- a/docs/src/components/header/HeaderNavDropdown.tsx
+++ b/docs/src/components/header/HeaderNavDropdown.tsx
@@ -77,7 +77,7 @@ const PRODUCTS = [
   },
   {
     name: 'Toolpad',
-    description: 'Low-code admin builder for Material UI apps.',
+    description: 'Self-hosted, low-code internal tool builder.',
     href: ROUTES.productToolpad,
     chip: 'Beta',
   },
@@ -111,7 +111,7 @@ const DOCS = [
   },
   {
     name: 'Toolpad',
-    description: 'Low-code admin builder for Material UI apps.',
+    description: 'Self-hosted, low-code internal tool builder.',
     href: ROUTES.toolpadStudioDocs,
     chip: 'Beta',
   },

--- a/docs/src/components/header/HeaderNavDropdown.tsx
+++ b/docs/src/components/header/HeaderNavDropdown.tsx
@@ -67,7 +67,7 @@ const PRODUCTS = [
   },
   {
     name: 'Templates',
-    description: 'Fully built, out-of-the-box, templates for your application.',
+    description: 'Fully built templates for your application.',
     href: ROUTES.productTemplates,
   },
   {
@@ -77,7 +77,7 @@ const PRODUCTS = [
   },
   {
     name: 'Toolpad',
-    description: 'Low-code admin builder.',
+    description: 'Low-code admin builder for Material UI apps.',
     href: ROUTES.productToolpad,
     chip: 'Beta',
   },
@@ -111,7 +111,7 @@ const DOCS = [
   },
   {
     name: 'Toolpad',
-    description: 'Low-code admin builder',
+    description: 'Low-code admin builder for Material UI apps.',
     href: ROUTES.toolpadStudioDocs,
     chip: 'Beta',
   },

--- a/docs/src/modules/components/MuiProductSelector.tsx
+++ b/docs/src/modules/components/MuiProductSelector.tsx
@@ -165,28 +165,28 @@ const advancedProducts = [
   {
     id: 'x-data-grid',
     name: 'Data Grid',
-    description: 'A fast and extendable data table.',
+    description: 'Fast and extendable data table.',
     icon: <BackupTableRoundedIcon sx={iconStyles} />,
     href: ROUTES.dataGridOverview,
   },
   {
     id: 'x-date-pickers',
     name: 'Date and Time Pickers',
-    description: 'Let users select date or time values.',
+    description: 'Date, time, and range components.',
     icon: <CalendarMonthRoundedIcon sx={iconStyles} />,
     href: ROUTES.datePickersOverview,
   },
   {
     id: 'x-charts',
     name: 'Charts',
-    description: 'Multiple types of charts for data viz.',
+    description: 'Data visualization components.',
     icon: <BarChartRoundedIcon sx={iconStyles} />,
     href: ROUTES.chartsOverview,
   },
   {
     id: 'x-tree-view',
     name: 'Tree View',
-    description: 'Let users navigate hierarchical lists.',
+    description: 'Hierarchical list components.',
     icon: <AccountTreeRoundedIcon sx={iconStyles} />,
     href: ROUTES.treeViewOverview,
   },
@@ -268,7 +268,7 @@ const MuiProductSelector = React.forwardRef(function MuiProductSelector(
         name="Toolpad"
         href={ROUTES.toolpadStudioDocs}
         icon={<SvgToolpadLogo width={14} height={14} sx={logoColor} />}
-        description="A self-hosted, low-code internal tool builder."
+        description="Self-hosted, low-code internal tool builder."
         active={pageContext.productId === 'toolpad-core'}
         chip={
           <Chip

--- a/docs/src/modules/components/MuiProductSelector.tsx
+++ b/docs/src/modules/components/MuiProductSelector.tsx
@@ -134,7 +134,7 @@ const coreProducts = [
   {
     id: 'material-ui',
     name: 'Material UI',
-    description: 'Ready-to-use foundational components.',
+    description: 'Comprehensive foundational components.',
     icon: <SvgMuiLogomark width={14} height={14} sx={logoColor} />,
     href: ROUTES.materialDocs,
   },
@@ -148,14 +148,14 @@ const coreProducts = [
   {
     id: 'joy-ui',
     name: 'Joy UI',
-    description: 'Beautiful foudational components.',
+    description: 'Delightful modern components.',
     icon: <WebRoundedIcon sx={iconStyles} />,
     href: ROUTES.joyDocs,
   },
   {
     id: 'system',
     name: 'MUI System',
-    description: 'A set of CSS utilities.',
+    description: 'Ergonomic CSS utilities.',
     icon: <StyleRoundedIcon sx={iconStyles} />,
     href: ROUTES.systemDocs,
   },

--- a/docs/src/modules/components/MuiProductSelector.tsx
+++ b/docs/src/modules/components/MuiProductSelector.tsx
@@ -165,7 +165,7 @@ const advancedProducts = [
   {
     id: 'x-data-grid',
     name: 'Data Grid',
-    description: 'Fast and extendable data table.',
+    description: 'Fast and extensible data table.',
     icon: <BackupTableRoundedIcon sx={iconStyles} />,
     href: ROUTES.dataGridOverview,
   },


### PR DESCRIPTION
Fix typos, eliminate repeated words, standardize descriptions, match style and structure across the menus.