### PR TITLE
[test] Remove unnecessary prop type check in test

### DIFF
--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -114,13 +114,6 @@ describe('<Masonry />', () => {
         this.skip();
       }
 
-      // React 19 removed prop types support
-      if (reactMajor < 19) {
-        expect(() => render(<Masonry columns={3} spacing={1} />)).toErrorDev(
-          'Warning: Failed prop type: The prop `children` is marked as required in `ForwardRef(Masonry)`, but its value is `undefined`.',
-        );
-      }
-
       expect(() => render(<Masonry columns={3} spacing={1} />)).not.to.throw(new TypeError());
     });
   });

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -114,6 +114,13 @@ describe('<Masonry />', () => {
         this.skip();
       }
 
+      // React 19 removed prop types support
+      if (reactMajor < 19) {
+        expect(() => render(<Masonry columns={3} spacing={1} />)).toErrorDev(
+          'Warning: Failed prop type: The prop `children` is marked as required in `ForwardRef(Masonry)`, but its value is `undefined`.',
+        );
+      }
+
       expect(() => render(<Masonry columns={3} spacing={1} />)).not.to.throw(new TypeError());
     });
   });

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -115,7 +115,7 @@ describe('<Masonry />', () => {
       }
 
       // React 19 removed prop types support
-      if (reactMajor < 18) {
+      if (reactMajor < 19) {
         expect(() => render(<Masonry columns={3} spacing={1} />)).toErrorDev(
           'Warning: Failed prop type: The prop `children` is marked as required in `ForwardRef(Masonry)`, but its value is `undefined`.',
         );

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -100,6 +100,7 @@ describe('<Masonry />', () => {
     });
 
     it('should throw console error when children are empty', function test() {
+      // React 19 removed prop types support
       if (!/jsdom/.test(window.navigator.userAgent) || reactMajor >= 19) {
         this.skip();
       }
@@ -112,9 +113,14 @@ describe('<Masonry />', () => {
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
-      expect(() => render(<Masonry columns={3} spacing={1} />)).toErrorDev(
-        'Warning: Failed prop type: The prop `children` is marked as required in `ForwardRef(Masonry)`, but its value is `undefined`.',
-      );
+
+      // React 19 removed prop types support
+      if (reactMajor < 18) {
+        expect(() => render(<Masonry columns={3} spacing={1} />)).toErrorDev(
+          'Warning: Failed prop type: The prop `children` is marked as required in `ForwardRef(Masonry)`, but its value is `undefined`.',
+        );
+      }
+
       expect(() => render(<Masonry columns={3} spacing={1} />)).not.to.throw(new TypeError());
     });
   });


### PR DESCRIPTION
Removes a prop type check in a test because it's already covered in another test in the same file. We forgot to fix this one in https://github.com/mui/material-ui/pull/43155.

Example of the test failure without this fix: https://app.circleci.com/pipelines/github/mui/material-ui/135461/workflows/b151718a-3164-404f-974a-3c13802fca53/jobs/730232?invite=true#step-111-171

Context: React 19 removed prop type checks so we need to skip them in prior versions. More info: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops