### PR TITLE
[material-ui][mui-system] Cherry-pick: Add support for version runtime checks (#43190)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -88,6 +88,19 @@ module.exports = function getBabelConfig(api) {
         mode: 'unsafe-wrap',
       },
     ],
+    [
+      'transform-inline-environment-variables',
+      {
+        include: [
+          'MUI_VERSION',
+          'MUI_MAJOR_VERSION',
+          'MUI_MINOR_VERSION',
+          'MUI_PATCH_VERSION',
+          'MUI_PRERELEASE_LABEL',
+          'MUI_PRERELEASE_NUMBER',
+        ],
+      },
+    ],
   ];
 
   if (process.env.NODE_ENV === 'production') {

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-plugin-optimize-clsx": "^2.6.2",
     "babel-plugin-react-remove-properties": "^0.3.0",
+    "babel-plugin-transform-inline-environment-variables": "^0.4.4",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "chalk": "^5.3.0",
     "compression-webpack-plugin": "^11.1.0",

--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -476,6 +476,8 @@ export * from './useAutocomplete';
 export { default as GlobalStyles } from './GlobalStyles';
 export * from './GlobalStyles';
 
+export * from './version';
+
 /**
  * @deprecated will be removed in v5.beta, please use StyledEngineProvider from @mui/material/styles instead
  */

--- a/packages/mui-material/src/index.js
+++ b/packages/mui-material/src/index.js
@@ -417,3 +417,5 @@ export * from './generateUtilityClass';
 export { default as generateUtilityClasses } from './generateUtilityClasses';
 
 export { default as Unstable_TrapFocus } from './Unstable_TrapFocus';
+
+export * from './version';

--- a/packages/mui-material/src/index.test.js
+++ b/packages/mui-material/src/index.test.js
@@ -6,15 +6,24 @@
 import { expect } from 'chai';
 import * as MaterialUI from './index';
 
+const versionExports = [
+  'version',
+  'major',
+  'minor',
+  'patch',
+  'preReleaseLabel',
+  'preReleaseNumber',
+];
+
 describe('material-ui', () => {
   it('should have exports', () => {
     expect(typeof MaterialUI).to.equal('object');
   });
 
   it('should not have undefined exports', () => {
-    Object.keys(MaterialUI).forEach((exportKey) =>
-      expect(Boolean(MaterialUI[exportKey])).to.equal(true),
-    );
+    Object.keys(MaterialUI)
+      .filter((exportKey) => !versionExports.includes(exportKey))
+      .forEach((exportKey) => expect(Boolean(MaterialUI[exportKey])).to.equal(true));
   });
 
   it('should reexport certain members from @mui/base', () => {

--- a/packages/mui-material/src/version/index.ts
+++ b/packages/mui-material/src/version/index.ts
@@ -1,0 +1,8 @@
+export const version = process.env.MUI_VERSION;
+export const major = Number(process.env.MUI_MAJOR_VERSION);
+export const minor = Number(process.env.MUI_MINOR_VERSION);
+export const patch = Number(process.env.MUI_PATCH_VERSION);
+export const preReleaseLabel = process.env.MUI_PRERELEASE_LABEL || null;
+export const preReleaseNumber = Number(process.env.MUI_PRERELEASE_NUMBER) || null;
+
+export default version;

--- a/packages/mui-system/src/index.d.ts
+++ b/packages/mui-system/src/index.d.ts
@@ -181,3 +181,5 @@ export * from './Unstable_Grid';
 
 export { default as Stack } from './Stack';
 export * from './Stack';
+
+export * from './version';

--- a/packages/mui-system/src/index.js
+++ b/packages/mui-system/src/index.js
@@ -66,6 +66,7 @@ export { default as unstable_createCssVarsTheme } from './cssVars/createCssVarsT
 export { default as responsivePropType } from './responsivePropType';
 export { default as RtlProvider } from './RtlProvider';
 export * from './RtlProvider';
+export * from './version';
 
 /** ----------------- */
 /** Layout components */

--- a/packages/mui-system/src/version/index.ts
+++ b/packages/mui-system/src/version/index.ts
@@ -1,0 +1,8 @@
+export const version = process.env.MUI_VERSION;
+export const major = Number(process.env.MUI_MAJOR_VERSION);
+export const minor = Number(process.env.MUI_MINOR_VERSION);
+export const patch = Number(process.env.MUI_PATCH_VERSION);
+export const preReleaseLabel = process.env.MUI_PRERELEASE_LABEL || null;
+export const preReleaseNumber = Number(process.env.MUI_PRERELEASE_NUMBER) || null;
+
+export default version;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       babel-plugin-react-remove-properties:
         specifier: ^0.3.0
         version: 0.3.0
+      babel-plugin-transform-inline-environment-variables:
+        specifier: ^0.4.4
+        version: 0.4.4
       babel-plugin-transform-react-remove-prop-types:
         specifier: ^0.4.24
         version: 0.4.24
@@ -5744,6 +5747,9 @@ packages:
 
   babel-plugin-transform-flow-enums@0.0.2:
     resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
+
+  babel-plugin-transform-inline-environment-variables@0.4.4:
+    resolution: {integrity: sha512-bJILBtn5a11SmtR2j/3mBOjX4K3weC6cq+NNZ7hG22wCAqpc3qtj/iN7dSe9HDiS46lgp1nHsQgeYrea/RUe+g==}
 
   babel-plugin-transform-react-remove-prop-types@0.4.24:
     resolution: {integrity: sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==}
@@ -16682,6 +16688,8 @@ snapshots:
       '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.9)
     transitivePeerDependencies:
       - '@babel/core'
+
+  babel-plugin-transform-inline-environment-variables@0.4.4: {}
 
   babel-plugin-transform-react-remove-prop-types@0.4.24: {}
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -31,7 +31,7 @@ async function run(argv) {
     NODE_ENV: 'production',
     BABEL_ENV: bundle,
     MUI_BUILD_VERBOSE: verbose,
-    ...getVersionEnvVariables(),
+    ...(await getVersionEnvVariables()),
   };
 
   const babelConfigPath = path.resolve(getWorkspaceRoot(), 'babel.config.js');

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -3,7 +3,7 @@ import glob from 'fast-glob';
 import path from 'path';
 import { promisify } from 'util';
 import yargs from 'yargs';
-import { getWorkspaceRoot } from './utils.mjs';
+import { getVersionEnvVariables, getWorkspaceRoot } from './utils.mjs';
 
 const exec = promisify(childProcess.exec);
 
@@ -31,7 +31,9 @@ async function run(argv) {
     NODE_ENV: 'production',
     BABEL_ENV: bundle,
     MUI_BUILD_VERBOSE: verbose,
+    ...(await getVersionEnvVariables()),
   };
+
   const babelConfigPath = path.resolve(getWorkspaceRoot(), 'babel.config.js');
   const srcDir = path.resolve('./src');
   const extensions = ['.js', '.ts', '.tsx'];

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -31,7 +31,7 @@ async function run(argv) {
     NODE_ENV: 'production',
     BABEL_ENV: bundle,
     MUI_BUILD_VERBOSE: verbose,
-    ...(await getVersionEnvVariables()),
+    ...getVersionEnvVariables(),
   };
 
   const babelConfigPath = path.resolve(getWorkspaceRoot(), 'babel.config.js');

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,5 +1,6 @@
 import path from 'path';
 import url from 'url';
+import fse from 'fs-extra';
 
 /**
  * Returns the full path of the root directory of this repository.
@@ -9,4 +10,33 @@ export function getWorkspaceRoot() {
   const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
   const workspaceRoot = path.resolve(currentDirectory, '..');
   return workspaceRoot;
+}
+
+/**
+ * Returns the version and destructured values of the version as env variables to be replaced.
+ */
+export async function getVersionEnvVariables() {
+  const packageJsonData = await fse.readFile(path.resolve('./package.json'), 'utf8');
+  const { version = null } = JSON.parse(packageJsonData);
+
+  if (!version) {
+    throw new Error('Could not find the version in the package.json');
+  }
+
+  const [versionNumber, preReleaseInfo] = version.split('-');
+  const [major, minor, patch] = versionNumber.split('.');
+  const [preReleaseLabel, preReleaseNumber] = preReleaseInfo ? preReleaseInfo.split('.') : [];
+
+  if (!major || !minor || !patch) {
+    throw new Error(`Couldn't parse version from package.json`);
+  }
+
+  return {
+    MUI_VERSION: version,
+    MUI_MAJOR_VERSION: major,
+    MUI_MINOR_VERSION: minor,
+    MUI_PATCH_VERSION: patch,
+    MUI_PRERELEASE_LABEL: preReleaseLabel,
+    MUI_PRERELEASE_NUMBER: preReleaseNumber,
+  };
 }

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,6 +1,6 @@
 import path from 'path';
 import url from 'url';
-import fse from 'fs-extra';
+import fs from 'fs';
 
 /**
  * Returns the full path of the root directory of this repository.
@@ -15,8 +15,8 @@ export function getWorkspaceRoot() {
 /**
  * Returns the version and destructured values of the version as env variables to be replaced.
  */
-export async function getVersionEnvVariables() {
-  const packageJsonData = await fse.readFile(path.resolve('./package.json'), 'utf8');
+export function getVersionEnvVariables() {
+  const packageJsonData = fs.readFileSync(path.resolve('./package.json'), 'utf8');
   const { version = null } = JSON.parse(packageJsonData);
 
   if (!version) {

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,6 +1,6 @@
 import path from 'path';
 import url from 'url';
-import fs from 'fs';
+import fs from 'fs/promises';
 
 /**
  * Returns the full path of the root directory of this repository.
@@ -15,8 +15,8 @@ export function getWorkspaceRoot() {
 /**
  * Returns the version and destructured values of the version as env variables to be replaced.
  */
-export function getVersionEnvVariables() {
-  const packageJsonData = fs.readFileSync(path.resolve('./package.json'), 'utf8');
+export async function getVersionEnvVariables() {
+  const packageJsonData = await fs.readFile(path.resolve('./package.json'), 'utf8');
   const { version = null } = JSON.parse(packageJsonData);
 
   if (!version) {


### PR DESCRIPTION
Cherry-pick #43190 to master, so the version consts are available in v5 as well
