### PR TITLE
[docs] Update server-rendering.md

### DIFF
--- a/docs/data/material/guides/server-rendering/server-rendering.md
+++ b/docs/data/material/guides/server-rendering/server-rendering.md
@@ -208,7 +208,7 @@ function Main() {
   );
 }
 
-ReactDOM.hydrate(<Main />, document.querySelector('#root'));
+ReactDOM.hydrateRoot(<Main />, document.querySelector('#root'));
 ```
 
 ## Reference implementations


### PR DESCRIPTION
.hydrate() is deprecated and it will be removed completely in a future version of React. ref: https://react.dev/reference/react-dom/hydrate

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
