### PR TITLE
[docs/perf] Update babel config

### DIFF
--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -8,10 +8,10 @@ const { version: transformRuntimeVersion } = fse.readJSONSync(
 );
 
 module.exports = {
-  // TODO: Enable once nextjs uses babel 7.13
-  // assumptions: {
-  //   noDocumentAll: true,
-  // },
+  assumptions: {
+    noDocumentAll: true,
+    setSpreadProperties: true,
+  },
   presets: [
     // backport of https://github.com/vercel/next.js/pull/9511
     [

--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -52,7 +52,6 @@ function withDocsInfra(nextConfig) {
     // Can be turned on when https://github.com/vercel/next.js/issues/24640 is fixed
     optimizeFonts: false,
     reactStrictMode: true,
-    productionBrowserSourceMaps: true,
     ...nextConfig,
     env: {
       BUILD_ONLY_ENGLISH_LOCALE: 'true', // disable translations by default

--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -52,6 +52,7 @@ function withDocsInfra(nextConfig) {
     // Can be turned on when https://github.com/vercel/next.js/issues/24640 is fixed
     optimizeFonts: false,
     reactStrictMode: true,
+    productionBrowserSourceMaps: true,
     ...nextConfig,
     env: {
       BUILD_ONLY_ENGLISH_LOCALE: 'true', // disable translations by default


### PR DESCRIPTION
Use this assumption to speed up the spread operator: https://babeljs.io/docs/assumptions#setspreadproperties

Our docs don't use the fast object spread operator, this babel assumption makes code that uses `const x = { ...y }` faster. This change is already done in X but I haven't had time to do it here as well.

The test case is: open the MUI material docs overview page, then click on the "Button" section. The following graphs show the performance of the first section of code that follows that click event. This section of code is the render functions, and shows an improvement of around 10%.

| before | after |
| --- | --- |
| ![spread-before](https://github.com/user-attachments/assets/c0bf30f6-c0dd-4d03-8f8e-ba7ca5b33f8b) | ![spread-after](https://github.com/user-attachments/assets/7e7afd94-6e4d-438a-bf2a-25508f460aa1) |
