### PR TITLE
[material-ui][Modal] Fix exited initial state

### DIFF
--- a/packages/mui-material/src/Modal/useModal.ts
+++ b/packages/mui-material/src/Modal/useModal.ts
@@ -58,7 +58,7 @@ function useModal(parameters: UseModalParameters): UseModalReturnValue {
   const mountNodeRef = React.useRef<HTMLElement | null>(null);
   const modalRef = React.useRef<HTMLDivElement>(null);
   const handleRef = useForkRef(modalRef, rootRef);
-  const [exited, setExited] = React.useState(!open);
+  const [exited, setExited] = React.useState(true);
   const hasTransition = getHasTransition(children);
 
   let ariaHiddenProp = true;


### PR DESCRIPTION
While upgrading to React 19 ([PR](https://github.com/mui/material-ui/pull/42824)), a `Modal` component test started to fail ([failure example](https://app.circleci.com/pipelines/github/mui/material-ui/135645/workflows/fddf4f65-f8dc-488b-ac66-5ce83d40c941/jobs/731226?invite=true#step-106-44)). The `Modal` is not unmounted.

https://github.com/mui/material-ui/blob/d00b50e76cc7f81f93307d151ab72a2ea6407b4a/packages/mui-material/src/Modal/Modal.test.js#L590-L612 

The [issue](https://github.com/mui/material-ui/issues/12831) linked in the comment above the test points to a [PR](https://github.com/mui/material-ui/pull/16694) where a fix was implemented for a bug with the backdrop staying open. The fix consisted on:

```diff
-const [exited, setExited] = React.useState(!open);
+const [exited, setExited] = React.useState(true);
```

This fix was lost in translation once `Modal` was migrated to use `useModal` from Base UI. Last year, a user [reported the bug](https://github.com/mui/material-ui/issues/12831#issuecomment-1441222517) again.

Re-applying the old fix solves the failing test and I don't see any downsides with it. Plus using `true` as the initial state is the approach used [across the codebase](https://github.com/search?q=repo%3Amui%2Fmaterial-ui%20%22const%20%5Bexited%2C%20setExited%5D%20%3D%20React.useState(true)%3B%22&type=code), with `Modal` being the only component using `!open` as the initial state.

**Why the test started to fail in React 19?** The exact reason is unclear, but spending too much time on it seems not worth it given Base UI is in the horizon.

You can see the test passing in the React 19 [PR](https://github.com/mui/material-ui/pull/42824) with this PR's change applied.

### How to test

Make sure all `Modal` demos work as expected.