### PR TITLE
[IconButton] Fix hover background color behavior

### DIFF
--- a/packages/mui-material/src/IconButton/IconButton.js
+++ b/packages/mui-material/src/IconButton/IconButton.js
@@ -164,6 +164,7 @@ const IconButton = React.forwardRef(function IconButton(inProps, ref) {
     color = 'default',
     disabled = false,
     disableFocusRipple = false,
+    disableRipple = false,
     size = 'medium',
     ...other
   } = props;
@@ -174,6 +175,7 @@ const IconButton = React.forwardRef(function IconButton(inProps, ref) {
     color,
     disabled,
     disableFocusRipple,
+    disableRipple,
     size,
   };
 
@@ -185,6 +187,7 @@ const IconButton = React.forwardRef(function IconButton(inProps, ref) {
       centerRipple
       focusRipple={!disableFocusRipple}
       disabled={disabled}
+      disableRipple={disableRipple}
       ref={ref}
       {...other}
       ownerState={ownerState}

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import { createRenderer, reactMajor } from '@mui/internal-test-utils';
+import { createRenderer, reactMajor, fireEvent } from '@mui/internal-test-utils';
 import capitalize from '@mui/utils/capitalize';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import IconButton, { iconButtonClasses as classes } from '@mui/material/IconButton';
@@ -140,5 +140,23 @@ describe('<IconButton />', () => {
         <IconButton />
       </ThemeProvider>
     )).not.to.throw();
+  });
+
+  it('should apply the hover background by default', () => {
+    const { container, getByTestId } = render(<IconButton data-testid="icon" />);
+
+    fireEvent.mouseMove(container.firstChild, {
+      clientX: 19,
+    });
+    expect(getComputedStyle(getByTestId('icon')).backgroundColor).to.equal('rgba(0, 0, 0, 0.04)');
+  });
+
+  it('should not apply the hover background if disableRipple is true', () => {
+    const { container, getByTestId } = render(<IconButton disableRipple data-testid="icon" />);
+
+    fireEvent.mouseMove(container.firstChild, {
+      clientX: 19,
+    });
+    expect(getComputedStyle(getByTestId('icon')).backgroundColor).to.equal('rgba(0, 0, 0, 0)');
   });
 });

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -142,7 +142,11 @@ describe('<IconButton />', () => {
     )).not.to.throw();
   });
 
-  it('should apply the hover background by default', () => {
+  it('should apply the hover background by default', function test() {
+    if(!/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+    
     const { container, getByTestId } = render(<IconButton data-testid="icon-button" />);
 
     fireEvent.mouseMove(container.firstChild, {
@@ -154,6 +158,10 @@ describe('<IconButton />', () => {
   });
 
   it('should not apply the hover background if disableRipple is true', () => {
+    if(!/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
     const { container, getByTestId } = render(
       <IconButton disableRipple data-testid="icon-button" />,
     );

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -143,10 +143,10 @@ describe('<IconButton />', () => {
   });
 
   it('should apply the hover background by default', function test() {
-    if(!/jsdom/.test(window.navigator.userAgent)) {
+    if (!/jsdom/.test(window.navigator.userAgent)) {
       this.skip();
     }
-    
+
     const { container, getByTestId } = render(<IconButton data-testid="icon-button" />);
 
     fireEvent.mouseMove(container.firstChild, {
@@ -157,8 +157,8 @@ describe('<IconButton />', () => {
     });
   });
 
-  it('should not apply the hover background if disableRipple is true', () => {
-    if(!/jsdom/.test(window.navigator.userAgent)) {
+  it('should not apply the hover background if disableRipple is true', function test() {
+    if (!/jsdom/.test(window.navigator.userAgent)) {
       this.skip();
     }
 

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -143,20 +143,24 @@ describe('<IconButton />', () => {
   });
 
   it('should apply the hover background by default', () => {
-    const { container, getByTestId } = render(<IconButton data-testid="icon" />);
+    const { container, getByTestId } = render(<IconButton data-testid="icon-button" />);
 
     fireEvent.mouseMove(container.firstChild, {
       clientX: 19,
     });
-    expect(getComputedStyle(getByTestId('icon')).backgroundColor).to.equal('rgba(0, 0, 0, 0.04)');
+    expect(getByTestId('icon-button')).toHaveComputedStyle({
+      backgroundColor: 'rgba(0, 0, 0, 0.04)',
+    });
   });
 
   it('should not apply the hover background if disableRipple is true', () => {
-    const { container, getByTestId } = render(<IconButton disableRipple data-testid="icon" />);
+    const { container, getByTestId } = render(
+      <IconButton disableRipple data-testid="icon-button" />,
+    );
 
     fireEvent.mouseMove(container.firstChild, {
       clientX: 19,
     });
-    expect(getComputedStyle(getByTestId('icon')).backgroundColor).to.equal('rgba(0, 0, 0, 0)');
+    expect(getByTestId('icon-button')).toHaveComputedStyle({ backgroundColor: 'rgba(0, 0, 0, 0)' });
   });
 });


### PR DESCRIPTION
The hover behavior was broken on the IconButton component, as the styles are looking for `disabledRipple: false` (for e.g. check [this](https://github.com/mui/material-ui/blob/490abc4820ffe15d0c3c8143d4cde929405480b2/packages/mui-material/src/IconButton/IconButton.js#L56)), while there was no default value set in the component.

Preview: https://deploy-preview-43271--material-ui.netlify.app/material-ui/react-button/#icon-button
Previous behavior: https://next.mui.com/material-ui/react-button/#icon-button