### PR TITLE
[code-infra] Do not look for changes with previous commit when releasing a canary version

### DIFF
--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -18,6 +18,6 @@ jobs:
           node-version: 18
           cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: pnpm install
-      - run: pnpm canary:release --ignore @mui/icons-material --yes
+      - run: pnpm canary:release --ignore @mui/icons-material --yes --skip-last-commit-comparison
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Follow-up to https://github.com/mui/material-ui/pull/43066

Since the canary releases are triggered manually, there's no need to check for changes with the previous commit. 