### PR TITLE
[core] Fix Netlify build cache issue

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,6 @@
 
 [build.environment]
   NODE_VERSION = "18"
-  PNPM_FLAGS = "--shamefully-hoist"
 
 [[plugins]]
   package = "./packages/netlify-plugin-cache-docs"


### PR DESCRIPTION
Replicate the change in: https://github.com/mui/mui-x/pull/14182.

It looks like this setting was the culprit of sporadic Netlify behavior such as pulling a stale cache on some builds.