### PR TITLE
[utils] Fix "useId" & "useSyncExternalStore" imports to not be statically analysable

### DIFF
--- a/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
@@ -72,7 +72,8 @@ function useMediaQueryOld(
   return match;
 }
 
-// eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention -- Workaround for https://github.com/webpack/webpack/issues/14814
+// See https://github.com/mui/material-ui/issues/41190#issuecomment-2040873379 for why
+// eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
 const safeReact = { ...React };
 const maybeReactUseSyncExternalStore: undefined | any = safeReact.useSyncExternalStore;
 

--- a/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
@@ -73,7 +73,6 @@ function useMediaQueryOld(
 }
 
 // See https://github.com/mui/material-ui/issues/41190#issuecomment-2040873379 for why
-// eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
 const safeReact = { ...React };
 const maybeReactUseSyncExternalStore: undefined | any = safeReact.useSyncExternalStore;
 

--- a/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
@@ -71,8 +71,9 @@ function useMediaQueryOld(
   return match;
 }
 
-// eslint-disable-next-line no-useless-concat -- Workaround for https://github.com/webpack/webpack/issues/14814
-const maybeReactUseSyncExternalStore: undefined | any = (React as any)['useSyncExternalStore' + ''];
+// eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention -- Workaround for https://github.com/webpack/webpack/issues/14814
+const _React = { ...React };
+const maybeReactUseSyncExternalStore: undefined | any = _React.useSyncExternalStore;
 
 function useMediaQueryNew(
   query: string,

--- a/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
@@ -30,6 +30,7 @@ export interface UseMediaQueryOptions {
   ssrMatchMedia?: (query: string) => { matches: boolean };
 }
 
+// TODO React 17: Remove `useMediaQueryOld` once React 17 support is removed
 function useMediaQueryOld(
   query: string,
   defaultMatches: boolean,
@@ -149,7 +150,6 @@ export default function useMediaQuery<Theme = unknown>(
   let query = typeof queryInput === 'function' ? queryInput(theme) : queryInput;
   query = query.replace(/^@media( ?)/m, '');
 
-  // TODO: Drop `useMediaQueryOld` and use  `use-sync-external-store` shim in `useMediaQueryNew` once the package is stable
   const useMediaQueryImplementation =
     maybeReactUseSyncExternalStore !== undefined ? useMediaQueryNew : useMediaQueryOld;
   const match = useMediaQueryImplementation(

--- a/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/mui-system/src/useMediaQuery/useMediaQuery.ts
@@ -73,8 +73,8 @@ function useMediaQueryOld(
 }
 
 // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention -- Workaround for https://github.com/webpack/webpack/issues/14814
-const _React = { ...React };
-const maybeReactUseSyncExternalStore: undefined | any = _React.useSyncExternalStore;
+const safeReact = { ...React };
+const maybeReactUseSyncExternalStore: undefined | any = safeReact.useSyncExternalStore;
 
 function useMediaQueryNew(
   query: string,

--- a/packages/mui-utils/src/useId/useId.test.js
+++ b/packages/mui-utils/src/useId/useId.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
-import useId from './useId';
+import useId from '@mui/utils/useId';
 
 describe('useId', () => {
   const { render, renderToString } = createRenderer();

--- a/packages/mui-utils/src/useId/useId.ts
+++ b/packages/mui-utils/src/useId/useId.ts
@@ -20,7 +20,8 @@ function useGlobalId(idOverride?: string): string | undefined {
   return id;
 }
 
-// eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention -- Workaround for https://github.com/webpack/webpack/issues/14814
+// See https://github.com/mui/material-ui/issues/41190#issuecomment-2040873379 for why
+// eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
 const safeReact = { ...React };
 const maybeReactUseId: undefined | (() => string) = safeReact.useId;
 

--- a/packages/mui-utils/src/useId/useId.ts
+++ b/packages/mui-utils/src/useId/useId.ts
@@ -2,6 +2,8 @@
 import * as React from 'react';
 
 let globalId = 0;
+
+// TODO React 17: Remove `useGlobalId` once React 17 support is removed
 function useGlobalId(idOverride?: string): string | undefined {
   const [defaultId, setDefaultId] = React.useState(idOverride);
   const id = idOverride || defaultId;

--- a/packages/mui-utils/src/useId/useId.ts
+++ b/packages/mui-utils/src/useId/useId.ts
@@ -21,6 +21,7 @@ function useGlobalId(idOverride?: string): string | undefined {
 // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention -- Workaround for https://github.com/webpack/webpack/issues/14814
 const _React = { ...React };
 const maybeReactUseId: undefined | (() => string) = _React.useId;
+
 /**
  *
  * @example <div id={useId()} />
@@ -28,10 +29,12 @@ const maybeReactUseId: undefined | (() => string) = _React.useId;
  * @returns {string}
  */
 export default function useId(idOverride?: string): string | undefined {
+  // React.useId() is only available from React 17.0.0.
   if (maybeReactUseId !== undefined) {
     const reactId = maybeReactUseId();
     return idOverride ?? reactId;
   }
+
   // TODO: uncomment once we enable eslint-plugin-react-compiler // eslint-disable-next-line react-compiler/react-compiler
   // eslint-disable-next-line react-hooks/rules-of-hooks -- `React.useId` is invariant at runtime.
   return useGlobalId(idOverride);

--- a/packages/mui-utils/src/useId/useId.ts
+++ b/packages/mui-utils/src/useId/useId.ts
@@ -21,8 +21,8 @@ function useGlobalId(idOverride?: string): string | undefined {
 }
 
 // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention -- Workaround for https://github.com/webpack/webpack/issues/14814
-const _React = { ...React };
-const maybeReactUseId: undefined | (() => string) = _React.useId;
+const safeReact = { ...React };
+const maybeReactUseId: undefined | (() => string) = safeReact.useId;
 
 /**
  *

--- a/packages/mui-utils/src/useId/useId.ts
+++ b/packages/mui-utils/src/useId/useId.ts
@@ -18,8 +18,9 @@ function useGlobalId(idOverride?: string): string | undefined {
   return id;
 }
 
-// downstream bundlers may remove unnecessary concatenation, but won't remove toString call -- Workaround for https://github.com/webpack/webpack/issues/14814
-const maybeReactUseId: undefined | (() => string) = (React as any)['useId'.toString()];
+// eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention -- Workaround for https://github.com/webpack/webpack/issues/14814
+const _React = { ...React };
+const maybeReactUseId: undefined | (() => string) = _React.useId;
 /**
  *
  * @example <div id={useId()} />

--- a/packages/mui-utils/src/useId/useId.ts
+++ b/packages/mui-utils/src/useId/useId.ts
@@ -21,7 +21,6 @@ function useGlobalId(idOverride?: string): string | undefined {
 }
 
 // See https://github.com/mui/material-ui/issues/41190#issuecomment-2040873379 for why
-// eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
 const safeReact = { ...React };
 const maybeReactUseId: undefined | (() => string) = safeReact.useId;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

fixes #41190