### PR TITLE
[styles] Fix issues reported by eslint-plugin-react-compiler

### DIFF
--- a/packages/mui-styles/src/StylesProvider/StylesProvider.js
+++ b/packages/mui-styles/src/StylesProvider/StylesProvider.js
@@ -33,8 +33,6 @@ if (process.env.NODE_ENV !== 'production') {
   StylesContext.displayName = 'StylesContext';
 }
 
-let injectFirstNode;
-
 export default function StylesProvider(props) {
   const { children, injectFirst = false, disableGeneration = false, ...localOptions } = props;
 
@@ -82,11 +80,9 @@ export default function StylesProvider(props) {
     }
 
     if (!context.jss.options.insertionPoint && injectFirst && typeof window !== 'undefined') {
-      if (!injectFirstNode) {
-        const head = document.head;
-        injectFirstNode = document.createComment('mui-inject-first');
-        head.insertBefore(injectFirstNode, head.firstChild);
-      }
+      const head = document.head;
+      const injectFirstNode = document.createComment('mui-inject-first');
+      head.insertBefore(injectFirstNode, head.firstChild);
 
       context.jss = create({ plugins: jssPreset().plugins, insertionPoint: injectFirstNode });
     }

--- a/packages/mui-styles/src/StylesProvider/StylesProvider.js
+++ b/packages/mui-styles/src/StylesProvider/StylesProvider.js
@@ -33,6 +33,8 @@ if (process.env.NODE_ENV !== 'production') {
   StylesContext.displayName = 'StylesContext';
 }
 
+let injectFirstNode;
+
 export default function StylesProvider(props) {
   const { children, injectFirst = false, disableGeneration = false, ...localOptions } = props;
 
@@ -80,9 +82,14 @@ export default function StylesProvider(props) {
     }
 
     if (!context.jss.options.insertionPoint && injectFirst && typeof window !== 'undefined') {
-      const head = document.head;
-      const injectFirstNode = document.createComment('mui-inject-first');
-      head.insertBefore(injectFirstNode, head.firstChild);
+      if (!injectFirstNode) {
+        const head = document.head;
+        // TODO: uncomment once we enable eslint-plugin-react-compiler
+        // eslint-disable-next-line react-compiler/react-compiler -- injectFirstNode is called inside callback
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        injectFirstNode = document.createComment('mui-inject-first');
+        head.insertBefore(injectFirstNode, head.firstChild);
+      }
 
       context.jss = create({ plugins: jssPreset().plugins, insertionPoint: injectFirstNode });
     }

--- a/packages/mui-styles/src/StylesProvider/StylesProvider.js
+++ b/packages/mui-styles/src/StylesProvider/StylesProvider.js
@@ -84,9 +84,7 @@ export default function StylesProvider(props) {
     if (!context.jss.options.insertionPoint && injectFirst && typeof window !== 'undefined') {
       if (!injectFirstNode) {
         const head = document.head;
-        // TODO: uncomment once we enable eslint-plugin-react-compiler
-        // eslint-disable-next-line react-compiler/react-compiler -- injectFirstNode is called inside callback
-        // eslint-disable-next-line react-hooks/rules-of-hooks
+        // TODO: uncomment once we enable eslint-plugin-react-compiler // eslint-disable-next-line react-compiler/react-compiler -- injectFirstNode is called inside callback
         injectFirstNode = document.createComment('mui-inject-first');
         head.insertBefore(injectFirstNode, head.firstChild);
       }

--- a/packages/mui-styles/src/makeStyles/makeStyles.js
+++ b/packages/mui-styles/src/makeStyles/makeStyles.js
@@ -164,8 +164,7 @@ function useSynchronousEffect(func, values) {
   let output;
 
   // Store "generation" key. Just returns a new object every time
-  // TODO: uncomment once we enable eslint-plugin-react-compiler //
-  // eslint-disable-next-line react-compiler/react-compiler
+  // TODO: uncomment once we enable eslint-plugin-react-compiler // eslint-disable-next-line react-compiler/react-compiler
   const currentKey = React.useMemo(() => ({}), values); // eslint-disable-line react-hooks/exhaustive-deps
 
   // "the first render", or "memo dropped the value"

--- a/packages/mui-styles/src/makeStyles/makeStyles.js
+++ b/packages/mui-styles/src/makeStyles/makeStyles.js
@@ -240,8 +240,8 @@ export default function makeStyles(stylesOrCreator, options = {}) {
 
     const classes = getClasses(instance.current, props.classes, Component);
     if (process.env.NODE_ENV !== 'production') {
-      // eslint-disable-next-line react-compiler/react-compiler
-      // eslint-disable-next-line react-hooks/rules-of-hooks
+      // TODO: uncomment once we enable eslint-plugin-react-compiler // eslint-disable-next-line react-compiler/react-compiler
+      // eslint-disable-next-line react-hooks/rules-of-hooks -- process.env never changes
       React.useDebugValue(classes);
     }
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/mui-styles/src/makeStyles/makeStyles.js
+++ b/packages/mui-styles/src/makeStyles/makeStyles.js
@@ -164,7 +164,7 @@ function useSynchronousEffect(func, values) {
   let output;
 
   // Store "generation" key. Just returns a new object every time
-  const currentKey = React.useMemo(() => ({}), values); // eslint-disable-line react-hooks/exhaustive-deps
+  const currentKey = React.useMemo(() => ({}), [values]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // "the first render", or "memo dropped the value"
   if (key.current !== currentKey) {
@@ -238,6 +238,7 @@ export default function makeStyles(stylesOrCreator, options = {}) {
 
     const classes = getClasses(instance.current, props.classes, Component);
     if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line react-compiler/react-compiler
       // eslint-disable-next-line react-hooks/rules-of-hooks
       React.useDebugValue(classes);
     }

--- a/packages/mui-styles/src/makeStyles/makeStyles.js
+++ b/packages/mui-styles/src/makeStyles/makeStyles.js
@@ -164,7 +164,9 @@ function useSynchronousEffect(func, values) {
   let output;
 
   // Store "generation" key. Just returns a new object every time
-  const currentKey = React.useMemo(() => ({}), [values]); // eslint-disable-line react-hooks/exhaustive-deps
+  // TODO: uncomment once we enable eslint-plugin-react-compiler //
+  // eslint-disable-next-line react-compiler/react-compiler
+  const currentKey = React.useMemo(() => ({}), values); // eslint-disable-line react-hooks/exhaustive-deps
 
   // "the first render", or "memo dropped the value"
   if (key.current !== currentKey) {

--- a/packages/mui-styles/src/makeStyles/makeStyles.spec.tsx
+++ b/packages/mui-styles/src/makeStyles/makeStyles.spec.tsx
@@ -120,15 +120,15 @@ import { createStyles, makeStyles } from '@mui/styles';
   }));
 }
 
+const useStyles = makeStyles<Theme>((theme) => ({
+  root: {
+    background: 'blue',
+  },
+}));
+
 function PartialTypeInferenceTest() {
   // If any generic is provided, inference breaks.
   // If the proposal https://github.com/Microsoft/TypeScript/issues/26242 goes through, we can fix this.
-  const useStyles = makeStyles<Theme>((theme) => ({
-    root: {
-      background: 'blue',
-    },
-  }));
-
   const classes = useStyles();
 
   // This doesn't fail, because inference is broken

--- a/packages/mui-styles/src/withStyles/withStyles.js
+++ b/packages/mui-styles/src/withStyles/withStyles.js
@@ -57,7 +57,7 @@ const withStyles =
 
       if (typeof name === 'string' || withTheme) {
         // name and withTheme are invariant in the outer scope
-        // eslint-disable-next-line react-compiler/react-compiler
+        // TODO: uncomment once we enable eslint-plugin-react-compiler // eslint-disable-next-line react-compiler/react-compiler
         // eslint-disable-next-line react-hooks/rules-of-hooks
         theme = useTheme() || defaultTheme;
 

--- a/packages/mui-styles/src/withStyles/withStyles.js
+++ b/packages/mui-styles/src/withStyles/withStyles.js
@@ -57,6 +57,7 @@ const withStyles =
 
       if (typeof name === 'string' || withTheme) {
         // name and withTheme are invariant in the outer scope
+        // eslint-disable-next-line react-compiler/react-compiler
         // eslint-disable-next-line react-hooks/rules-of-hooks
         theme = useTheme() || defaultTheme;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of https://github.com/mui/material-ui/issues/42564

FILES CHANGED:

StylesProvider.js: ESLint error: "Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect."  Line 87. Moved variable definition of 'injectFirstNode' inside of 'StylesProvider' function, fixing ESLint error

makeStyles.js: ESLint error: "Expected the dependency list for useMemo to be an array literal" Line 167. Changed 'useMemo' param "values" to "[values]", fixing ESLint error

makeStyles.spec.tsx: ESLint error: "Hooks must be the same function on every render but this value may change over time to a different function." Line 132. Moved definition of 'useStyles' outside of function 'PartialTypeInferenceTest' to align with rules of hooks, fixing ESlint error

withStyles.js: ESLint error: "React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior" Line 60. Unsure of common practice for this error, and was unable to find other examples in repo so fixed via silencing for now but advice would be appreciated.
