### PR TITLE
[code-infra] Fix `@mui/internal-test-utils` `screen` export type

### DIFF
--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -15,6 +15,7 @@ import {
   within,
   RenderResult,
   screen as rtlScreen,
+  Screen,
 } from '@testing-library/react/pure';
 import { userEvent } from '@testing-library/user-event';
 import { useFakeTimers } from 'sinon';
@@ -740,4 +741,4 @@ const bodyBoundQueries = within(document.body, { ...queries, ...customQueries })
 
 export * from '@testing-library/react/pure';
 export { act, fireEvent };
-export const screen = { ...rtlScreen, ...bodyBoundQueries };
+export const screen: Screen & typeof bodyBoundQueries = { ...rtlScreen, ...bodyBoundQueries };

--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -15,7 +15,6 @@ import {
   within,
   RenderResult,
   screen as rtlScreen,
-  Screen,
 } from '@testing-library/react/pure';
 import { userEvent } from '@testing-library/user-event';
 import { useFakeTimers } from 'sinon';
@@ -740,5 +739,5 @@ function act<T>(callback: () => void | T | Promise<T>) {
 const bodyBoundQueries = within(document.body, { ...queries, ...customQueries });
 
 export * from '@testing-library/react/pure';
-export { act, cleanup, fireEvent };
-export const screen: Screen = { ...rtlScreen, ...bodyBoundQueries };
+export { act, fireEvent };
+export const screen = { ...rtlScreen, ...bodyBoundQueries };


### PR DESCRIPTION
Follow up on https://github.com/mui/material-ui/pull/42968.

Fix [issues](https://app.circleci.com/pipelines/github/mui/mui-x/63297/workflows/23210296-a30f-4dec-938d-9d49303d350c/jobs/361379) in: https://github.com/mui/mui-x/pull/14002.

P.S. Tested locally that a package built on this PR fixes the TS issue. 