### PR TITLE
[material-ui][SpeedDial] Spread props in button instead of tooltip

### DIFF
--- a/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
+++ b/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
@@ -229,6 +229,12 @@ The `Grid2` (previously `Unstable_Grid2`) was updated and stabilized:
 
 This brings some breaking changes described in the following sections.
 
+### SpeedDialAction
+
+The SpeedDialAction component consists of a button wrapped inside a tooltip. Previously, additional props were spread on the tooltip. Now, additional props are spread on the button, which is now considered the root component.
+
+If you need to customize the tooltip or pass props to it, you can use the `slots` and `slotProps` respectively.
+
 #### Unstable prefix removed
 
 The `Grid2` component API was stabilized, so its import no longer contains the `Unstable_` prefix:

--- a/docs/pages/material-ui/api/speed-dial-action.json
+++ b/docs/pages/material-ui/api/speed-dial-action.json
@@ -4,8 +4,18 @@
     "delay": { "type": { "name": "number" }, "default": "0" },
     "FabProps": { "type": { "name": "object" }, "default": "{}" },
     "icon": { "type": { "name": "node" } },
-    "id": { "type": { "name": "string" } },
     "open": { "type": { "name": "bool" } },
+    "slotProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ root?: func<br>&#124;&nbsp;object, tooltip?: func<br>&#124;&nbsp;object }"
+      },
+      "default": "{}"
+    },
+    "slots": {
+      "type": { "name": "shape", "description": "{ root?: elementType, tooltip?: elementType }" },
+      "default": "{}"
+    },
     "sx": {
       "type": {
         "name": "union",
@@ -28,6 +38,20 @@
   "imports": [
     "import SpeedDialAction from '@mui/material/SpeedDialAction';",
     "import { SpeedDialAction } from '@mui/material';"
+  ],
+  "slots": [
+    {
+      "name": "root",
+      "description": "The component that renders the root component.",
+      "default": "Fab",
+      "class": null
+    },
+    {
+      "name": "tooltip",
+      "description": "The component that renders the tooltip.",
+      "default": "Tooltip",
+      "class": null
+    }
   ],
   "classes": [
     {
@@ -78,7 +102,7 @@
   "muiName": "MuiSpeedDialAction",
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js",
-  "inheritance": { "component": "Tooltip", "pathname": "/material-ui/api/tooltip/" },
+  "inheritance": { "component": "Fab", "pathname": "/material-ui/api/fab/" },
   "demos": "<ul><li><a href=\"/material-ui/react-speed-dial/\">Speed Dial</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/translations/api-docs/speed-dial-action/speed-dial-action.json
+++ b/docs/translations/api-docs/speed-dial-action/speed-dial-action.json
@@ -9,10 +9,9 @@
       "description": "Props applied to the <a href=\"/material-ui/api/fab/\"><code>Fab</code></a> component."
     },
     "icon": { "description": "The icon to display in the SpeedDial Fab." },
-    "id": {
-      "description": "This prop is used to help implement the accessibility logic. If you don&#39;t provide this prop. It falls back to a randomly generated id."
-    },
     "open": { "description": "If <code>true</code>, the component is shown." },
+    "slotProps": { "description": "The props used for each slot inside." },
+    "slots": { "description": "The components used for each slot inside." },
     "sx": {
       "description": "The system prop that allows defining system overrides as well as additional CSS styles."
     },
@@ -51,5 +50,9 @@
     "tooltipPlacementRight": {
       "description": "Styles applied to the root element if <code>tooltipOpen={true}</code> and `tooltipPlacement=&quot;right&quot;``"
     }
+  },
+  "slotDescriptions": {
+    "root": "The component that renders the root component.",
+    "tooltip": "The component that renders the tooltip."
   }
 }

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.d.ts
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.d.ts
@@ -1,12 +1,37 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
 import { Theme } from '../styles';
-import { InternalStandardProps as StandardProps } from '..';
-import { FabProps } from '../Fab';
+import { FabProps, FabTypeMap } from '../Fab';
 import { TooltipProps } from '../Tooltip';
 import { SpeedDialActionClasses } from './speedDialActionClasses';
+import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { CreateSlotsAndSlotProps, SlotProps } from '../utils';
+import { SpeedDialProps } from '../SpeedDial/SpeedDial';
 
-export interface SpeedDialActionProps extends StandardProps<Partial<TooltipProps>, 'children'> {
+export interface SpeedDialActionSlots {
+  /**
+   * The component that renders the root component.
+   * @default Fab
+   */
+  root?: React.ElementType;
+  /**
+   * The component that renders the tooltip.
+   * @default Tooltip
+   */
+  tooltip?: React.ElementType;
+}
+
+export type SpeedDialActionSlotsAndSlotProps = CreateSlotsAndSlotProps<
+  SpeedDialActionSlots,
+  {
+    root: SlotProps<React.ElementType<FabProps>, {}, SpeedDialActionOwnerState>;
+    tooltip: SlotProps<React.ElementType<TooltipProps>, {}, SpeedDialActionOwnerState>;
+  }
+>;
+
+export interface SpeedDialActionOwnProps
+  extends Partial<Omit<FabProps, 'children'>>,
+    SpeedDialActionSlotsAndSlotProps {
   /**
    * Override or extend the styles applied to the component.
    */
@@ -25,6 +50,10 @@ export interface SpeedDialActionProps extends StandardProps<Partial<TooltipProps
    * The icon to display in the SpeedDial Fab.
    */
   icon?: React.ReactNode;
+  /**
+   * If `true`, the component is shown.
+   */
+  open?: SpeedDialProps['open'];
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
@@ -49,6 +78,14 @@ export interface SpeedDialActionProps extends StandardProps<Partial<TooltipProps
   tooltipOpen?: boolean;
 }
 
+export interface SpeedDialActionTypeMap<
+  AdditionalProps = {},
+  RootComponent extends React.ElementType = FabTypeMap['defaultComponent'],
+> {
+  props: AdditionalProps & SpeedDialActionOwnProps;
+  defaultComponent: RootComponent;
+}
+
 /**
  *
  * Demos:
@@ -58,6 +95,17 @@ export interface SpeedDialActionProps extends StandardProps<Partial<TooltipProps
  * API:
  *
  * - [SpeedDialAction API](https://next.mui.com/material-ui/api/speed-dial-action/)
- * - inherits [Tooltip API](https://next.mui.com/material-ui/api/tooltip/)
+ * - inherits [Fab API](https://next.mui.com/material-ui/api/fab/)
  */
-export default function SpeedDialAction(props: SpeedDialActionProps): React.JSX.Element;
+declare const SpeedDialAction: OverridableComponent<SpeedDialActionTypeMap>;
+
+export type SpeedDialActionProps<
+  RootComponent extends React.ElementType = SpeedDialActionTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<SpeedDialActionTypeMap<AdditionalProps, RootComponent>, RootComponent> & {
+  component?: React.ElementType;
+};
+
+export interface SpeedDialActionOwnerState extends SpeedDialActionProps {}
+
+export default SpeedDialAction;

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js
@@ -169,13 +169,15 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) 
   const fab = (
     <SpeedDialActionFab
       size="small"
-      className={clsx(classes.fab, className)}
       tabIndex={-1}
       role="menuitem"
       ownerState={ownerState}
+      {...other}
       {...FabProps}
+      className={clsx(classes.fab, other.className, className)}
       style={{
         ...transitionStyle,
+        ...(other.style || {}),
         ...FabProps.style,
       }}
     >
@@ -190,7 +192,6 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) 
         ref={ref}
         className={classes.staticTooltip}
         ownerState={ownerState}
-        {...other}
       >
         <SpeedDialActionStaticTooltipLabel
           style={transitionStyle}
@@ -221,7 +222,6 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) 
       onOpen={handleTooltipOpen}
       open={open && tooltipOpen}
       classes={TooltipClasses}
