### PR TITLE
[website] Make beta chip consistent for Toolpad

### DIFF
--- a/docs/src/components/header/HeaderNavBar.tsx
+++ b/docs/src/components/header/HeaderNavBar.tsx
@@ -111,24 +111,24 @@ const ProductSubMenu = React.forwardRef<HTMLAnchorElement, ProductSubMenuProps>(
         {...props}
       >
         <Box sx={{ px: 2 }}>{icon}</Box>
-        <Box sx={{ flexGrow: 1 }}>
-          <Box
-            sx={{
+        <div style={{ flexGrow: 1 }}>
+          <div
+            style={{
               display: 'flex',
               flexDirection: 'row',
               alignItems: 'center',
-              gap: '6px',
+              gap: '0.5rem',
             }}
           >
             <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 'bold' }}>
               {name}
             </Typography>
             {chip}
-          </Box>
+          </div>
           <Typography variant="body2" sx={{ color: 'text.secondary' }}>
             {description}
           </Typography>
-        </Box>
+        </div>
       </Box>
     );
   },

--- a/docs/src/components/header/HeaderNavBar.tsx
+++ b/docs/src/components/header/HeaderNavBar.tsx
@@ -112,14 +112,23 @@ const ProductSubMenu = React.forwardRef<HTMLAnchorElement, ProductSubMenuProps>(
       >
         <Box sx={{ px: 2 }}>{icon}</Box>
         <Box sx={{ flexGrow: 1 }}>
-          <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 'bold' }}>
-            {name}
-          </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: '6px',
+            }}
+          >
+            <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 'bold' }}>
+              {name}
+            </Typography>
+            {chip}
+          </Box>
           <Typography variant="body2" sx={{ color: 'text.secondary' }}>
             {description}
           </Typography>
         </Box>
-        {chip}
       </Box>
     );
   },
@@ -303,7 +312,24 @@ export default function HeaderNavBar() {
                         href={ROUTES.productToolpad}
                         icon={<IconImage name="product-toolpad" />}
                         name="Toolpad"
-                        chip={<Chip label="Beta" size="small" color="primary" variant="outlined" />}
+                        chip={
+                          <Chip
+                            label="Beta"
+                            size="small"
+                            color="primary"
+                            variant="outlined"
+                            sx={{
+                              fontSize: '.625rem',
+                              fontWeight: 'semiBold',
+                              textTransform: 'uppercase',
+                              letterSpacing: '.04rem',
+                              height: '16px',
+                              '& .MuiChip-label': {
+                                px: '4px',
+                              },
+                            }}
+                          />
+                        }
                         description="Components and tools for dashboards and internal apps."
                       />
                     </li>

--- a/docs/src/components/header/HeaderNavDropdown.tsx
+++ b/docs/src/components/header/HeaderNavDropdown.tsx
@@ -229,6 +229,16 @@ export default function HeaderNavDropdown() {
                                 label={item.chip}
                                 color="primary"
                                 variant="outlined"
+                                sx={{
+                                  fontSize: '.625rem',
+                                  fontWeight: 'semiBold',
+                                  textTransform: 'uppercase',
+                                  letterSpacing: '.04rem',
+                                  height: '16px',
+                                  '& .MuiChip-label': {
+                                    px: '4px',
+                                  },
+                                }}
                               />
                             ) : null}
                           </Box>
@@ -280,6 +290,16 @@ export default function HeaderNavDropdown() {
                                 label={item.chip}
                                 color="primary"
                                 variant="outlined"
+                                sx={{
+                                  fontSize: '.625rem',
+                                  fontWeight: 'semiBold',
+                                  textTransform: 'uppercase',
+                                  letterSpacing: '.04rem',
+                                  height: '16px',
+                                  '& .MuiChip-label': {
+                                    px: '4px',
+                                  },
+                                }}
                               />
                             ) : null}
                           </Box>


### PR DESCRIPTION
- [x] All caps
- [x] In web, made it adjacent to the title to match with other occurrences (docs menu and MUI product showcase)

| Location | Before | After |
|--------|--------|--------|
| Mobile | <img width="353" alt="Screenshot 2024-08-21 at 7 25 53 PM" src="https://github.com/user-attachments/assets/a6380e5e-e2b8-4e30-8184-ff3bd34fa506">| <img width="361" alt="Screenshot 2024-08-21 at 7 24 21 PM" src="https://github.com/user-attachments/assets/15bc890a-df63-4483-abd0-f0f15df2b6d6">
| Web Product menu | <img width="489" alt="Screenshot 2024-08-21 at 7 31 24 PM" src="https://github.com/user-attachments/assets/7cb057d0-ea80-4e25-8292-910c55a7f8f6"> | <img width="489" alt="Screenshot 2024-08-21 at 7 29 59 PM" src="https://github.com/user-attachments/assets/31548874-fe00-4e11-ba66-e31d66e2c352"> |
