### PR TITLE
[docs-infra] Fix some TS issues for X docs

### DIFF
--- a/docs/src/modules/components/ApiPage.tsx
+++ b/docs/src/modules/components/ApiPage.tsx
@@ -94,7 +94,7 @@ interface ApiPageProps {
   descriptions: {
     [lang: string]: PropsTranslations & {
       // Table of Content added by the mapApiPageTranslations function
-      componentDescriptionToc: TableOfContentsEntry[];
+      componentDescriptionToc: TableOfContentsParams[];
     };
   };
   disableAd?: boolean;

--- a/docs/src/modules/components/ApiPage.tsx
+++ b/docs/src/modules/components/ApiPage.tsx
@@ -180,17 +180,17 @@ export default function ApiPage(props: ApiPageProps) {
     slotDescriptions,
   });
 
-  function createTocEntry(sectionName: ApiHeaderKeys) {
+  function createTocEntry(sectionName: ApiHeaderKeys): TableOfContentsParams {
     return {
       text: getTranslatedHeader(t, sectionName),
       hash: sectionName,
       children: [
         ...(sectionName === 'props' && inheritance
           ? [{ text: t('api-docs.inheritance'), hash: 'inheritance', children: [] }]
-          : []),
+          : ([] as TableOfContentsParams[])),
         ...(sectionName === 'props' && pageContent.themeDefaultProps
           ? [{ text: t('api-docs.themeDefaultProps'), hash: 'theme-default-props', children: [] }]
-          : []),
+          : ([] as TableOfContentsParams[])),
       ],
     };
   }

--- a/docs/src/modules/components/AppLayoutDocs.d.ts
+++ b/docs/src/modules/components/AppLayoutDocs.d.ts
@@ -1,0 +1,18 @@
+export interface AppLayoutDocsProps {
+  BannerComponent: React.ElementType;
+  cardOptions: {
+    description: string;
+    title: string;
+  };
+  children: React.ReactNode;
+  description: string;
+  disableAd: boolean;
+  disableLayout: boolean;
+  disableToc: boolean;
+  hasTabs: boolean;
+  location: string;
+  title: string;
+  toc: any[];
+}
+
+export default React.ComponentType<AppLayoutDocsProps>;


### PR DESCRIPTION
Make some typing fixes that we need in X and Toolpad
* Add typings for `docs/src/modules/components/AppLayoutDocs.js`.  We can also migrate to TS, but this was quick and easy
* Some type issues in `docs/src/modules/components/ApiPage.tsx` that for some reason are not reported in the core repo. To investigate


See https://github.com/mui/mui-x/pull/14141