### PR TITLE
[code-infra] Fix utils bundle size entrypoint

### DIFF
--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -127,7 +127,7 @@ async function getWebpackEntries() {
     ...coreComponents,
     {
       id: '@material-ui/utils',
-      path: 'packages/mui-utils/build/index.js',
+      path: 'packages/mui-utils/build/esm/index.js',
     },
     // TODO: Requires webpack v5
     // Resolution of webpack/acorn to 7.x is blocked by nextjs (https://github.com/vercel/next.js/issues/11947)
@@ -186,21 +186,6 @@ function createWebpackConfig(entry, environment) {
         reportFilename: `${entry.id}.html`,
       }),
     ],
-    resolve: {
-      alias: {
-        '@mui/material': path.join(workspaceRoot, 'packages/mui-material/build'),
-        '@mui/lab': path.join(workspaceRoot, 'packages/mui-lab/build'),
-        '@mui/styled-engine': path.join(workspaceRoot, 'packages/mui-styled-engine/build'),
-        '@mui/styled-engine-sc': path.join(workspaceRoot, 'packages/mui-styles-sc/build'),
-        '@mui/styles': path.join(workspaceRoot, 'packages/mui-styles/build'),
-        '@mui/system': path.join(workspaceRoot, 'packages/mui-system/build'),
-        '@mui/private-theming': path.join(workspaceRoot, 'packages/mui-private-theming/build'),
-        '@mui/utils': path.join(workspaceRoot, 'packages/mui-utils/build'),
-        '@mui/base': path.join(workspaceRoot, 'packages/mui-base/build'),
-        '@mui/material-nextjs': path.join(workspaceRoot, 'packages/mui-material-nextjs/build'),
-        '@mui/joy': path.join(workspaceRoot, 'packages/mui-joy/build'),
-      },
-    },
     entry: { [entry.id]: path.join(workspaceRoot, entry.path) },
     // TODO: 'browserslist:modern'
     // See https://github.com/webpack/webpack/issues/14203

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -186,6 +186,21 @@ function createWebpackConfig(entry, environment) {
         reportFilename: `${entry.id}.html`,
       }),
     ],
+    resolve: {
+      alias: {
+        '@mui/material': path.join(workspaceRoot, 'packages/mui-material/build'),
+        '@mui/lab': path.join(workspaceRoot, 'packages/mui-lab/build'),
+        '@mui/styled-engine': path.join(workspaceRoot, 'packages/mui-styled-engine/build'),
+        '@mui/styled-engine-sc': path.join(workspaceRoot, 'packages/mui-styles-sc/build'),
+        '@mui/styles': path.join(workspaceRoot, 'packages/mui-styles/build'),
+        '@mui/system': path.join(workspaceRoot, 'packages/mui-system/build'),
+        '@mui/private-theming': path.join(workspaceRoot, 'packages/mui-private-theming/build'),
+        '@mui/utils': path.join(workspaceRoot, 'packages/mui-utils/build/esm'),
+        '@mui/base': path.join(workspaceRoot, 'packages/mui-base/build'),
+        '@mui/material-nextjs': path.join(workspaceRoot, 'packages/mui-material-nextjs/build'),
+        '@mui/joy': path.join(workspaceRoot, 'packages/mui-joy/build'),
+      },
+    },
     entry: { [entry.id]: path.join(workspaceRoot, entry.path) },
     // TODO: 'browserslist:modern'
     // See https://github.com/webpack/webpack/issues/14203


### PR DESCRIPTION
Use an ESM entrypoint instead of a commonjs to get a more accurate depiction of reality. Also removing the alias as we can rely on pnpm package linking through the `publishConfig.directory` option.
We don't have this problem with other modules as they don't use the `esm/` layout. We'll unify the package layout as part of improved ESM support.

Noticed this in https://github.com/mui/material-ui/pull/43243

🤔 I was initially surprised by the large bundle size reduction. It looks like it now manages to aggressively tree-shake things such as the (in production) unused `chainProptypes` and the functions it's called with.

[bundles diff](https://www.diffchecker.com/92auTICh/)