### PR TITLE
[test] Make conformance tests work with async render function

### DIFF
--- a/packages-internal/test-utils/src/describeConformance.tsx
+++ b/packages-internal/test-utils/src/describeConformance.tsx
@@ -41,7 +41,7 @@ export interface ConformanceOptions {
   refInstanceof: any;
   after?: () => void;
   inheritComponent?: React.ElementType;
-  render: (node: React.ReactElement<any>) => MuiRenderResult;
+  render: (node: React.ReactElement<any>) => MuiRenderResult | Promise<MuiRenderResult>;
   only?: Array<keyof typeof fullSuite>;
   skip?: Array<keyof typeof fullSuite | 'classesRoot'>;
   testComponentsRootPropWith?: string;
@@ -94,7 +94,7 @@ export function testClassName(
   element: React.ReactElement<any>,
   getOptions: () => ConformanceOptions,
 ) {
-  it('applies the className to the root component', () => {
+  it('applies the className to the root component', async () => {
     const { render } = getOptions();
 
     if (!render) {
@@ -104,7 +104,7 @@ export function testClassName(
     const className = randomStringValue();
     const testId = randomStringValue();
 
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       React.cloneElement(element, { className, 'data-testid': testId }),
     );
 
@@ -121,7 +121,7 @@ export function testComponentProp(
   getOptions: () => ConformanceOptions,
 ) {
   describe('prop: component', () => {
-    it('can render another root component with the `component` prop', () => {
+    it('can render another root component with the `component` prop', async () => {
       const { render, testComponentPropWith: component = 'em' } = getOptions();
       if (!render) {
         throwMissingPropError('render');
@@ -130,7 +130,7 @@ export function testComponentProp(
       const testId = randomStringValue();
 
       if (typeof component === 'string') {
-        const { getByTestId } = render(
+        const { getByTestId } = await render(
           React.cloneElement(element, { component, 'data-testid': testId }),
         );
         expect(getByTestId(testId)).not.to.equal(null);
@@ -138,7 +138,7 @@ export function testComponentProp(
       } else {
         const componentWithTestId = (props: {}) =>
           React.createElement(component, { ...props, 'data-testid': testId });
-        const { getByTestId } = render(
+        const { getByTestId } = await render(
           React.cloneElement(element, {
             component: componentWithTestId,
           }),
@@ -156,7 +156,7 @@ export function testPropsSpread(
   element: React.ReactElement<any>,
   getOptions: () => ConformanceOptions,
 ) {
-  it(`spreads props to the root component`, () => {
+  it(`spreads props to the root component`, async () => {
     // type def in ConformanceOptions
     const { render } = getOptions();
 
@@ -168,7 +168,7 @@ export function testPropsSpread(
     const value = randomStringValue();
     const testId = randomStringValue();
 
-    const { getByTestId } = render(
+    const { getByTestId } = await render(
       React.cloneElement(element, { [testProp]: value, 'data-testid': testId }),
     );
 
@@ -187,7 +187,7 @@ export function describeRef(
   getOptions: () => ConformanceOptions,
 ) {
   describe('ref', () => {
-    it(`attaches the ref`, () => {
+    it(`attaches the ref`, async () => {
       // type def in ConformanceOptions
       const { render, refInstanceof } = getOptions();
 
@@ -197,7 +197,7 @@ export function describeRef(
 
       const ref = React.createRef();
 
-      render(React.cloneElement(element, { ref }));
+      await render(React.cloneElement(element, { ref }));
 
       expect(ref.current).to.be.instanceof(refInstanceof);
     });
@@ -211,7 +211,7 @@ export function testRootClass(
   element: React.ReactElement<any>,
   getOptions: () => ConformanceOptions,
 ) {
-  it('applies the root class to the root component if it has this class', () => {
+  it('applies the root class to the root component if it has this class', async () => {
     const { classes, render, skip } = getOptions();
     if (classes.root == null) {
       return;
@@ -219,7 +219,7 @@ export function testRootClass(
 
     const className = randomStringValue();
     const classesRootClassname = randomStringValue();
-    const { container } = render(
+    const { container } = await render(
       React.cloneElement(element, {
         className,
         classes: { ...classes, root: `${classes.root} ${classesRootClassname}` },
@@ -273,7 +273,7 @@ function testSlotsProp(element: React.ReactElement<any>, getOptions: () => Confo
   ));
 
   forEachSlot(slots, (slotName, slotOptions) => {
-    it(`allows overriding the ${slotName} slot with a component using the slots.${slotName} prop`, () => {
+    it(`allows overriding the ${slotName} slot with a component using the slots.${slotName} prop`, async () => {
       if (!render) {
         throwMissingPropError('render');
       }
@@ -284,7 +284,7 @@ function testSlotsProp(element: React.ReactElement<any>, getOptions: () => Confo
         [slotName]: slotComponent,
       };
 
-      const { queryByTestId } = render(React.cloneElement(element, { slots: components }));
+      const { queryByTestId } = await render(React.cloneElement(element, { slots: components }));
       const renderedElement = queryByTestId('custom');
       expect(renderedElement).not.to.equal(null);
       if (slotOptions.expectedClassName) {
@@ -293,7 +293,7 @@ function testSlotsProp(element: React.ReactElement<any>, getOptions: () => Confo
     });
 
     if (slotOptions.testWithElement !== null) {
-      it(`allows overriding the ${slotName} slot with an element using the slots.${slotName} prop`, () => {
+      it(`allows overriding the ${slotName} slot with an element using the slots.${slotName} prop`, async () => {
         if (!render) {
           throwMissingPropError('render');
         }
@@ -310,7 +310,7 @@ function testSlotsProp(element: React.ReactElement<any>, getOptions: () => Confo
           },
         };
 
-        const { queryByTestId } = render(
+        const { queryByTestId } = await render(
           React.cloneElement(element, { slots: components, slotProps }),
         );
 
@@ -328,7 +328,7 @@ function testSlotsProp(element: React.ReactElement<any>, getOptions: () => Confo
     if (testLegacyComponentsProp) {
       it(`allows overriding the ${slotName} slot with a component using the components.${capitalize(
         slotName,
-      )} prop`, () => {
+      )} prop`, async () => {
         if (!render) {
           throwMissingPropError('render');
         }
@@ -339,7 +339,7 @@ function testSlotsProp(element: React.ReactElement<any>, getOptions: () => Confo
           [capitalize(slotName)]: slotComponent,
         };
 
-        const { queryByTestId } = render(React.cloneElement(element, { components }));
+        const { queryByTestId } = await render(React.cloneElement(element, { components }));
         const renderedElement = queryByTestId('custom');
         expect(renderedElement).not.to.equal(null);
         if (slotOptions.expectedClassName) {
@@ -349,7 +349,7 @@ function testSlotsProp(element: React.ReactElement<any>, getOptions: () => Confo
 
       it(`prioritizes the 'slots.${slotName}' over components.${capitalize(
         slotName,
-      )} if both are defined`, () => {
+      )} if both are defined`, async () => {
         if (!render) {
           throwMissingPropError('render');
         }
@@ -386,7 +386,7 @@ function testSlotsProp(element: React.ReactElement<any>, getOptions: () => Confo
           [slotName]: ComponentForSlotsProp,
         };
 
-        const { queryByTestId } = render(
+        const { queryByTestId } = await render(
           React.cloneElement(element, { components, slots: slotOverrides }),
         );
 
@@ -397,7 +397,7 @@ function testSlotsProp(element: React.ReactElement<any>, getOptions: () => Confo
       if (slotOptions.testWithElement !== null) {
         it(`allows overriding the ${slotName} slot with an element using the components.${capitalize(
           slotName,
-        )} prop`, () => {
+        )} prop`, async () => {
           if (!render) {
             throwMissingPropError('render');
           }
@@ -414,7 +414,7 @@ function testSlotsProp(element: React.ReactElement<any>, getOptions: () => Confo
             },
           };
 
-          const { queryByTestId } = render(
+          const { queryByTestId } = await render(
             React.cloneElement(element, { components, componentsProps }),
           );
 
@@ -439,14 +439,14 @@ function testSlotPropsProp(element: React.ReactElement<any>, getOptions: () => C
   }
 
   forEachSlot(slots, (slotName, slotOptions) => {
-    it(`sets custom properties on the ${slotName} slot's element with the slotProps.${slotName} prop`, () => {
+    it(`sets custom properties on the ${slotName} slot's element with the slotProps.${slotName} prop`, async () => {
       const slotProps = {
         [slotName]: {
           'data-testid': 'custom',
         },
       };
 
-      const { queryByTestId } = render(React.cloneElement(element, { slotProps }));
+      const { queryByTestId } = await render(React.cloneElement(element, { slotProps }));
       const slotComponent = queryByTestId('custom');
       expect(slotComponent).not.to.equal(null);
 
@@ -456,7 +456,7 @@ function testSlotPropsProp(element: React.ReactElement<any>, getOptions: () => C
     });
 
     if (slotOptions.expectedClassName) {
-      it(`merges the class names provided in slotsProps.${slotName} with the built-in ones`, () => {
+      it(`merges the class names provided in slotsProps.${slotName} with the built-in ones`, async () => {
         const slotProps = {
           [slotName]: {
             'data-testid': 'custom',
@@ -464,7 +464,7 @@ function testSlotPropsProp(element: React.ReactElement<any>, getOptions: () => C
           },
         };
 
-        const { getByTestId } = render(React.cloneElement(element, { slotProps }));
+        const { getByTestId } = await render(React.cloneElement(element, { slotProps }));
 
         expect(getByTestId('custom')).to.have.class(slotOptions.expectedClassName);
         expect(getByTestId('custom')).to.have.class(slotProps[slotName].className);
@@ -472,14 +472,14 @@ function testSlotPropsProp(element: React.ReactElement<any>, getOptions: () => C
     }
 
     if (testLegacyComponentsProp) {
-      it(`sets custom properties on the ${slotName} slot's element with the componentsProps.${slotName} prop`, () => {
+      it(`sets custom properties on the ${slotName} slot's element with the componentsProps.${slotName} prop`, async () => {
         const componentsProps = {
           [slotName]: {
             'data-testid': 'custom',
           },
         };
 
-        const { queryByTestId } = render(React.cloneElement(element, { componentsProps }));
+        const { queryByTestId } = await render(React.cloneElement(element, { componentsProps }));
         const slotComponent = queryByTestId('custom');
         expect(slotComponent).not.to.equal(null);
 
@@ -488,7 +488,7 @@ function testSlotPropsProp(element: React.ReactElement<any>, getOptions: () => C
         }
       });
 
-      it(`prioritizes the 'slotProps.${slotName}' over componentsProps.${slotName} if both are defined`, () => {
+      it(`prioritizes the 'slotProps.${slotName}' over componentsProps.${slotName} if both are defined`, async () => {
         const componentsProps = {
           [slotName]: {
             'data-testid': 'custom',
@@ -503,7 +503,7 @@ function testSlotPropsProp(element: React.ReactElement<any>, getOptions: () => C
           },
         };
 
-        const { queryByTestId } = render(
+        const { queryByTestId } = await render(
           React.cloneElement(element, { componentsProps, slotProps }),
         );
         const slotComponent = queryByTestId('custom');
@@ -525,14 +525,14 @@ function testSlotPropsCallback(
   }
 
   forEachSlot(slots, (slotName) => {
-    it(`sets custom properties on the ${slotName} slot's element with the slotProps.${slotName} callback`, () => {
+    it(`sets custom properties on the ${slotName} slot's element with the slotProps.${slotName} callback`, async () => {
       const slotProps = {
         [slotName]: (ownerState: Record<string, any>) => ({
           'data-testid': ownerState.className,
         }),
       };
 
-      const { queryByTestId } = render(
+      const { queryByTestId } = await render(
         React.cloneElement(element, { slotProps, className: 'custom' }),
       );
       const slotComponent = queryByTestId('custom');
@@ -550,7 +550,7 @@ function testComponentsProp(
   getOptions: () => ConformanceOptions,
 ) {
   describe('prop components:', () => {
-    it('can render another root component with the `components` prop', () => {
+    it('can render another root component with the `components` prop', async () => {
       const { render, testComponentsRootPropWith: component = 'em' } = getOptions();
       if (!render) {
         throwMissingPropError('render');
@@ -558,7 +558,7 @@ function testComponentsProp(
 
       const testId = randomStringValue();
 
-      const { getByTestId } = render(
+      const { getByTestId } = await render(
         React.cloneElement(element, { components: { Root: component }, 'data-testid': testId }),
       );
       expect(getByTestId(testId)).not.to.equal(null);
@@ -576,7 +576,7 @@ function testThemeDefaultProps(
   getOptions: () => ConformanceOptions,
 ) {
   describe('theme default components:', () => {
-    it("respect theme's defaultProps", () => {
+    it("respect theme's defaultProps", async () => {
       const testProp = 'data-id';
       const { muiName, render, ThemeProvider, createTheme } = getOptions();
 
@@ -606,7 +606,7 @@ function testThemeDefaultProps(
         },
       });
 
-      const { container } = render(<ThemeProvider theme={theme}>{element}</ThemeProvider>);
+      const { container } = await render(<ThemeProvider theme={theme}>{element}</ThemeProvider>);
 
       expect(container.firstChild).to.have.attribute(testProp, 'testProp');
     });
@@ -622,7 +622,7 @@ function testThemeStyleOverrides(
   getOptions: () => ConformanceOptions,
 ) {
   describe('theme style overrides:', () => {
-    it("respect theme's styleOverrides custom state", function test() {
+    it("respect theme's styleOverrides custom state", async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
@@ -666,7 +666,7 @@ function testThemeStyleOverrides(
         return;
       }
 
-      const { container } = render(
+      const { container } = await render(
         <ThemeProvider theme={theme}>
           {React.cloneElement(element, {
             [testStateOverrides.prop]: testStateOverrides.value,
@@ -677,7 +677,7 @@ function testThemeStyleOverrides(
       expect(container.firstChild).to.toHaveComputedStyle(testStyle);
     });
 
-    it("respect theme's styleOverrides slots", function test() {
+    it("respect theme's styleOverrides slots", async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
@@ -742,7 +742,7 @@ function testThemeStyleOverrides(
         },
       });
 
-      const { container, setProps } = render(
+      const { container, setProps } = await render(
         <ThemeProvider theme={theme}>{element}</ThemeProvider>,
       );
 
@@ -788,7 +788,7 @@ function testThemeStyleOverrides(
       }
     });
 
-    it('overrideStyles does not replace each other in slots', function test() {
+    it('overrideStyles does not replace each other in slots', async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
@@ -844,7 +844,7 @@ function testThemeStyleOverrides(
         return;
       }
 
-      render(
+      await render(
         <ThemeProvider theme={theme}>
           {React.cloneElement(element, {
             [testStateOverrides.prop]: testStateOverrides.value,
@@ -866,7 +866,7 @@ function testThemeStyleOverrides(
  */
 function testThemeVariants(element: React.ReactElement<any>, getOptions: () => ConformanceOptions) {
   describe('theme variants:', () => {
-    it("respect theme's variants", function test() {
+    it("respect theme's variants", async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
@@ -910,7 +910,7 @@ function testThemeVariants(element: React.ReactElement<any>, getOptions: () => C
         },
       });
 
-      const { getByTestId } = render(
+      const { getByTestId } = await render(
         <ThemeProvider theme={theme}>
           {React.cloneElement(element, { ...testVariantProps, 'data-testid': 'with-props' })}
           {React.cloneElement(element, { 'data-testid': 'without-props' })}
@@ -921,7 +921,7 @@ function testThemeVariants(element: React.ReactElement<any>, getOptions: () => C
       expect(getByTestId('without-props')).not.to.toHaveComputedStyle(testStyle);
     });
 
-    it('supports custom variant', function test() {
+    it('supports custom variant', async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
@@ -954,7 +954,7 @@ function testThemeVariants(element: React.ReactElement<any>, getOptions: () => C
         },
       });
 
-      const { getByTestId } = render(
+      const { getByTestId } = await render(
         <ThemeProvider theme={theme}>
           {React.cloneElement(element, { variant: 'unknown', 'data-testid': 'custom-variant' })}
         </ThemeProvider>,

--- a/packages-internal/test-utils/src/flushMicrotasks.ts
+++ b/packages-internal/test-utils/src/flushMicrotasks.ts
@@ -1,8 +1,5 @@
 import { act } from './createRenderer';
 
 export default async function flushMicrotasks() {
-  if (/jsdom/.test(window.navigator.userAgent)) {
-    // This is only needed for JSDOM and causes issues in real browsers
-    await act(async () => {});
-  }
+  await act(async () => {});
 }

--- a/packages/mui-base/src/Menu/Menu.test.tsx
+++ b/packages/mui-base/src/Menu/Menu.test.tsx
@@ -32,7 +32,7 @@ describe('<Menu />', () => {
     element: React.ReactElement<any, string | React.JSXElementConstructor<any>>,
     options?: RenderOptions,
   ): Promise<MuiRenderResult> {
-    const rendered = internalRender(element, options);
+    const rendered = await internalRender(element, options);
     await flushMicrotasks();
     return rendered;
   }
@@ -206,7 +206,7 @@ describe('<Menu />', () => {
       const item2 = getByTestId('item-2');
       const item3 = getByTestId('item-3');
 
-      act(() => {
+      await act(() => {
         item1.focus();
       });
 
@@ -234,7 +234,7 @@ describe('<Menu />', () => {
       const item1 = getByTestId('item-1');
       const item3 = getByTestId('item-3');
 
-      act(() => {
+      await act(() => {
         item1.focus();
       });
 
@@ -260,7 +260,7 @@ describe('<Menu />', () => {
       const item1 = getByTestId('item-1');
       const item2 = getByTestId('item-2');
 
-      act(() => {
+      await act(() => {
         item1.focus();
       });
 
@@ -293,7 +293,7 @@ describe('<Menu />', () => {
 
         const items = getAllByRole('menuitem');
 
-        act(() => {
+        await act(() => {
           items[0].focus();
         });
 
@@ -326,7 +326,7 @@ describe('<Menu />', () => {
 
         const items = getAllByRole('menuitem');
 
-        act(() => {
+        await act(() => {
           items[0].focus();
         });
 
@@ -357,7 +357,7 @@ describe('<Menu />', () => {
 
         const items = getAllByRole('menuitem');
 
-        act(() => {
+        await act(() => {
           items[0].focus();
         });
 
@@ -399,7 +399,7 @@ describe('<Menu />', () => {
 
         const items = getAllByRole('menuitem');
 
-        act(() => {
+        await act(() => {
           items[0].focus();
         });
 
@@ -436,7 +436,7 @@ describe('<Menu />', () => {
 
         const items = getAllByRole('menuitem');
 
-        act(() => {
+        await act(() => {
           items[0].focus();
         });
 
@@ -471,7 +471,7 @@ describe('<Menu />', () => {
 
         const items = getAllByRole('menuitem');
 
-        act(() => {
+        await act(() => {
           items[0].focus();
         });
 
@@ -666,7 +666,7 @@ describe('<Menu />', () => {
     );
 
     const menuItems = getAllByRole('menuitem');
-    act(() => {
+    await act(() => {
       menuItems[0].focus();
     });
 

--- a/packages/mui-base/src/Select/Select.test.tsx
+++ b/packages/mui-base/src/Select/Select.test.tsx
@@ -752,7 +752,7 @@ describe('<Select />', () => {
       expect(onChange.notCalled).to.equal(true);
     });
 
-    it('is not called after initial render when when controlled value is set to null', () => {
+    it('is not called after initial render when when controlled value is set to null', async () => {
       function TestComponent({ onChange }: { onChange: (value: string | null) => void }) {
         const [value, setValue] = React.useState<string | null>(null);
         const handleChange = (event: React.SyntheticEvent | null, newValue: string | null) => {
@@ -769,12 +769,12 @@ describe('<Select />', () => {
       }
 
       const onChange = spy();
-      render(<TestComponent onChange={onChange} />);
+      await render(<TestComponent onChange={onChange} />);
 
       expect(onChange.notCalled).to.equal(true);
     });
 
-    it('is not called after initial render when when the default uncontrolled value is set to null', () => {
+    it('is not called after initial render when when the default uncontrolled value is set to null', async () => {
       function TestComponent({ onChange }: { onChange: (value: string | null) => void }) {
         const handleChange = (event: React.SyntheticEvent | null, newValue: string | null) => {
           onChange(newValue);
@@ -789,12 +789,12 @@ describe('<Select />', () => {
       }
 
       const onChange = spy();
-      render(<TestComponent onChange={onChange} />);
+      await render(<TestComponent onChange={onChange} />);
 
       expect(onChange.notCalled).to.equal(true);
     });
 
-    it('is not called after initial render when the controlled value is set to a valid option', () => {
+    it('is not called after initial render when the controlled value is set to a valid option', async () => {
       function TestComponent({ onChange }: { onChange: (value: string | null) => void }) {
         const [value, setValue] = React.useState<string | null>('1');
         const handleChange = (event: React.SyntheticEvent | null, newValue: string | null) => {
@@ -811,12 +811,12 @@ describe('<Select />', () => {
       }
 
       const onChange = spy();
-      render(<TestComponent onChange={onChange} />);
+      await render(<TestComponent onChange={onChange} />);
 
       expect(onChange.notCalled).to.equal(true);
     });
 
-    it('is not called after initial render when when the default uncontrolled value is set to a valid option', () => {
+    it('is not called after initial render when when the default uncontrolled value is set to a valid option', async () => {
       function TestComponent({ onChange }: { onChange: (value: string | null) => void }) {
         const handleChange = (event: React.SyntheticEvent | null, newValue: string | null) => {
           onChange(newValue);
@@ -831,12 +831,12 @@ describe('<Select />', () => {
       }
 
       const onChange = spy();
-      render(<TestComponent onChange={onChange} />);
+      await render(<TestComponent onChange={onChange} />);
 
       expect(onChange.notCalled).to.equal(true);
     });
 
-    it('is called after initial render with `null` when the controlled value is set to a nonexistent option', () => {
+    it('is called after initial render with `null` when the controlled value is set to a nonexistent option', async () => {
       function TestComponent({ onChange }: { onChange: (value: string | null) => void }) {
         const [value, setValue] = React.useState<string | null>('42');
         const handleChange = (event: React.SyntheticEvent | null, newValue: string | null) => {
@@ -853,13 +853,13 @@ describe('<Select />', () => {
       }
 
       const onChange = spy();
-      render(<TestComponent onChange={onChange} />);
+      await render(<TestComponent onChange={onChange} />);
 
       expect(onChange.called).to.equal(true);
       expect(onChange.args[0][0]).to.equal(null);
     });
 
-    it('is called after initial render when when the default uncontrolled value is set to a nonexistent option', () => {
+    it('is called after initial render when when the default uncontrolled value is set to a nonexistent option', async () => {
       function TestComponent({ onChange }: { onChange: (value: string | null) => void }) {
         const handleChange = (event: React.SyntheticEvent | null, newValue: string | null) => {
           onChange(newValue);
@@ -874,7 +874,7 @@ describe('<Select />', () => {
       }
 
       const onChange = spy();
-      render(<TestComponent onChange={onChange} />);
+      await render(<TestComponent onChange={onChange} />);
 
       expect(onChange.called).to.equal(true);
       expect(onChange.args[0][0]).to.equal(null);
@@ -978,8 +978,8 @@ describe('<Select />', () => {
 
   // according to WAI-ARIA 1.2 (https://www.w3.org/TR/wai-aria-1.2/#combobox)
   describe('a11y attributes', () => {
-    it('should have the `combobox` role', () => {
-      render(
+    it('should have the `combobox` role', async () => {
+      await render(
         <Select>
           <Option value={1}>One</Option>
         </Select>,
@@ -988,8 +988,8 @@ describe('<Select />', () => {
       expect(screen.queryByRole('combobox')).not.to.equal(null);
     });
 
-    it('should have the aria-expanded attribute', () => {
-      render(
+    it('should have the aria-expanded attribute', async () => {
+      await render(
         <Select>
           <Option value={1}>One</Option>
         </Select>,

--- a/packages/mui-base/test/describeConformanceUnstyled.tsx
+++ b/packages/mui-base/test/describeConformanceUnstyled.tsx
@@ -92,7 +92,7 @@ function testPropForwarding(
     expect(customRoot).to.have.attribute('data-foobar', otherProps.fooBar);
   });
 
-  it('does forward standard props to the root element if an intrinsic element is provided', () => {
+  it('does forward standard props to the root element if an intrinsic element is provided', async () => {
     const otherProps = {
       lang: 'fr',
       'data-foobar': randomStringValue(),
@@ -100,7 +100,7 @@ function testPropForwarding(
       ...(rootElementNameMustMatchComponentProp ? { rootElementName: Element } : {}),
     };
 
-    render(React.cloneElement(element, { slots: { root: Element }, ...otherProps }));
+    await render(React.cloneElement(element, { slots: { root: Element }, ...otherProps }));
 
     const customRoot = screen.getByTestId('custom-root');
     expect(customRoot).to.have.attribute('lang', otherProps.lang);
@@ -346,7 +346,7 @@ function testOwnerStatePropagation(
   }
 
   forEachSlot(slots, (slotName) => {
-    it(`sets the ownerState prop on the ${slotName} slot's component`, () => {
+    it(`sets the ownerState prop on the ${slotName} slot's component`, async () => {
       let componentOwnerState;
       const TestComponent = React.forwardRef(
         ({ ownerState }: WithOwnerState, ref: React.Ref<any>) => {
@@ -365,7 +365,7 @@ function testOwnerStatePropagation(
         id: 'foo',
       };
 
-      render(
+      await render(
         React.cloneElement(element, {
           slots: slotOverrides,
           id: 'foo',
@@ -388,8 +388,8 @@ function testDisablingClassGeneration(
     throwMissingPropError('render');
   }
 
-  it(`does not generate any class names if placed within a ClassNameConfigurator`, () => {
-    render(<ClassNameConfigurator disableDefaultClasses>{element}</ClassNameConfigurator>);
+  it(`does not generate any class names if placed within a ClassNameConfigurator`, async () => {
+    await render(<ClassNameConfigurator disableDefaultClasses>{element}</ClassNameConfigurator>);
 
     const elementsWithClasses = document.querySelectorAll(`[class]`);
 


### PR DESCRIPTION
The `flushMicrotasks` function was incorrectly skipped during browser (karma) tests. I initially thought that the errors it throws on this environment are caused by specifics of karma. However, it turns out these errors were valid and indicated a bigger problem - the lack of support for async render functions in conformance tests.
This PR fixes both the `flushMicrotasks` function, making it run regardless of the environment, and conformance tests, to support async render functions (required in Menu and Select tests, plus many more in the future once @base_ui/react is used).