### PR TITLE
[docs] Fix the link test script

### DIFF
--- a/docs/.link-check-errors.txt
+++ b/docs/.link-check-errors.txt
@@ -1,2 +1,7 @@
 Broken links found by `pnpm docs:link-check` that exist:
 
+- https://mui.com/material-ui/customization/css-theme-variables/configuration/#advanced-configuration
+- https://mui.com/material-ui/customization/css-theme-variables/configuration/#changing-variable-prefixes
+- https://mui.com/material-ui/customization/theme-components/#creating-new-component-variants
+- https://mui.com/material-ui/customization/theme-components/#overrides-based-on-props
+- https://mui.com/material-ui/react-grid2/#whats-changed

--- a/docs/scripts/reportBrokenLinks.js
+++ b/docs/scripts/reportBrokenLinks.js
@@ -10,8 +10,8 @@ function getPageLinks(markdown) {
   const hrefs = [];
 
   const renderer = new marked.Renderer();
-  renderer.link = (href) => {
-    if (href[0] === '/') {
+  renderer.link = ({ href }) => {
+    if (href.startsWith('/')) {
       hrefs.push(href);
     }
   };
@@ -211,8 +211,12 @@ if (require.main === module) {
     .filter((link) => UNSUPPORTED_PATHS.every((unsupportedPath) => !link.includes(unsupportedPath)))
     .sort()
     .forEach((linkKey) => {
+      //
+      // <!-- #default-branch-switch -->
+      //
       write(`- https://mui.com${linkKey}`);
       console.log(`https://mui.com${linkKey}`);
+
       console.log(`used in`);
       usedLinks[linkKey].forEach((f) => console.log(`- ${path.relative(docsSpaceRoot, f)}`));
       console.log('available anchors on the same page:');


### PR DESCRIPTION
The issue came from the  `marked` package migration from v5 to v13.

The argument of the `link` callback was not correct.