### PR TITLE
[docs] Fix broken link to milestones

### DIFF
--- a/docs/data/material/discover-more/roadmap/roadmap.md
+++ b/docs/data/material/discover-more/roadmap/roadmap.md
@@ -26,6 +26,6 @@ We typically add umbrella issues to the project board after discussing them inte
 We also create milestones within the Material UI repository to keep track of larger cycles.
 Check it out to keep up with ongoing progress and see which issues have been picked up for the stable release.
 
-**[Visit the Material UI milestones page 👉](https://github.com/mui/material-ui/milestone/42)**
+**[Visit the Material UI milestones page 👉](https://github.com/mui/material-ui/milestones/)**
 
 <img src="/static/material-ui/roadmap/milestone.png" style="width: 814px;" alt="A screenshot from GitHub of the Material UI v6 milestone." width="1628" height="400" />

--- a/docs/data/material/discover-more/roadmap/roadmap.md
+++ b/docs/data/material/discover-more/roadmap/roadmap.md
@@ -24,7 +24,7 @@ We typically add umbrella issues to the project board after discussing them inte
 ### Milestones
 
 We also create milestones within the Material UI repository to keep track of larger cycles.
-Check it out to keep up with ongoing progress and see which issues have been picked up for the stable release.
+Check it out to keep up with ongoing changes and updates to the library.
 
 **[Visit the Material UI milestones page 👉](https://github.com/mui/material-ui/milestones/)**
 


### PR DESCRIPTION
I got confused following the link in https://next.mui.com/material-ui/discover-more/roadmap/#milestones. It's not what the page says.