### PR TITLE
[codemod] Add Grid2 to removeSystemProps codemod

### DIFF
--- a/packages/mui-codemod/src/v6.0.0/system-props/removeSystemProps.js
+++ b/packages/mui-codemod/src/v6.0.0/system-props/removeSystemProps.js
@@ -129,7 +129,7 @@ const defaultSxConfig = {
   typography: {},
 };
 const systemProps = Object.keys(defaultSxConfig);
-const components = ['Box', 'Stack', 'Typography', 'Link', 'Grid'];
+const components = ['Box', 'Stack', 'Typography', 'Link', 'Grid', 'Grid2'];
 
 /**
  * @param {import('jscodeshift').FileInfo} file

--- a/packages/mui-codemod/src/v6.0.0/system-props/test-cases/system-props.actual.js
+++ b/packages/mui-codemod/src/v6.0.0/system-props/test-cases/system-props.actual.js
@@ -1,4 +1,4 @@
-import { Box as Boxxx, Grid as Griddd } from '@mui/material';
+import { Box as Boxxx, Grid as Griddd, Grid2 as Griddd2 } from '@mui/material';
 import Typographyyy from '@mui/material/Typography';
 import Stackkk from '@mui/material/Stack';
 
@@ -6,6 +6,7 @@ import Stackkk from '@mui/material/Stack';
 <Boxxx color="palette.main" sx={{ display: 'block' }} />;
 
 <Griddd container flexDirection={`column`} />;
+<Griddd2 container flexDirection={`column`} />;
 
 const sx = { display: 'flex' };
 const ml = 2;

--- a/packages/mui-codemod/src/v6.0.0/system-props/test-cases/system-props.expected.js
+++ b/packages/mui-codemod/src/v6.0.0/system-props/test-cases/system-props.expected.js
@@ -1,4 +1,4 @@
-import { Box as Boxxx, Grid as Griddd } from '@mui/material';
+import { Box as Boxxx, Grid as Griddd, Grid2 as Griddd2 } from '@mui/material';
 import Typographyyy from '@mui/material/Typography';
 import Stackkk from '@mui/material/Stack';
 
@@ -12,6 +12,9 @@ import Stackkk from '@mui/material/Stack';
   }} />;
 
 <Griddd container sx={{
+  flexDirection: `column`
+}} />;
+<Griddd2 container sx={{
   flexDirection: `column`
 }} />;
 


### PR DESCRIPTION
Follow up on https://github.com/mui/material-ui/pull/43054#discussion_r1693188940. Add `Grid2` to `removeSystemProps` codemod