### PR TITLE
[docs] Fix outdated references to Materal UI version

### DIFF
--- a/docs/data/material/customization/theme-components/theme-components.md
+++ b/docs/data/material/customization/theme-components/theme-components.md
@@ -206,10 +206,10 @@ This prop lets you write inline styles using a superset of CSS.
 Learn more about [the concept behind the `sx` prop](/system/getting-started/the-sx-prop/) and [how `sx` differs from the `styled` utility](/system/styled/#difference-with-the-sx-prop).
 
 You can use the `sx` prop inside the `styleOverrides` key to modify styles within the theme using shorthand CSS notation.
-This is especially handy if you're already using the `sx` prop with your components, because you can use the same syntax in your theme and quickly transfer styles between the two.
+This is especially handy if you're already using the `sx` prop with your components because you can use the same syntax in your theme and quickly transfer styles between the two.
 
 :::info
-The `sx` prop is a stable feature for customizing components in Material UI v5, but it is still considered _experimental_ when used directly inside the theme object.
+The `sx` prop is a stable feature for customizing components since Material UI v5, but it is still considered _experimental_ when used directly inside the theme object.
 :::
 
 {{"demo": "GlobalThemeOverrideSx.js", "defaultCodeOpen": false}}

--- a/docs/data/material/getting-started/overview/overview.md
+++ b/docs/data/material/getting-started/overview/overview.md
@@ -10,10 +10,10 @@ title: Overview
 
 Material UI is an open-source React component library that implements Google's [Material Design](https://m2.material.io/).
 
-It includes a comprehensive collection of prebuilt components that are ready for use in production right out of the box, and features a suite of customization options that make it easy to implement your own custom design system on top of our components.
+It includes a comprehensive collection of prebuilt components that are ready for use in production right out of the box and features a suite of customization options that make it easy to implement your own custom design system on top of our components.
 
 :::info
-Material UI v5 supports Material Design 2.
+Material UI v6 supports Material Design 2.
 Adoption of Material Design 3 is tentatively planned for Material UI v7—see [the announcement blog post](/blog/2023-material-ui-v6-and-beyond/) for more details.
 You can follow [this GitHub issue](https://github.com/mui/material-ui/issues/29345) for future updates.
 :::

--- a/examples/material-ui-cra-tailwind-ts/README.md
+++ b/examples/material-ui-cra-tailwind-ts/README.md
@@ -27,7 +27,7 @@ or:
 ## The idea behind the example
 
 This example demonstrates how you can use [Tailwind CSS](https://tailwindcss.com/) and [Create React App](https://github.com/facebookincubator/create-react-app) together with Material UI.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v5.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
 
 ## What's next?
 

--- a/examples/material-ui-cra-ts/README.md
+++ b/examples/material-ui-cra-ts/README.md
@@ -29,7 +29,7 @@ or:
 ## The idea behind the example
 
 This example demonstrates how you can use Material UI with [Create React App](https://github.com/facebookincubator/create-react-app) in [TypeScript](https://github.com/Microsoft/TypeScript).
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v5.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
 If you prefer, you can [use styled-components instead](https://next.mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## What's next?

--- a/examples/material-ui-cra/README.md
+++ b/examples/material-ui-cra/README.md
@@ -31,7 +31,7 @@ or:
 <!-- #default-branch-switch -->
 
 This example demonstrates how you can use [Create React App](https://github.com/facebookincubator/create-react-app) with Material UI.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v5.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
 If you prefer, you can [use styled-components instead](https://next.mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## What's next?

--- a/examples/material-ui-express-ssr/README.md
+++ b/examples/material-ui-express-ssr/README.md
@@ -30,7 +30,7 @@ or:
 
 This is the reference implementation of the [Server Rendering tutorial](https://next.mui.com/material-ui/guides/server-rendering/).
 
-The example project includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v5.
+The example project includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
 If you prefer, you can [use styled-components instead](https://next.mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## What's next?

--- a/examples/material-ui-gatsby/README.md
+++ b/examples/material-ui-gatsby/README.md
@@ -21,7 +21,7 @@ npm run develop
 ## The idea behind the example
 
 The project uses [Gatsby](https://github.com/gatsbyjs/gatsby), which is a static site generator for React.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v5.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
 If you prefer, you can [use styled-components instead](https://next.mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## What's next?

--- a/examples/material-ui-nextjs-pages-router-ts/README.md
+++ b/examples/material-ui-nextjs-pages-router-ts/README.md
@@ -33,7 +33,8 @@ As of Next.js 13.4, the newer App Router pattern is stable.
 We recommend starting new projects with the [Material UI with Next.js (App Router) example](https://github.com/mui/material-ui/tree/next/examples/material-ui-nextjs-ts) unless you need (or prefer) the Pages Router.
 
 The project uses [Next.js](https://github.com/vercel/next.js), which is a framework for server-rendered React apps.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v5. If you prefer, you can [use styled-components instead](https://next.mui.com/material-ui/integrations/interoperability/#styled-components).
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+If you prefer, you can [use styled-components instead](https://next.mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## The link component
 

--- a/examples/material-ui-nextjs-pages-router/README.md
+++ b/examples/material-ui-nextjs-pages-router/README.md
@@ -33,7 +33,7 @@ As of Next.js 13.4, the newer App Router pattern is stable.
 We recommend starting new projects with the [Material UI with Next.js (App Router) example](https://github.com/mui/material-ui/tree/next/examples/material-ui-nextjs) unless you need (or prefer) the Pages Router.
 
 The project uses [Next.js](https://github.com/vercel/next.js), which is a framework for server-rendered React apps.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v5.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
 If you prefer, you can [use styled-components instead](https://next.mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## The Link component

--- a/examples/material-ui-nextjs-ts-v4-v5-migration/README.md
+++ b/examples/material-ui-nextjs-ts-v4-v5-migration/README.md
@@ -1,4 +1,4 @@
-# Material UI v5 and Next.js example with @mui/styles (in TypeScript)
+# Material UI and Next.js example with @mui/styles (in TypeScript)
 
 ## How to use
 
@@ -29,7 +29,9 @@ or:
 ## The idea behind the example
 
 The project uses [Next.js](https://github.com/vercel/next.js), which is a framework for server-rendered React apps.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v5. If you prefer, you can [use styled-components instead](https://next.mui.com/material-ui/integrations/interoperability/#styled-components).
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+If you prefer, you can [use styled-components instead](https://next.mui.com/material-ui/integrations/interoperability/#styled-components).
+
 It also includes `@mui/styles`, the legacy styling solution that uses JSS as an engine.
 It provides all the necessary config for working with both Emotion and JSS for server-side rendering.
 The project is intended as a basic starter for migrating your application from v4 to v5, as it lets the JSS style overrides take precedence over the default styles passed to the components by Emotion.

--- a/examples/material-ui-preact/README.md
+++ b/examples/material-ui-preact/README.md
@@ -24,7 +24,7 @@ The project uses Material UI with [Preact](https://github.com/developit/preact)
 
 This example uses CRA with `react-app-rewired` for adding Webpack aliases for Preact.
 
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v5.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
 
 <!-- #default-branch-switch -->
 

--- a/examples/material-ui-remix-ts/README.md
+++ b/examples/material-ui-remix-ts/README.md
@@ -28,8 +28,8 @@ or:
 
 ## The idea behind the example
 
-The project uses [Remix](https://remix.run/), which is a full stack web framework.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v5.
+The project uses [Remix](https://remix.run/), which is a full-stack web framework.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
 If you prefer, you can [use styled-components instead](https://next.mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## What's next?

--- a/examples/material-ui-vite-ts/README.md
+++ b/examples/material-ui-vite-ts/README.md
@@ -29,7 +29,7 @@ or:
 ## The idea behind the example
 
 This example uses [Vite.js](https://github.com/vitejs/vite).
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v5.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
 
 ## What's next?
 

--- a/examples/material-ui-vite/README.md
+++ b/examples/material-ui-vite/README.md
@@ -29,7 +29,7 @@ or:
 ## The idea behind the example
 
 This example uses [Vite.js](https://github.com/vitejs/vite).
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v5.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
 
 ## What's next?
 


### PR DESCRIPTION
I landed on the docs landing page of Material UI v6 that is closer to be stable https://next--material-ui.netlify.app/material-ui/getting-started/ and got confused:

<img width="839" alt="SCR-20240815-uqvt" src="https://github.com/user-attachments/assets/1a73ab47-5c0c-47a5-8765-d6734715b6f5">

This looks like a quick win.