### PR TITLE
[material-ui][Badge] Fix stale values being used when badge is invisible

### DIFF
--- a/packages/mui-base/src/useBadge/useBadge.ts
+++ b/packages/mui-base/src/useBadge/useBadge.ts
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import { usePreviousProps } from '@mui/utils';
 import { UseBadgeParameters, UseBadgeReturnValue } from './useBadge.types';
 
 /**
@@ -21,18 +20,13 @@ export function useBadge(parameters: UseBadgeParameters): UseBadgeReturnValue {
     showZero = false,
   } = parameters;
 
-  const prevProps = usePreviousProps({
-    badgeContent: badgeContentProp,
-    max: maxProp,
-  });
-
   let invisible = invisibleProp;
 
   if (invisibleProp === false && badgeContentProp === 0 && !showZero) {
     invisible = true;
   }
 
-  const { badgeContent, max = maxProp } = invisible ? prevProps : parameters;
+  const { badgeContent, max = maxProp } = parameters;
 
   const displayValue: React.ReactNode =
     badgeContent && Number(badgeContent) > max ? `${max}+` : badgeContent;

--- a/packages/mui-material/src/Badge/useBadge.ts
+++ b/packages/mui-material/src/Badge/useBadge.ts
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import { usePreviousProps } from '@mui/utils';
 import { UseBadgeParameters, UseBadgeReturnValue } from './useBadge.types';
 
 /**
@@ -21,18 +20,13 @@ function useBadge(parameters: UseBadgeParameters): UseBadgeReturnValue {
     showZero = false,
   } = parameters;
 
-  const prevProps = usePreviousProps({
-    badgeContent: badgeContentProp,
-    max: maxProp,
-  });
-
   let invisible = invisibleProp;
 
   if (invisibleProp === false && badgeContentProp === 0 && !showZero) {
     invisible = true;
   }
 
-  const { badgeContent, max = maxProp } = invisible ? prevProps : parameters;
+  const { badgeContent, max = maxProp } = parameters;
 
   const displayValue: React.ReactNode =
     badgeContent && Number(badgeContent) > max ? `${max}+` : badgeContent;


### PR DESCRIPTION
Fixes: https://github.com/mui/material-ui/issues/43081

To see the error:

- Go to the before/after demo
- Inspect the `.MuiBadge-badge` element
- Change the value back and forth between 8 and 0
- Observe the `.MuiBadge-badge` element's value

Before: https://stackblitz.com/edit/react-qkjzbj?file=Demo.tsx
After: _Waiting for CI build_

I think the use of `usePreviousProps` is incorrect, as `badgeContent`, `max` and `displayValue` shouldn't be coupled with the `invisible` value. They should always be updated regardless. It was originally added for another use case: https://github.com/mnajdova/material-ui/commit/7572c905d57a5e44630dc1980ea1395424dd0947#diff-26877d58ee4ebaa271700aae39d84f0ce250e8d01c677024bbf0d53f46159b1b, so it might've stuck around inadvertently.

I fixed in both `mui-material` and `mui-base` for consistency.


