### PR TITLE
[core] Use fs instead of fs-extra in script utils

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -29,7 +29,7 @@ async function run(argv) {
     NODE_ENV: 'production',
     BABEL_ENV: bundle,
     MUI_BUILD_VERBOSE: verbose,
-    ...(await getVersionEnvVariables()),
+    ...getVersionEnvVariables(),
   };
 
   const babelConfigPath = path.resolve(getWorkspaceRoot(), 'babel.config.js');

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -29,7 +29,7 @@ async function run(argv) {
     NODE_ENV: 'production',
     BABEL_ENV: bundle,
     MUI_BUILD_VERBOSE: verbose,
-    ...getVersionEnvVariables(),
+    ...(await getVersionEnvVariables()),
   };
 
   const babelConfigPath = path.resolve(getWorkspaceRoot(), 'babel.config.js');

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,6 +1,6 @@
 import path from 'path';
 import url from 'url';
-import fse from 'fs-extra';
+import fs from 'fs';
 
 /**
  * Returns the full path of the root directory of this repository.
@@ -15,8 +15,8 @@ export function getWorkspaceRoot() {
 /**
  * Returns the version and destructured values of the version as env variables to be replaced.
  */
-export async function getVersionEnvVariables() {
-  const packageJsonData = await fse.readFile(path.resolve('./package.json'), 'utf8');
+export function getVersionEnvVariables() {
+  const packageJsonData = fs.readFileSync(path.resolve('./package.json'), 'utf8');
   const { version = null } = JSON.parse(packageJsonData);
 
   if (!version) {

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,6 +1,6 @@
 import path from 'path';
 import url from 'url';
-import fs from 'fs';
+import fs from 'fs/promises';
 
 /**
  * Returns the full path of the root directory of this repository.
@@ -15,8 +15,8 @@ export function getWorkspaceRoot() {
 /**
  * Returns the version and destructured values of the version as env variables to be replaced.
  */
-export function getVersionEnvVariables() {
-  const packageJsonData = fs.readFileSync(path.resolve('./package.json'), 'utf8');
+export async function getVersionEnvVariables() {
+  const packageJsonData = await fs.readFile(path.resolve('./package.json'), 'utf8');
   const { version = null } = JSON.parse(packageJsonData);
 
   if (!version) {


### PR DESCRIPTION
Use `fs` instead of `fs-extra` in utils to avoid [this pitfall](https://github.com/DiegoAndai/material-ui/blob/next/scripts/useReactVersion.mjs#L7). I'm not sure why it didn't fail in https://github.com/mui/material-ui/pull/43190 but it did in https://github.com/mui/material-ui/pull/43233.
