### PR TITLE
[material-ui][ListItem] Replace `<ListItem button/>` with `<ListItemButton/>` in composition guide

### DIFF
--- a/docs/data/material/guides/composition/composition.md
+++ b/docs/data/material/guides/composition/composition.md
@@ -40,12 +40,12 @@ The following example will render the `List` component with a `<nav>` element as
 
 ```jsx
 <List component="nav">
-  <ListItem button>
+  <ListItemButton>
     <ListItemText primary="Trash" />
-  </ListItem>
-  <ListItem button>
+  </ListItemButton>
+  <ListItemButton>
     <ListItemText primary="Spam" />
-  </ListItem>
+  </ListItemButton>
 </List>
 ```
 
@@ -67,10 +67,10 @@ function ListItemLink(props) {
 
   return (
     <li>
-      <ListItem button component={CustomLink}>
+      <ListItemButton component={CustomLink}>
         <ListItemIcon>{icon}</ListItemIcon>
         <ListItemText primary={primary} />
-      </ListItem>
+      </ListItemButton>
     </li>
   );
 }
@@ -101,10 +101,10 @@ function ListItemLink(props) {
 
   return (
     <li>
-      <ListItem button component={CustomLink}>
+      <ListItemButton component={CustomLink}>
         <ListItemIcon>{icon}</ListItemIcon>
         <ListItemText primary={primary} />
-      </ListItem>
+      </ListItemButton>
     </li>
   );
 }
@@ -118,7 +118,7 @@ In this example, we don't create any intermediary component:
 ```jsx
 import { Link } from 'react-router-dom';
 
-<ListItem button component={Link} to="/">
+<ListItemButton component={Link} to="/">
 ```
 
 :::warning


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Since `button` prop in `ListItem` is removed, we should remove it's references from docs

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
