### PR TITLE
[core] Run `@mui/system` TypeScript module augmentation tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,6 +328,7 @@ jobs:
             pnpm --filter @mui/material typescript:module-augmentation
             pnpm --filter @mui/base typescript:module-augmentation
             pnpm --filter @mui/joy typescript:module-augmentation
+            pnpm --filter @mui/system typescript:module-augmentation
       - run:
           name: Diff declaration files
           command: |


### PR DESCRIPTION
I noticed in #43384 that the test was added, but MUI System's TypeScript module augmentation tests weren't running in CI.