### PR TITLE
[docs][material-ui][Popover] Fix description and title of hover interaction section

### DIFF
--- a/docs/data/material/components/popover/MouseHoverPopover.js
+++ b/docs/data/material/components/popover/MouseHoverPopover.js
@@ -2,10 +2,10 @@ import * as React from 'react';
 import Popover from '@mui/material/Popover';
 import Typography from '@mui/material/Typography';
 
-export default function MouseOverPopover() {
-  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+export default function MouseHoverPopover() {
+  const [anchorEl, setAnchorEl] = React.useState(null);
 
-  const handlePopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
+  const handlePopoverOpen = (event) => {
     setAnchorEl(event.currentTarget);
   };
 

--- a/docs/data/material/components/popover/MouseHoverPopover.tsx
+++ b/docs/data/material/components/popover/MouseHoverPopover.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import Popover from '@mui/material/Popover';
 import Typography from '@mui/material/Typography';
 
-export default function MouseOverPopover() {
-  const [anchorEl, setAnchorEl] = React.useState(null);
+export default function MouseHoverPopover() {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
 
-  const handlePopoverOpen = (event) => {
+  const handlePopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
 

--- a/docs/data/material/components/popover/popover.md
+++ b/docs/data/material/components/popover/popover.md
@@ -32,7 +32,7 @@ the position of the popover.
 
 ## Mouse over interaction
 
-This demo demonstrates how to use the `Popover` component and the mouseover event to achieve popover behavior.
+This demo demonstrates how to use the `Popover` component with `mouseenter` and `mouseleave` events to achieve popover behavior.
 
 {{"demo": "MouseOverPopover.js"}}
 

--- a/docs/data/material/components/popover/popover.md
+++ b/docs/data/material/components/popover/popover.md
@@ -30,11 +30,11 @@ the position of the popover.
 
 {{"demo": "AnchorPlayground.js", "hideToolbar": true}}
 
-## Mouse over interaction
+## Mouse hover interaction
 
 This demo demonstrates how to use the `Popover` component with `mouseenter` and `mouseleave` events to achieve popover behavior.
 
-{{"demo": "MouseOverPopover.js"}}
+{{"demo": "MouseHoverPopover.js"}}
 
 ## Virtual element
 


### PR DESCRIPTION
While reviewing issue #43231, I noticed that `mouseover` was incorrectly mentioned instead of `mouseenter`. I also updated the section title and renamed the file/demo.

Preview: https://deploy-preview-43290--material-ui.netlify.app/material-ui/react-popover/#mouse-hover-interaction