### PR TITLE
[Autocomplete] Add asyncOptions (flag) prop to suppress the warning

### DIFF
--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.d.ts
@@ -73,6 +73,12 @@ export interface UseAutocompleteProps<
    */
   autoSelect?: boolean;
   /**
+   * If `true`, the component will handle asynchronously loaded options.
+   * This suppresses warnings about mismatched values when options are not yet loaded.
+   * @default false
+   */
+  asyncOptions?: boolean;
+  /**
    * Control if the input should be blurred when an option is selected:
    *
    * - `false` the input is not blurred.

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -72,6 +72,7 @@ export function useAutocomplete(props) {
     autoComplete = false,
     autoHighlight = false,
     autoSelect = false,
+    asyncOptions = false,
     blurOnSelect = false,
     clearOnBlur = !props.freeSolo,
     clearOnEscape = false,
@@ -244,7 +245,7 @@ export function useAutocomplete(props) {
   const listboxAvailable = open && filteredOptions.length > 0 && !readOnly;
 
   if (process.env.NODE_ENV !== 'production') {
-    if (value !== null && !freeSolo && options.length > 0) {
+    if (value !== null && !freeSolo && options.length > 0 && !asyncOptions) {
       const missingValue = (multiple ? value : [value]).filter(
         (value2) => !options.some((option) => isOptionEqualToValue(option, value2)),
       );
@@ -259,6 +260,7 @@ export function useAutocomplete(props) {
                 : JSON.stringify(missingValue[0])
             }\`.`,
             'You can use the `isOptionEqualToValue` prop to customize the equality test.',
+            'If you using asynchronous options, make sure that the `asyncOptions` prop is `true`.',
           ].join('\n'),
         );
       }

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -782,12 +782,6 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   // │    To update them, edit the d.ts file and run `pnpm proptypes`.     │
   // └─────────────────────────────────────────────────────────────────────┘
   /**
-   * If `true`, the component will handle asynchronously loaded options.
-   * This suppresses warnings about mismatched values when options are not yet loaded.
-   * @default false
-   */
-  asyncOptions: PropTypes.bool,
-  /**
    * If `true`, the portion of the selected suggestion that the user hasn't typed,
    * known as the completion string, appears inline after the input cursor in the textbox.
    * The inline completion string is visually highlighted and has a selected state.

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -417,6 +417,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
     autoComplete = false,
     autoHighlight = false,
     autoSelect = false,
+    asyncOptions = false,
     blurOnSelect = false,
     ChipProps: ChipPropsProp,
     className,
@@ -780,6 +781,12 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   // │ These PropTypes are generated from the TypeScript type definitions. │
   // │    To update them, edit the d.ts file and run `pnpm proptypes`.     │
   // └─────────────────────────────────────────────────────────────────────┘
+  /**
+   * If `true`, the component will handle asynchronously loaded options.
+   * This suppresses warnings about mismatched values when options are not yet loaded.
+   * @default false
+   */
+  asyncOptions: PropTypes.bool,
   /**
    * If `true`, the portion of the selected suggestion that the user hasn't typed,
    * known as the completion string, appears inline after the input cursor in the textbox.

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -782,6 +782,12 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   // │    To update them, edit the d.ts file and run `pnpm proptypes`.     │
   // └─────────────────────────────────────────────────────────────────────┘
   /**
+   * If `true`, the component will handle asynchronously loaded options.
+   * This suppresses warnings about mismatched values when options are not yet loaded.
+   * @default false
+   */
+  asyncOptions: PropTypes.bool,
+  /**
    * If `true`, the portion of the selected suggestion that the user hasn't typed,
    * known as the completion string, appears inline after the input cursor in the textbox.
    * The inline completion string is visually highlighted and has a selected state.

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -72,6 +72,7 @@ function useAutocomplete(props) {
     autoComplete = false,
     autoHighlight = false,
     autoSelect = false,
+    asyncOptions = false,
     blurOnSelect = false,
     clearOnBlur = !props.freeSolo,
     clearOnEscape = false,
@@ -244,7 +245,7 @@ function useAutocomplete(props) {
   const listboxAvailable = open && filteredOptions.length > 0 && !readOnly;
 
   if (process.env.NODE_ENV !== 'production') {
-    if (value !== null && !freeSolo && options.length > 0) {
+    if (value !== null && !freeSolo && options.length > 0 && !asyncOptions) {
       const missingValue = (multiple ? value : [value]).filter(
         (value2) => !options.some((option) => isOptionEqualToValue(option, value2)),
       );
@@ -259,6 +260,7 @@ function useAutocomplete(props) {
                 : JSON.stringify(missingValue[0])
             }\`.`,
             'You can use the `isOptionEqualToValue` prop to customize the equality test.',
+            'If you using asynchronous options, make sure that the `asyncOptions` prop is `true`.',
           ].join('\n'),
         );
       }


### PR DESCRIPTION
These changes introduce a new prop called **asyncOptions** to suppress the warning "The value provided to Autocomplete is invalid." This warning occurs when using asynchronous options because the selected options may no longer exist when the options are updated, leading to the warning during the comparison process. The **asyncOptions** prop disables this warning but does not remove it entirely.

Learn more about this: #29727, #43227