### PR TITLE
[docs] Add two Toolpad Core components to Material UI sidebar

### DIFF
--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -140,6 +140,14 @@ const pages: MuiPage[] = [
         ],
       },
       {
+        pathname: '/toolpad', // the pathname does not matter here because the links to Toolpad are outbound.
+        subheader: 'Toolpad Core',
+        children: [
+          { pathname: '/toolpad/core/react-dashboard-layout/', title: 'Dashboard Layout' },
+          { pathname: '/toolpad/core/react-sign-in-page/', title: 'Sign In Page' },
+        ],
+      },
+      {
         pathname: '/material-ui',
         subheader: 'lab',
         children: [

--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -145,7 +145,7 @@ const pages: MuiPage[] = [
         newFeature: true,
         children: [
           { pathname: '/toolpad/core/react-dashboard-layout/', title: 'Dashboard Layout' },
-          { pathname: '/toolpad/core/react-sign-in-page/', title: 'Sign In Page' },
+          { pathname: '/toolpad/core/react-sign-in-page/', title: 'Sign-in Page' },
         ],
       },
       {

--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -142,6 +142,7 @@ const pages: MuiPage[] = [
       {
         pathname: '/toolpad', // the pathname does not matter here because the links to Toolpad are outbound.
         subheader: 'Toolpad Core',
+        newFeature: true,
         children: [
           { pathname: '/toolpad/core/react-dashboard-layout/', title: 'Dashboard Layout' },
           { pathname: '/toolpad/core/react-sign-in-page/', title: 'Sign In Page' },

--- a/docs/scripts/i18n.ts
+++ b/docs/scripts/i18n.ts
@@ -8,7 +8,7 @@ import basePages from 'docs/data/base/pages';
 import joyPages from 'docs/data/joy/pages';
 import { MuiPage } from 'docs/src/MuiPage';
 
-const EXCLUDES = ['/api', '/blog', '/x/react-'];
+const EXCLUDES = ['/api', '/blog', '/x/react-', '/toolpad'];
 
 async function run() {
   const translationsFilename = path.join(__dirname, '../translations/translations.json');


### PR DESCRIPTION
<img width="274" alt="Screenshot 2024-08-22 at 7 37 43 PM" src="https://github.com/user-attachments/assets/6c715051-c91b-48e7-9d35-4782208b6887">
