### PR TITLE
[code-infra] Change docs:start script to serve the exports folder

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "dev": "next dev",
     "deploy": "git push -f material-ui-docs next:next",
     "icons": "rimraf --glob public/static/icons/* && node ./scripts/buildIcons.js",
-    "start": "next start",
+    "start": "serve ./export",
     "create-playground": "cpy --cwd=scripts playground.template.tsx ../../pages/playground --rename=index.tsx",
     "typescript": "tsc -p tsconfig.json && tsc -p scripts/tsconfig.json",
     "typescript:transpile": "echo 'Use `pnpm docs:typescript:formatted'` instead && exit 1",


### PR DESCRIPTION
Change the production start command to statically serve the export folder. The `next start` command doesn't work with static export.