### PR TITLE
Remove redux-form mentions from TextField documentation #43152

### DIFF
--- a/docs/data/material/components/text-fields/text-fields.md
+++ b/docs/data/material/components/text-fields/text-fields.md
@@ -357,7 +357,6 @@ For more advanced use cases, you might be able to take advantage of:
 - [react-hook-form](https://react-hook-form.com/): React hook for form validation.
 - [react-hook-form-mui](https://github.com/dohomi/react-hook-form-mui): Material UI and react-hook-form combined.
 - [formik-material-ui](https://github.com/stackworx/formik-mui): Bindings for using Material UI with [formik](https://formik.org/).
-- [redux-form-material-ui](https://github.com/erikras/redux-form-material-ui): Bindings for using Material UI with [Redux Form](https://redux-form.com/).
 - [mui-rff](https://github.com/lookfirst/mui-rff): Bindings for using Material UI with [React Final Form](https://final-form.org/react).
 - [@ui-schema/ds-material](https://www.npmjs.com/package/@ui-schema/ds-material) Bindings for using Material UI with [UI Schema](https://github.com/ui-schema/ui-schema). JSON Schema compatible.
 - [@data-driven-forms/mui-component-mapper](https://www.data-driven-forms.org/provided-mappers/mui-component-mapper): Bindings for using Material UI with [Data Driven Forms](https://github.com/data-driven-forms/react-forms).


### PR DESCRIPTION
### Summary

This PR removes mentions of `redux-form-material-ui` from the TextField component documentation, as both libraries are no longer maintained.

### Changes

- Removed references to `redux-form-material-ui` from `TextField.md`.

### Context

This addresses the issue discussed in [#43152](https://github.com/mui/material-ui/issues/43152).

### Checklist

- [x] Documentation updated

Please review the changes and let me know if any adjustments are needed.