### PR TITLE
[material-ui][ListItem] Remove unnecessary TypeScript test

### DIFF
--- a/packages/mui-material/src/ListItem/ListItem.spec.tsx
+++ b/packages/mui-material/src/ListItem/ListItem.spec.tsx
@@ -13,12 +13,3 @@ function MouseEnterTest() {
   <ListItem onMouseEnter={handleMouseEnterButton} />; // desired: missing property button
   <ListItemButton onMouseEnter={handleMouseEnterButton} />;
 }
-
-// https://github.com/mui/material-ui/issues/26469
-const StyledListItem = styled(ListItem)({});
-function StyledTest() {
-  <StyledListItem dense />;
-
-  // @ts-expect-error
-  <StyledListItem button />; // `button` is deprecated in v5, can be removed in v6
-}

--- a/packages/mui-material/src/ListItem/ListItem.spec.tsx
+++ b/packages/mui-material/src/ListItem/ListItem.spec.tsx
@@ -13,3 +13,9 @@ function MouseEnterTest() {
   <ListItem onMouseEnter={handleMouseEnterButton} />; // desired: missing property button
   <ListItemButton onMouseEnter={handleMouseEnterButton} />;
 }
+
+// https://github.com/mui/material-ui/issues/26469
+const StyledListItem = styled(ListItem)({});
+function StyledTest() {
+  <StyledListItem dense />;
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Since `button` prop is removed from `ListItem`, i felt [this](https://github.com/mui/material-ui/pull/43359/files#diff-cc917c026400cc6bdef8fd581f8a4babe10b2659b6d88965806a4b781f4244f5) test is unnecessary

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
