### PR TITLE
[docs-infra] Add link to the source in API page if available

### DIFF
--- a/docs/src/modules/components/ApiPage.tsx
+++ b/docs/src/modules/components/ApiPage.tsx
@@ -360,6 +360,23 @@ export default function ApiPage(props: ApiPageProps) {
           layoutStorageKey={layoutStorageKey.classes}
           displayClassKeys
         />
+
+        {pageContent.filename ? (
+          <div
+            className="MuiCallout-root MuiCallout-info"
+            dangerouslySetInnerHTML={{
+              __html: t('api-docs.seeSourceCode').replace(
+                '{{href}}',
+                `${process.env.SOURCE_CODE_REPO}/blob/v${process.env.LIB_VERSION}/${pageContent.filename}`,
+              ),
+            }}
+            style={{
+              alignItems: 'baseline',
+              gap: '4px',
+              marginTop: 0,
+            }}
+          />
+        ) : null}
       </MarkdownElement>
       <svg style={{ display: 'none' }} xmlns="http://www.w3.org/2000/svg">
         <symbol id="anchor-link-icon" viewBox="0 0 12 6">

--- a/packages/mui-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx
+++ b/packages/mui-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx
@@ -107,7 +107,7 @@ export function ComponentLinkHeader(props: ComponentLinkHeaderProps) {
             size="small"
             variant="outlined"
             rel="nofollow"
-            href={`${process.env.SOURCE_CODE_REPO}/tree/${process.env.SOURCE_GITHUB_BRANCH}/${headers.githubSource}`}
+            href={`${process.env.SOURCE_CODE_REPO}/blob/v${process.env.LIB_VERSION}/${headers.githubSource}`}
             icon={<GitHubIcon />}
             data-ga-event-category="ComponentLinkHeader"
             data-ga-event-action="click"

--- a/packages/mui-docs/src/translations/translations.json
+++ b/packages/mui-docs/src/translations/translations.json
@@ -45,6 +45,7 @@
     "refNotHeld": "The component cannot hold a ref.",
     "refRootElement": "The <code>ref</code> is forwarded to the root element.",
     "ruleName": "Rule name",
+    "seeSourceCode": "If you did not find the information in this AOI page, consider having a look at the <a href=\"{{href}}\">implementation of the component</a> for more detail.",
     "signature": "Signature",
     "slots": "Slots",
     "spreadHint": "Props of the {{spreadHintElement}} component are also available.",


### PR DESCRIPTION
Fix #36824
Fix https://github.com/mui/material-ui/pull/43228#discussion_r1724073716

Not entirely satisfied by the UI aspect but I can't find a better place. At least at the bottom, it should not hurt users