### PR TITLE
[perf] Fast color manipulation

### DIFF
--- a/packages/mui-system/src/colorManipulator/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator/colorManipulator.js
@@ -238,6 +238,11 @@ export function getContrastRatio(foreground, background) {
  * @returns {string} A CSS color string. Hex input values are returned as rgb
  */
 export function alpha(color, value) {
+  // Test fast implementation
+  if (color.charAt(0) === '#') {
+    return colorToString(alphaColor(parseColor(color), value))
+  }
+
   color = decomposeColor(color);
   value = clampWrapper(value);
 
@@ -261,6 +266,57 @@ export function private_safeAlpha(color, value, warning) {
     }
     return color;
   }
+}
+
+// Fast color manipulation functions
+function parseColor(color) {
+  const hex = color.slice(1);
+  let r = '00';
+  let g = '00';
+  let b = '00';
+  let a = 'ff';
+
+  switch (hex.length) {
+    // #59f
+    case 3: {
+      r = hex.charAt(0) + hex.charAt(0);
+      g = hex.charAt(1) + hex.charAt(1);
+      b = hex.charAt(2) + hex.charAt(2);
+      break
+    }
+    // #599eff
+    case 6: {
+      r = hex.slice(0, 2);
+      g = hex.slice(2, 4);
+      b = hex.slice(4, 6);
+      break
+    }
+    // #599eff88
+    case 8: {
+      r = hex.slice(0, 2);
+      g = hex.slice(2, 4);
+      b = hex.slice(4, 6);
+      a = hex.slice(6, 8);
+      hasAlpha = true
+      break
+    }
+    default: {
+      break
+    }
+  }
+
+  return (
+    (parseInt(r, 16) << 24) +
+    (parseInt(g, 16) << 16) +
+    (parseInt(b, 16) <<  8) +
+    (parseInt(a, 16) <<  0)
+  )
+}
+function alphaColor(color, value) {
+  return (color & 0xffffff00) | (value << 0)
+}
+function colorToString(color) {
+  return `rgba(${(color & 0xff000000) >> 24}, ${(color & 0x00ff0000) >> 16}, ${(color & 0x0000ff00) >> 8}, ${(color & 0x000000ff) / 255})`
 }
 
 /**


### PR DESCRIPTION
I have noticed that some of our components use color manipulation functions in their style definition, e.g. `alpha(theme.palette.something, 0.5)`. These functions are run everytime those components mount (and render I think), but the implementation is very costly. For example, `alpha('#00000088', 0.6)` currently calls `decomposeColor x 2`, `hexToRGB` and `recomposeColor`. The MUI color representation with `{ type: 'rgb' | 'hsl' | ..., values: number[] }` is quite heavy for something that is called as often as that. A more efficient color representation would be to use a single integer in the range `0x00000000` to `0xffffffff` to represent the RGBA channels in a cannonical way, and to operate on that representation with bitwise operators. For example, setting the alpha channel is as simple as `color & 0xffffff00 | alpha`.

I've tested this approach by replacing only `alpha()` with the more efficient implementation in the test case linked below. Before, the color manipulation functions totals around 7.5% of the runtime. After, the total runtime is less than 1% (not shown, the entry is below the viewport).

| before | after |
| --- | --- |
| ![color-0-before](https://github.com/user-attachments/assets/416abb01-b175-4100-abee-9378ab15839c) | ![color-1-after](https://github.com/user-attachments/assets/7b5bd481-0361-4297-b9a3-52d136282cb7) |

[Test case gist](https://gist.github.com/romgrk/dbb8e09dea8be89c80269af4807c284b): Mount 20 buttons, 10 switches, 10 text fields.

I would like to propose to replace the color manipulation functions with this new approach. This means that for each CSS color format, we would need to introduce a parser that transforms it into the cannonical representation. This would however also mean that our manipulation functions, although vastly more efficient, would now erase the input color format. This is already the case to some extent, for example we always return input hex format (`#abcdef`) as an RGB color instead (`rgb(12, 34, 56)`).

The current manipulation functions are public so it would be a breaking change to remove them, but it's also possible to add a new implementation and keep exposing the old functions.