-      {...other}
     >
       {fab}
     </Tooltip>
@@ -264,6 +264,10 @@ SpeedDialAction.propTypes /* remove-proptypes */ = {
    * If `true`, the component is shown.
    */
   open: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  style: PropTypes.object,
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, fireEvent } from '@mui/internal-test-utils';
+import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import Icon from '@mui/material/Icon';
 import Tooltip from '@mui/material/Tooltip';
 import { fabClasses } from '@mui/material/Fab';
@@ -76,5 +76,11 @@ describe('<SpeedDialAction />', () => {
     );
     expect(container.querySelector('button')).to.have.class(classes.fab);
     expect(container.querySelector('button')).to.have.class(classes.fabClosed);
+  });
+
+  it('should spread other props on the underlying button', () => {
+    render(<SpeedDialAction icon={<Icon>add</Icon>} tooltipTitle="Add" data-testid="test" />);
+
+    expect(screen.getByRole('menuitem', { name: 'Add' })).to.have.attribute('data-testid', 'test');
   });
 });

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
@@ -2,24 +2,42 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import Icon from '@mui/material/Icon';
-import Tooltip from '@mui/material/Tooltip';
-import { fabClasses } from '@mui/material/Fab';
+import Fab, { fabClasses } from '@mui/material/Fab';
 import SpeedDialAction, { speedDialActionClasses as classes } from '@mui/material/SpeedDialAction';
 import describeConformance from '../../test/describeConformance';
 
 describe('<SpeedDialAction />', () => {
   const { clock, render } = createRenderer({ clock: 'fake' });
+  const CustomRootComponent = React.forwardRef((props, ref) => {
+    const { ownerState, ...other } = props;
+    return <button {...other} ref={ref} data-testid="custom" />;
+  });
+  const CustomTooltipComponent = React.forwardRef((props, ref) => {
+    const { onOpen, ownerState, ...other } = props;
+    return <div {...other} ref={ref} data-testid="custom" />;
+  });
 
   describeConformance(
     <SpeedDialAction icon={<Icon>add</Icon>} tooltipTitle="placeholder" />,
     () => ({
       classes,
-      inheritComponent: Tooltip,
+      inheritComponent: Fab,
       render,
       refInstanceof: window.HTMLButtonElement,
       muiName: 'MuiSpeedDialAction',
-      testRootOverrides: { slotName: 'fab' },
+      testRootOverrides: { slotName: 'root' },
       testVariantProps: { tooltipPlacement: 'right' },
+      slots: {
+        root: {
+          expectedClassName: classes.fab,
+          testWithComponent: CustomRootComponent,
+          testWithElement: null,
+        },
+        tooltip: {
+          testWithComponent: CustomTooltipComponent,
+          testWithElement: null,
+        },
+      },
       skip: ['componentProp', 'componentsProp'],
     }),
   );


### PR DESCRIPTION
Resolves https://github.com/mui/material-ui/issues/36220

`SpeedDialAction` consists of a `Tooltip` wrapping a `Fab` button i.e. the root node is the tooltip. This PR introduces a change on how we spread props: instead of spreading them in the tooltip (root), we spread them in the button.

### Breaking change

The `SpeedDialAction` component now spreads props on the underlying button instead of the tooltip that wraps the button.
