### PR TITLE
[website] Replace React.MutableRefObject with React.RefObject

### DIFF
--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -1088,7 +1088,7 @@ function StickyHead({
   container,
   disableCalculation = false,
 }: {
-  container: React.MutableRefObject<HTMLElement | null>;
+  container: React.RefObject<HTMLElement | null>;
   disableCalculation?: boolean;
 }) {
   const [hidden, setHidden] = React.useState(true);

--- a/docs/src/components/productMaterial/MaterialStyling.tsx
+++ b/docs/src/components/productMaterial/MaterialStyling.tsx
@@ -64,7 +64,7 @@ const endLine = [37, 20, 12];
 const scrollTo = [27, 10, 4];
 
 export const useResizeHandle = (
-  target: React.MutableRefObject<HTMLDivElement | null>,
+  target: React.RefObject<HTMLDivElement | null>,
   options?: { minWidth?: string; maxWidth?: string },
 ) => {
   const { minWidth = '0px', maxWidth = '100%' } = options || {};


### PR DESCRIPTION
Extracted from https://github.com/mui/material-ui/pull/42824

Replacing a couple of instances of `React.MutableRefObject` with `React.RefObject`. `React.MutableRefObject` will be deprecated in React 19 types.