### PR TITLE
[core] Replace JSX namespace usages with React.JSX

### DIFF
--- a/docs/data/base/components/select/select.md
+++ b/docs/data/base/components/select/select.md
@@ -60,7 +60,7 @@ const CustomSelect = React.forwardRef(function CustomSelect<TValue>(
   return <Select {...props} ref={ref} />;
 }) as <TValue>(
   props: SelectProps<TValue> & React.RefAttributes<HTMLUListElement>,
-) => JSX.Element;
+) => React.JSX.Element;
 ```
 
 For the sake of brevity, the rest of the demos throughout this doc will not use `forwardRef`.

--- a/docs/src/components/animation/FlashCode.tsx
+++ b/docs/src/components/animation/FlashCode.tsx
@@ -23,7 +23,7 @@ const FlashCodeRoot = styled('div', {
 }));
 
 const FlashCode = React.forwardRef(function FlashCode(
-  props: JSX.IntrinsicElements['div'] & {
+  props: React.JSX.IntrinsicElements['div'] & {
     sx?: SxProps;
     endLine?: number;
     startLine?: number;


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/42381

Commit based on https://github.com/mui/material-ui/pull/42824

Replaces the latest occurrences of the `JSX` TypeScript namespace with `React.JSX`. More info in the [React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript).