### PR TITLE
fix(docs): missing and incorrect scripts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ To install the required packages, from `/docs`, run:
 pnpm install
 ```
 
-To start the docs site in development mode, from the project root, run:
+To start the docs site in development mode, from `/docs`, run:
 
 ```bash
 pnpm dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ pnpm install
 To start the docs site in development mode, from the project root, run:
 
 ```bash
-pnpm start
+pnpm dev
 ```
 
 If you do not have pnpm installed, select your OS and follow the instructions on the [pnpm website](https://pnpm.io/installation).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,12 @@
 
 This is the website of the company (MUI), the documentation of Material UI, Base UI, MUI System, and Joy UI.
 
+To install the required packages, from `/docs`, run:
+
+```bash
+pnpm install
+```
+
 To start the docs site in development mode, from the project root, run:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,16 +2,10 @@
 
 This is the website of the company (MUI), the documentation of Material UI, Base UI, MUI System, and Joy UI.
 
-To install the required packages, from `/docs`, run:
+To start the docs site in development mode, from the project root, run:
 
 ```bash
-pnpm install
-```
-
-To start the docs site in development mode, from `/docs`, run:
-
-```bash
-pnpm dev
+pnpm docs:dev
 ```
 
 If you do not have pnpm installed, select your OS and follow the instructions on the [pnpm website](https://pnpm.io/installation).


### PR DESCRIPTION
Closes #43208

Adds a missing script: `pnpm install`.
Updates an incorrect script: `pnpm start` to `pnpm dev`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
