### PR TITLE
[docs] Fix alpha usage

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -298,10 +298,10 @@ const DemoRootMaterial = styled('div', {
       },
       style: {
         padding: theme.spacing(3),
-        backgroundColor: alpha((theme.vars || theme).palette.grey[50], 0.5),
+        backgroundColor: alpha(theme.palette.grey[50], 0.5),
         border: `1px solid ${(theme.vars || theme).palette.divider}`,
         ...theme.applyDarkStyles({
-          backgroundColor: alpha((theme.vars || theme).palette.primaryDark[700], 0.4),
+          backgroundColor: alpha(theme.palette.primaryDark[700], 0.4),
         }),
       },
     },
@@ -317,10 +317,10 @@ const DemoRootMaterial = styled('div', {
         borderRightWidth: 0,
         backgroundClip: 'padding-box',
         backgroundColor: alpha(theme.palette.primary[50], 0.2),
-        backgroundImage: `radial-gradient(120% 140% at 50% 10%, transparent 40%, ${alpha((theme.vars || theme).palette.primary[100], 0.2)} 70%)`,
+        backgroundImage: `radial-gradient(120% 140% at 50% 10%, transparent 40%, ${alpha(theme.palette.primary[100], 0.2)} 70%)`,
         ...theme.applyDarkStyles({
           backgroundColor: (theme.vars || theme).palette.primaryDark[900],
-          backgroundImage: `radial-gradient(120% 140% at 50% 10%, transparent 30%, ${alpha((theme.vars || theme).palette.primary[900], 0.3)} 80%)`,
+          backgroundImage: `radial-gradient(120% 140% at 50% 10%, transparent 30%, ${alpha(theme.palette.primary[900], 0.3)} 80%)`,
         }),
       },
     },
@@ -428,7 +428,7 @@ const selectionOverride = (theme) => ({
     borderColor: (theme.vars || theme).palette.primary[200],
     ...theme.applyDarkStyles({
       color: (theme.vars || theme).palette.primary[200],
-      backgroundColor: alpha((theme.vars || theme).palette.primary[900], 0.4),
+      backgroundColor: alpha(theme.palette.primary[900], 0.4),
       borderColor: (theme.vars || theme).palette.primary[800],
     }),
   },

--- a/docs/src/modules/components/DemoEditor.tsx
+++ b/docs/src/modules/components/DemoEditor.tsx
@@ -19,10 +19,10 @@ const StyledMarkdownElement = styled(MarkdownElement)(({ theme }) => [
       border: 0,
       colorScheme: 'dark',
       '&:hover': {
-        boxShadow: `0 0 0 3px ${alpha((theme.vars || theme).palette.primary[500], 0.5)}`,
+        boxShadow: `0 0 0 3px ${alpha(theme.palette.primary[500], 0.5)}`,
       },
       '&:focus-within': {
-        boxShadow: `0 0 0 3px ${alpha((theme.vars || theme).palette.primary[500], 0.8)}`,
+        boxShadow: `0 0 0 3px ${alpha(theme.palette.primary[500], 0.8)}`,
       },
       [theme.breakpoints.up('sm')]: {
         borderRadius: '0 0 12px 12px',

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -27,7 +27,7 @@ const NativeLink = styled('a')(({ theme }) => ({
     backgroundColor: (theme.vars || theme).palette.grey[50],
   },
   '&:focus-visible': {
-    outline: `3px solid ${alpha((theme.vars || theme).palette.primary[500], 0.5)}`,
+    outline: `3px solid ${alpha(theme.palette.primary[500], 0.5)}`,
     outlineOffset: '-3px',
   },
   '& img': {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

`alpha()` will throw an error if the input is a CSS variable. The usage is incorrect and the reason that the code does not throw error is because the documentation pages are not using CSS variables yet.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
