### PR TITLE
[docs][material-ui][system] Edit "How to use components selector API" section to add about direct import

### DIFF
--- a/docs/data/system/styled/styled.md
+++ b/docs/data/system/styled/styled.md
@@ -281,9 +281,9 @@ module.exports = {
             }
           },
           "@mui/material": {
-            "styled": {
-              "canonicalImport": ["@emotion/styled", "default"],
-              "styledBaseImport": ["@mui/material", "styled"]
+            styled: {
+              canonicalImport: ["@emotion/styled", "default"],
+              styledBaseImport: ["@mui/material", "styled"]
             }
           },
           "@mui/material/styles": {

--- a/docs/data/system/styled/styled.md
+++ b/docs/data/system/styled/styled.md
@@ -280,6 +280,12 @@ module.exports = {
               styledBaseImport: ["@mui/system", "styled"]
             }
           },
+          "@mui/material": {
+            "styled": {
+              "canonicalImport": ["@emotion/styled", "default"],
+              "styledBaseImport": ["@mui/material", "styled"]
+            }
+          },
           "@mui/material/styles": {
             styled: {
               canonicalImport: ["@emotion/styled", "default"],
@@ -293,5 +299,9 @@ module.exports = {
 };
 
 ```
+
+:::info
+Note: if [`babel-plugin-direct-import`](https://github.com/avocadowastaken/babel-plugin-direct-import) used, it must be after `@emotion/babel-plugin`.
+:::
 
 Now you should be able to use components as your selectors!

--- a/docs/data/system/styled/styled.md
+++ b/docs/data/system/styled/styled.md
@@ -301,7 +301,7 @@ module.exports = {
 ```
 
 :::info
-Note: if [`babel-plugin-direct-import`](https://github.com/avocadowastaken/babel-plugin-direct-import) used, it must be after `@emotion/babel-plugin`.
+Note: If you use [`babel-plugin-direct-import`](https://github.com/avocadowastaken/babel-plugin-direct-import), place it after `@emotion/babel-plugin` in the Babel config.
 :::
 
 Now you should be able to use components as your selectors!


### PR DESCRIPTION
- add @mui/material to @emotion/babel-plugin config
- add note about @emotion/babel-plugin and babel-plugin-direct-import order

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request). 

Proof that it works: https://stackblitz.com/edit/vitejs-vite-t82o8s?file=vite.config.ts,src%2FApp.tsx&terminal=dev