### PR TITLE
[core] Update supported Node.js version to 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths-ignore:
       # should sync with ci-check.yml as a workaround to bypass github checks
+      - 'docs/**'
       - 'examples/**'
 
 permissions: {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     paths-ignore:
       # should sync with ci-check.yml as a workaround to bypass github checks
-      - 'docs/**'
       - 'examples/**'
 
 permissions: {}

--- a/apps/pigment-css-next-app/src/app/material-ui/react-popover/page.tsx
+++ b/apps/pigment-css-next-app/src/app/material-ui/react-popover/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import BasicPopover from '../../../../../../docs/data/material/components/popover/BasicPopover';
-import MouseOverPopover from '../../../../../../docs/data/material/components/popover/MouseOverPopover';
+import MouseHoverPopover from '../../../../../../docs/data/material/components/popover/MouseHoverPopover';
 import PopoverPopupState from '../../../../../../docs/data/material/components/popover/PopoverPopupState';
 import VirtualElementPopover from '../../../../../../docs/data/material/components/popover/VirtualElementPopover';
 
@@ -17,7 +17,7 @@ export default function Popover() {
       <section>
         <h2> Mouse Over Popover</h2>
         <div className="demo-container">
-          <MouseOverPopover />
+          <MouseHoverPopover />
         </div>
       </section>
       <section>

--- a/apps/pigment-css-next-app/src/app/material-ui/react-popover/page.tsx
+++ b/apps/pigment-css-next-app/src/app/material-ui/react-popover/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import BasicPopover from '../../../../../../docs/data/material/components/popover/BasicPopover';
-import MouseHoverPopover from '../../../../../../docs/data/material/components/popover/MouseHoverPopover';
+import MouseOverPopover from '../../../../../../docs/data/material/components/popover/MouseHoverPopover';
 import PopoverPopupState from '../../../../../../docs/data/material/components/popover/PopoverPopupState';
 import VirtualElementPopover from '../../../../../../docs/data/material/components/popover/VirtualElementPopover';
 
@@ -17,7 +17,7 @@ export default function Popover() {
       <section>
         <h2> Mouse Over Popover</h2>
         <div className="demo-container">
-          <MouseHoverPopover />
+          <MouseOverPopover />
         </div>
       </section>
       <section>

--- a/docs/data/material/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/data/material/getting-started/supported-platforms/supported-platforms.md
@@ -25,7 +25,7 @@ You can expect Material UI's components to render without major issues.
 
 <!-- #stable-snapshot -->
 
-Material UI supports [Node.js](https://github.com/nodejs/node) starting with version 12.0 for server-side rendering.
+Material UI supports [Node.js](https://github.com/nodejs/node) starting with version 14.0 for server-side rendering.
 The objective is to support Node.js down to the [last version in maintenance mode](https://github.com/nodejs/Release#release-schedule).
 
 ## React

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -102,7 +102,7 @@
     "directory": "build"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "pigment-css": {
     "vite": {

--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -76,6 +76,6 @@
     "directory": "build"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
It looks like these were forgotten in https://github.com/mui/material-ui/pull/42920? This would allow us to add package `"exports"` on a minor.