### PR TITLE
[Grid2] Bring back the Unstable_Grid2 export

### DIFF
--- a/packages/mui-material/src/Unstable_Grid2/index.ts
+++ b/packages/mui-material/src/Unstable_Grid2/index.ts
@@ -1,0 +1,21 @@
+import Grid2 from '../Grid2';
+
+/**
+ * @ignore - internal component.
+ */
+
+/**
+ *
+ * Demos:
+ *
+ * - [Grid version 2](https://next.mui.com/material-ui/react-grid2/)
+ *
+ * API:
+ *
+ * - [Grid2 API](https://next.mui.com/material-ui/api/grid-2/)
+ *
+ * @deprecated `Unstable_Grid2` is deprecated. Use `Grid2` instead.
+ */
+const Unstable_Grid2 = Grid2;
+
+export default Unstable_Grid2;

--- a/packages/mui-material/src/Unstable_Grid2/index.ts
+++ b/packages/mui-material/src/Unstable_Grid2/index.ts
@@ -19,4 +19,6 @@ import Grid2 from '../Grid2';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const Unstable_Grid2 = Grid2;
 
+export * from '../Grid2';
+
 export default Unstable_Grid2;

--- a/packages/mui-material/src/Unstable_Grid2/index.ts
+++ b/packages/mui-material/src/Unstable_Grid2/index.ts
@@ -16,6 +16,7 @@ import Grid2 from '../Grid2';
  *
  * @deprecated `Unstable_Grid2` is deprecated. Use `Grid2` instead.
  */
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const Unstable_Grid2 = Grid2;
 
 export default Unstable_Grid2;

--- a/packages/mui-material/src/index.js
+++ b/packages/mui-material/src/index.js
@@ -416,3 +416,6 @@ export * from './generateUtilityClass';
 export { default as generateUtilityClasses } from './generateUtilityClasses';
 
 export { default as Unstable_TrapFocus } from './Unstable_TrapFocus';
+
+export { default as Unstable_Grid2 } from './Unstable_Grid2';
+export * from './Unstable_Grid2';


### PR DESCRIPTION
Bring back this export for one more major. This allows Toolpad to be compatible with v5.


