### PR TITLE
[website][docs] Update Store links to new templates page

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Our documentation features [a collection of example projects](https://github.com
 
 ## Premium templates
 
-You can find complete templates and themes in the [MUI Store](https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=readme-store).
+You can find complete templates and themes in the [MUI Store](https://mui.com/store/templates/?utm_source=docs&utm_medium=referral&utm_campaign=readme-store).
 
 ## Contributing
 

--- a/docs/data/material/getting-started/example-projects/example-projects.md
+++ b/docs/data/material/getting-started/example-projects/example-projects.md
@@ -21,7 +21,7 @@ See [Start a New React Project](https://react.dev/learn/start-a-new-react-projec
 
 Once you've chosen your preferred scaffold above, you could move on to the [Templates](/material-ui/getting-started/templates/) doc and choose a readymade user interface to plug in.
 
-For more complex prebuilt UIs, check out our [premium themes and templates](https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=example-projects-store) in the MUI Store.
+For more complex prebuilt UIs, check out our [premium themes and templates](https://mui.com/store/templates/?utm_source=docs&utm_medium=referral&utm_campaign=example-projects-store) in the MUI Store.
 
 ## Community project
 

--- a/docs/data/material/getting-started/templates/templates.md
+++ b/docs/data/material/getting-started/templates/templates.md
@@ -27,9 +27,9 @@ Please feel free to open an [issue](https://github.com/mui/material-ui/issues/ne
 
 ## Premium templates
 
-Looking for something more? You can find complete templates and themes in the <a href="https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=templates-store">premium template section</a>.
+Looking for something more? You can find complete templates and themes in the <a href="https://mui.com/store/templates/?utm_source=docs&utm_medium=referral&utm_campaign=templates-store">premium template section</a>.
 
-<a href="https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=templates-store">
+<a href="https://mui.com/store/templates/?utm_source=docs&utm_medium=referral&utm_campaign=templates-store">
 <span class="only-light-mode">
 <img src="/static/images/themes-display-light.png" alt="The MUI Store includes several carefully curated React templates using Material UI" width="2280" height="1200" />
 </span>

--- a/docs/src/components/productMaterial/MaterialTemplates.tsx
+++ b/docs/src/components/productMaterial/MaterialTemplates.tsx
@@ -173,7 +173,7 @@ export default function MaterialTemplates() {
         ))}
         <More
           component={Link}
-          href="https://mui.com/store/?utm_source=marketing&utm_medium=referral&utm_campaign=material-templates-cta2#populars"
+          href="https://mui.com/store/templates/?utm_source=marketing&utm_medium=referral&utm_campaign=material-templates-cta2#populars"
           noLinkStyle
         />
       </Group>

--- a/docs/src/components/productTemplate/TemplateDemo.tsx
+++ b/docs/src/components/productTemplate/TemplateDemo.tsx
@@ -87,7 +87,7 @@ export default function TemplateDemo() {
             ))}
             <More
               component={Link}
-              href="https://mui.com/store/?utm_source=marketing&utm_medium=referral&utm_campaign=templates-cta2#populars"
+              href="https://mui.com/store/templates/?utm_source=marketing&utm_medium=referral&utm_campaign=templates-cta2#populars"
               noLinkStyle
             />
           </Group>

--- a/docs/src/components/productTemplate/TemplateHero.tsx
+++ b/docs/src/components/productTemplate/TemplateHero.tsx
@@ -48,7 +48,7 @@ export default function TemplateHero() {
           <Button
             component={Link}
             noLinkStyle
-            href="https://mui.com/store/?utm_source=marketing&utm_medium=referral&utm_campaign=templates-cta#populars"
+            href="https://mui.com/store/templates/?utm_source=marketing&utm_medium=referral&utm_campaign=templates-cta"
             variant="contained"
             endIcon={<KeyboardArrowRightRounded />}
             sx={{ width: { xs: '100%', sm: 'auto' } }}

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -285,7 +285,7 @@
     "/material-ui/design-resources": "Design resources",
     "/material-ui/design-resources/material-ui-for-figma": "Figma Design Kit",
     "/material-ui/design-resources/material-ui-sync": "Figma Sync plugin",
-    "https://mui.com/store/templates/?utm_source=docs&utm_medium=referral&utm_campaign=sidenav": "Template store",
+    "https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=sidenav": "Template store",
     "/joy-ui/getting-started-group": "Getting started",
     "/joy-ui/getting-started": "Overview",
     "/joy-ui/getting-started/installation": "Installation",

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -285,7 +285,7 @@
     "/material-ui/design-resources": "Design resources",
     "/material-ui/design-resources/material-ui-for-figma": "Figma Design Kit",
     "/material-ui/design-resources/material-ui-sync": "Figma Sync plugin",
-    "https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=sidenav": "Template store",
+    "https://mui.com/store/templates/?utm_source=docs&utm_medium=referral&utm_campaign=sidenav": "Template store",
     "/joy-ui/getting-started-group": "Getting started",
     "/joy-ui/getting-started": "Overview",
     "/joy-ui/getting-started/installation": "Installation",

--- a/packages/mui-docs/src/Ad/Ad.tsx
+++ b/packages/mui-docs/src/Ad/Ad.tsx
@@ -44,14 +44,14 @@ const inHouseAds = [
   },
   {
     name: 'templates',
-    link: 'https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=in-house-templates',
+    link: 'https://mui.com/store/templates/?utm_source=docs&utm_medium=referral&utm_campaign=in-house-templates',
     img: '/static/ads-in-house/themes-2.jpg',
     description:
       '<b>Premium Templates</b>. Start your project with the best templates for admins, dashboards, and more.',
   },
   {
     name: 'themes',
-    link: 'https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=in-house-themes',
+    link: 'https://mui.com/store/templates/?utm_source=docs&utm_medium=referral&utm_campaign=in-house-themes',
     img: '/static/ads-in-house/themes.png',
     description:
       '<b>Premium Themes</b>. Kickstart your application development with a ready-made theme.',


### PR DESCRIPTION
This PR updates the existing Store links across the website/docs to point to the new templates page:

- Updated the URL from https://mui.com/store/ to https://mui.com/store/templates/

### Why

The Store has been restructured to better highlight available templates, with a page specific tailored for templates. This update ensures all relevant links now point directly to the new templates section, improving navigation and user experience.
