### PR TITLE
[core] Patch styled-components to use React.JSX namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -279,5 +279,10 @@
         ]
       }
     }
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "styled-components@6.1.12": "patches/styled-components@6.1.12.patch"
+    }
   }
 }

--- a/patches/styled-components@6.1.12.patch
+++ b/patches/styled-components@6.1.12.patch
@@ -1,0 +1,184 @@
+diff --git a/dist/hoc/withTheme.d.ts b/dist/hoc/withTheme.d.ts
+index f3452c16983a0b45ca314c7c717de9f6da75f90a..21fec5f48cc060f485520c0d77afc59bf7e7d487 100644
+--- a/dist/hoc/withTheme.d.ts
++++ b/dist/hoc/withTheme.d.ts
+@@ -1,3 +1,3 @@
+ import React from 'react';
+ import { AnyComponent, ExecutionProps } from '../types';
+-export default function withTheme<T extends AnyComponent>(Component: T): React.ForwardRefExoticComponent<React.PropsWithoutRef<JSX.LibraryManagedAttributes<T, ExecutionProps>> & React.RefAttributes<T>> & { [key in Exclude<keyof T, T extends React.MemoExoticComponent<any> ? "defaultProps" | "$$typeof" | "displayName" | "type" | "propTypes" | "compare" : T extends React.ForwardRefExoticComponent<any> ? "defaultProps" | "$$typeof" | "displayName" | "propTypes" | "render" : "prototype" | "length" | "arguments" | "caller" | "name" | "defaultProps" | "displayName" | "type" | "propTypes" | "contextType" | "contextTypes" | "childContextTypes" | "getDerivedStateFromProps" | "getDerivedStateFromError" | "getDefaultProps" | "mixins" | "callee" | "arity">]: T[key]; };
++export default function withTheme<T extends AnyComponent>(Component: T): React.ForwardRefExoticComponent<React.PropsWithoutRef<React.JSX.LibraryManagedAttributes<T, ExecutionProps>> & React.RefAttributes<T>> & { [key in Exclude<keyof T, T extends React.MemoExoticComponent<any> ? "defaultProps" | "$$typeof" | "displayName" | "type" | "propTypes" | "compare" : T extends React.ForwardRefExoticComponent<any> ? "defaultProps" | "$$typeof" | "displayName" | "propTypes" | "render" : "prototype" | "length" | "arguments" | "caller" | "name" | "defaultProps" | "displayName" | "type" | "propTypes" | "contextType" | "contextTypes" | "childContextTypes" | "getDerivedStateFromProps" | "getDerivedStateFromError" | "getDefaultProps" | "mixins" | "callee" | "arity">]: T[key]; };
+diff --git a/dist/models/ServerStyleSheet.d.ts b/dist/models/ServerStyleSheet.d.ts
+index b47f4589f4da7b7413b37907c491dadc433c019b..d3f07db75a689eb9d45ddf412537a2b8a0e374b4 100644
+--- a/dist/models/ServerStyleSheet.d.ts
++++ b/dist/models/ServerStyleSheet.d.ts
+@@ -8,9 +8,9 @@ export default class ServerStyleSheet {
+     sealed: boolean;
+     constructor();
+     _emitSheetCSS: () => string;
+-    collectStyles(children: any): JSX.Element;
++    collectStyles(children: any): React.JSX.Element;
+     getStyleTags: () => string;
+     getStyleElement: () => React.JSX.Element[];
+     interleaveWithNodeStream(input: Readable): streamInternal.Transform;
+     seal: () => void;
+ }
+diff --git a/dist/models/StyleSheetManager.d.ts b/dist/models/StyleSheetManager.d.ts
+index a2e4ac7f0ed10ea0e6827956c65a2e066948e3d1..0008e83fba4f3d84e90928da9d9af7cd2c85ad4e 100644
+--- a/dist/models/StyleSheetManager.d.ts
++++ b/dist/models/StyleSheetManager.d.ts
+@@ -62,4 +62,4 @@ export type IStyleSheetManager = React.PropsWithChildren<{
+      */
+     target?: undefined | HTMLElement;
+ }>;
+-export declare function StyleSheetManager(props: IStyleSheetManager): JSX.Element;
++export declare function StyleSheetManager(props: IStyleSheetManager): React.JSX.Element;
+diff --git a/dist/models/ThemeProvider.d.ts b/dist/models/ThemeProvider.d.ts
+index b5d7d32bd1748d30ccba747db5c8c54438124eb4..2511ae972a2cc124b8d703d990865c31264eb528 100644
+--- a/dist/models/ThemeProvider.d.ts
++++ b/dist/models/ThemeProvider.d.ts
+@@ -43,5 +43,5 @@ export declare function useTheme(): DefaultTheme;
+ /**
+  * Provide a theme to an entire react component tree via context
+  */
+-export default function ThemeProvider(props: Props): JSX.Element | null;
++export default function ThemeProvider(props: Props): React.JSX.Element | null;
+ export {};
+diff --git a/dist/types.d.ts b/dist/types.d.ts
+index a76cac2b82b733fa72d9be6ca9b764415d4ed8b4..5e166d7b485e98aa08ef684d7e0450fa601acee3 100644
+--- a/dist/types.d.ts
++++ b/dist/types.d.ts
+@@ -130,13 +130,13 @@ export type PolymorphicComponentProps<R extends Runtime, BaseProps extends objec
+  * any specialized props in the target component.
+  */
+ export interface PolymorphicComponent<R extends Runtime, BaseProps extends object> extends React.ForwardRefExoticComponent<BaseProps> {
+-    <AsTarget extends StyledTarget<R> | void = void, ForwardedAsTarget extends StyledTarget<R> | void = void>(props: PolymorphicComponentProps<R, BaseProps, AsTarget, ForwardedAsTarget>): JSX.Element;
++    <AsTarget extends StyledTarget<R> | void = void, ForwardedAsTarget extends StyledTarget<R> | void = void>(props: PolymorphicComponentProps<R, BaseProps, AsTarget, ForwardedAsTarget>): React.JSX.Element;
+ }
+ export interface IStyledComponentBase<R extends Runtime, Props extends object = BaseObject> extends PolymorphicComponent<R, Props>, IStyledStatics<R, Props>, StyledComponentBrand {
+     defaultProps?: (ExecutionProps & Partial<Props>) | undefined;
+     toString: () => string;
+ }
+-export type IStyledComponent<R extends Runtime, Props extends object = BaseObject> = IStyledComponentBase<R, Props> & 
++export type IStyledComponent<R extends Runtime, Props extends object = BaseObject> = IStyledComponentBase<R, Props> &
+ /**
+  * TypeScript doesn't allow using a styled component as a key inside object
+  * styles because "A computed property name must be of type 'string', 'number',
+diff --git a/native/dist/dist/hoc/withTheme.d.ts b/native/dist/dist/hoc/withTheme.d.ts
+index f3452c16983a0b45ca314c7c717de9f6da75f90a..21fec5f48cc060f485520c0d77afc59bf7e7d487 100644
+--- a/native/dist/dist/hoc/withTheme.d.ts
++++ b/native/dist/dist/hoc/withTheme.d.ts
+@@ -1,3 +1,3 @@
+ import React from 'react';
+ import { AnyComponent, ExecutionProps } from '../types';
+-export default function withTheme<T extends AnyComponent>(Component: T): React.ForwardRefExoticComponent<React.PropsWithoutRef<JSX.LibraryManagedAttributes<T, ExecutionProps>> & React.RefAttributes<T>> & { [key in Exclude<keyof T, T extends React.MemoExoticComponent<any> ? "defaultProps" | "$$typeof" | "displayName" | "type" | "propTypes" | "compare" : T extends React.ForwardRefExoticComponent<any> ? "defaultProps" | "$$typeof" | "displayName" | "propTypes" | "render" : "prototype" | "length" | "arguments" | "caller" | "name" | "defaultProps" | "displayName" | "type" | "propTypes" | "contextType" | "contextTypes" | "childContextTypes" | "getDerivedStateFromProps" | "getDerivedStateFromError" | "getDefaultProps" | "mixins" | "callee" | "arity">]: T[key]; };
++export default function withTheme<T extends AnyComponent>(Component: T): React.ForwardRefExoticComponent<React.PropsWithoutRef<React.JSX.LibraryManagedAttributes<T, ExecutionProps>> & React.RefAttributes<T>> & { [key in Exclude<keyof T, T extends React.MemoExoticComponent<any> ? "defaultProps" | "$$typeof" | "displayName" | "type" | "propTypes" | "compare" : T extends React.ForwardRefExoticComponent<any> ? "defaultProps" | "$$typeof" | "displayName" | "propTypes" | "render" : "prototype" | "length" | "arguments" | "caller" | "name" | "defaultProps" | "displayName" | "type" | "propTypes" | "contextType" | "contextTypes" | "childContextTypes" | "getDerivedStateFromProps" | "getDerivedStateFromError" | "getDefaultProps" | "mixins" | "callee" | "arity">]: T[key]; };
+diff --git a/native/dist/dist/models/ServerStyleSheet.d.ts b/native/dist/dist/models/ServerStyleSheet.d.ts
+index b47f4589f4da7b7413b37907c491dadc433c019b..086123ea82646c4e42a36abfa34b029c1339dc7e 100644
+--- a/native/dist/dist/models/ServerStyleSheet.d.ts
++++ b/native/dist/dist/models/ServerStyleSheet.d.ts
+@@ -8,7 +8,7 @@ export default class ServerStyleSheet {
+     sealed: boolean;
+     constructor();
+     _emitSheetCSS: () => string;
+-    collectStyles(children: any): JSX.Element;
++    collectStyles(children: any): React.JSX.Element;
+     getStyleTags: () => string;
+     getStyleElement: () => React.JSX.Element[];
+     interleaveWithNodeStream(input: Readable): streamInternal.Transform;
+diff --git a/native/dist/dist/models/StyleSheetManager.d.ts b/native/dist/dist/models/StyleSheetManager.d.ts
+index a2e4ac7f0ed10ea0e6827956c65a2e066948e3d1..0008e83fba4f3d84e90928da9d9af7cd2c85ad4e 100644
+--- a/native/dist/dist/models/StyleSheetManager.d.ts
++++ b/native/dist/dist/models/StyleSheetManager.d.ts
+@@ -62,4 +62,4 @@ export type IStyleSheetManager = React.PropsWithChildren<{
+      */
+     target?: undefined | HTMLElement;
+ }>;
+-export declare function StyleSheetManager(props: IStyleSheetManager): JSX.Element;
++export declare function StyleSheetManager(props: IStyleSheetManager): React.JSX.Element;
+diff --git a/native/dist/dist/models/ThemeProvider.d.ts b/native/dist/dist/models/ThemeProvider.d.ts
+index b5d7d32bd1748d30ccba747db5c8c54438124eb4..2511ae972a2cc124b8d703d990865c31264eb528 100644
+--- a/native/dist/dist/models/ThemeProvider.d.ts
++++ b/native/dist/dist/models/ThemeProvider.d.ts
+@@ -43,5 +43,5 @@ export declare function useTheme(): DefaultTheme;
+ /**
+  * Provide a theme to an entire react component tree via context
+  */
+-export default function ThemeProvider(props: Props): JSX.Element | null;
++export default function ThemeProvider(props: Props): React.JSX.Element | null;
+ export {};
+diff --git a/native/dist/dist/types.d.ts b/native/dist/dist/types.d.ts
+index a76cac2b82b733fa72d9be6ca9b764415d4ed8b4..5e166d7b485e98aa08ef684d7e0450fa601acee3 100644
+--- a/native/dist/dist/types.d.ts
++++ b/native/dist/dist/types.d.ts
+@@ -130,13 +130,13 @@ export type PolymorphicComponentProps<R extends Runtime, BaseProps extends objec
+  * any specialized props in the target component.
+  */
+ export interface PolymorphicComponent<R extends Runtime, BaseProps extends object> extends React.ForwardRefExoticComponent<BaseProps> {
+-    <AsTarget extends StyledTarget<R> | void = void, ForwardedAsTarget extends StyledTarget<R> | void = void>(props: PolymorphicComponentProps<R, BaseProps, AsTarget, ForwardedAsTarget>): JSX.Element;
++    <AsTarget extends StyledTarget<R> | void = void, ForwardedAsTarget extends StyledTarget<R> | void = void>(props: PolymorphicComponentProps<R, BaseProps, AsTarget, ForwardedAsTarget>): React.JSX.Element;
+ }
+ export interface IStyledComponentBase<R extends Runtime, Props extends object = BaseObject> extends PolymorphicComponent<R, Props>, IStyledStatics<R, Props>, StyledComponentBrand {
+     defaultProps?: (ExecutionProps & Partial<Props>) | undefined;
+     toString: () => string;
+ }
+-export type IStyledComponent<R extends Runtime, Props extends object = BaseObject> = IStyledComponentBase<R, Props> & 
++export type IStyledComponent<R extends Runtime, Props extends object = BaseObject> = IStyledComponentBase<R, Props> &
+ /**
+  * TypeScript doesn't allow using a styled component as a key inside object
+  * styles because "A computed property name must be of type 'string', 'number',
+diff --git a/native/dist/hoc/withTheme.d.ts b/native/dist/hoc/withTheme.d.ts
+index 7d244d05cbfd990881338c15ec8d53afc578f5bd..21a2eafb196fb5372b0ad2dbae6af015b16b4587 100644
+--- a/native/dist/hoc/withTheme.d.ts
++++ b/native/dist/hoc/withTheme.d.ts
+@@ -1,3 +1,3 @@
+ import React from 'react';
+ import { AnyComponent, ExecutionProps } from '../types';
+-export default function withTheme<T extends AnyComponent>(Component: T): React.ForwardRefExoticComponent<React.PropsWithoutRef<JSX.LibraryManagedAttributes<T, ExecutionProps>> & React.RefAttributes<T>> & { [key in Exclude<keyof T, T extends React.MemoExoticComponent<any> ? "propTypes" | "defaultProps" | "displayName" | "$$typeof" | "type" | "compare" : T extends React.ForwardRefExoticComponent<any> ? "propTypes" | "defaultProps" | "displayName" | "$$typeof" | "render" : "length" | "propTypes" | "contextType" | "contextTypes" | "childContextTypes" | "defaultProps" | "displayName" | "getDerivedStateFromProps" | "getDerivedStateFromError" | "type" | "getDefaultProps" | "mixins" | "name" | "prototype" | "caller" | "callee" | "arguments" | "arity">]: T[key]; };
++export default function withTheme<T extends AnyComponent>(Component: T): React.ForwardRefExoticComponent<React.PropsWithoutRef<React.JSX.LibraryManagedAttributes<T, ExecutionProps>> & React.RefAttributes<T>> & { [key in Exclude<keyof T, T extends React.MemoExoticComponent<any> ? "propTypes" | "defaultProps" | "displayName" | "$$typeof" | "type" | "compare" : T extends React.ForwardRefExoticComponent<any> ? "propTypes" | "defaultProps" | "displayName" | "$$typeof" | "render" : "length" | "propTypes" | "contextType" | "contextTypes" | "childContextTypes" | "defaultProps" | "displayName" | "getDerivedStateFromProps" | "getDerivedStateFromError" | "type" | "getDefaultProps" | "mixins" | "name" | "prototype" | "caller" | "callee" | "arguments" | "arity">]: T[key]; };
+diff --git a/native/dist/models/ServerStyleSheet.d.ts b/native/dist/models/ServerStyleSheet.d.ts
+index b47f4589f4da7b7413b37907c491dadc433c019b..086123ea82646c4e42a36abfa34b029c1339dc7e 100644
+--- a/native/dist/models/ServerStyleSheet.d.ts
++++ b/native/dist/models/ServerStyleSheet.d.ts
+@@ -8,7 +8,7 @@ export default class ServerStyleSheet {
+     sealed: boolean;
+     constructor();
+     _emitSheetCSS: () => string;
+-    collectStyles(children: any): JSX.Element;
++    collectStyles(children: any): React.JSX.Element;
+     getStyleTags: () => string;
+     getStyleElement: () => React.JSX.Element[];
+     interleaveWithNodeStream(input: Readable): streamInternal.Transform;
+diff --git a/native/dist/models/StyleSheetManager.d.ts b/native/dist/models/StyleSheetManager.d.ts
+index a2e4ac7f0ed10ea0e6827956c65a2e066948e3d1..0008e83fba4f3d84e90928da9d9af7cd2c85ad4e 100644
+--- a/native/dist/models/StyleSheetManager.d.ts
++++ b/native/dist/models/StyleSheetManager.d.ts
+@@ -62,4 +62,4 @@ export type IStyleSheetManager = React.PropsWithChildren<{
+      */
+     target?: undefined | HTMLElement;
+ }>;
+-export declare function StyleSheetManager(props: IStyleSheetManager): JSX.Element;
++export declare function StyleSheetManager(props: IStyleSheetManager): React.JSX.Element;
+diff --git a/native/dist/models/ThemeProvider.d.ts b/native/dist/models/ThemeProvider.d.ts
+index b5d7d32bd1748d30ccba747db5c8c54438124eb4..2511ae972a2cc124b8d703d990865c31264eb528 100644
+--- a/native/dist/models/ThemeProvider.d.ts
++++ b/native/dist/models/ThemeProvider.d.ts
+@@ -43,5 +43,5 @@ export declare function useTheme(): DefaultTheme;
+ /**
+  * Provide a theme to an entire react component tree via context
+  */
+-export default function ThemeProvider(props: Props): JSX.Element | null;
++export default function ThemeProvider(props: Props): React.JSX.Element | null;
+ export {};
+diff --git a/native/dist/types.d.ts b/native/dist/types.d.ts
+index 4a6953c145bbd6c0880378e09e0de80b7a2113f0..1e023c172fe4b569ec1a03710305458109931022 100644
+--- a/native/dist/types.d.ts
++++ b/native/dist/types.d.ts
+@@ -130,7 +130,7 @@ export type PolymorphicComponentProps<R extends Runtime, BaseProps extends objec
+  * any specialized props in the target component.
+  */
+ export interface PolymorphicComponent<R extends Runtime, BaseProps extends object> extends React.ForwardRefExoticComponent<BaseProps> {
+-    <AsTarget extends StyledTarget<R> | void = void, ForwardedAsTarget extends StyledTarget<R> | void = void>(props: PolymorphicComponentProps<R, BaseProps, AsTarget, ForwardedAsTarget>): JSX.Element;
++    <AsTarget extends StyledTarget<R> | void = void, ForwardedAsTarget extends StyledTarget<R> | void = void>(props: PolymorphicComponentProps<R, BaseProps, AsTarget, ForwardedAsTarget>): React.JSX.Element;
+ }
+ export interface IStyledComponent<R extends Runtime, Props extends object = BaseObject> extends PolymorphicComponent<R, Props>, IStyledStatics<R, Props>, StyledComponentBrand {
+     defaultProps?: (ExecutionProps & Partial<Props>) | undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,11 @@ overrides:
   '@pigment-css/nextjs-plugin': 0.0.18
   '@pigment-css/vite-plugin': 0.0.18
 
+patchedDependencies:
+  styled-components@6.1.12:
+    hash: ua4w6griwxbnxnkzzvndsl67he
+    path: patches/styled-components@6.1.12.patch
+
 importers:
 
   .:
@@ -520,7 +525,7 @@ importers:
         version: 6.1.5
       styled-components:
         specifier: ^6.1.12
-        version: 6.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.1.12(patch_hash=ua4w6griwxbnxnkzzvndsl67he)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       styled-system:
         specifier: ^5.1.5
         version: 5.1.5
@@ -796,7 +801,7 @@ importers:
         version: 5.0.10
       styled-components:
         specifier: ^6.1.12
-        version: 6.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.1.12(patch_hash=ua4w6griwxbnxnkzzvndsl67he)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       stylis:
         specifier: 4.2.0
         version: 4.2.0
@@ -1943,7 +1948,7 @@ importers:
         version: 18.3.1
       styled-components:
         specifier: ^6.1.12
-        version: 6.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.1.12(patch_hash=ua4w6griwxbnxnkzzvndsl67he)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     publishDirectory: build
 
   packages/mui-styles:
@@ -2103,7 +2108,7 @@ importers:
         version: 16.1.3
       styled-components:
         specifier: ^6.1.12
-        version: 6.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.1.12(patch_hash=ua4w6griwxbnxnkzzvndsl67he)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     publishDirectory: build
 
   packages/mui-types:
@@ -2306,7 +2311,7 @@ importers:
         version: 16.1.3
       styled-components:
         specifier: ^6.1.12
-        version: 6.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.1.12(patch_hash=ua4w6griwxbnxnkzzvndsl67he)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       stylis:
         specifier: 4.2.0
         version: 4.2.0
@@ -10320,7 +10325,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qjobs@1.2.0:
@@ -23500,7 +23504,7 @@ snapshots:
 
   style-search@0.1.0: {}
 
-  styled-components@6.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  styled-components@6.1.12(patch_hash=ua4w6griwxbnxnkzzvndsl67he)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@emotion/is-prop-valid': 1.2.2
       '@emotion/unitless': 0.8.1


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/42381

Commits cherry-picked/based on https://github.com/mui/material-ui/pull/42824

Patches `styled-components` to use the `React.JSX` TS namespace instead of `JSX`. More info in the [React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript).