### PR TITLE
[core] Enable manage-package-manager-versions pnpm flag

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 enable-pre-post-scripts = true
+manage-package-manager-versions = true


### PR DESCRIPTION
[pnpm 9.7.0](https://github.com/pnpm/pnpm/releases/tag/v9.7.0) added a new flag: [`manage-package-manager-versions`](https://pnpm.io/npmrc#manage-package-manager-versions). Corepack will likely be removed from Node, so using this new flag seems like a win. Per https://github.com/mui/material-ui/pull/43344#issuecomment-2296250327, looks like we're keen on enabling `manage-package-manager-versions`.