### PR TITLE
[core] Fix typescript-next CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -839,6 +839,10 @@ workflows:
           <<: *default-context
           requires:
             - checkout
+      - test_types_next:
+          <<: *default-context
+          requires:
+            - checkout
   e2e-website:
     when:
       equal: [e2e-website, << pipeline.parameters.workflow >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,13 +352,13 @@ jobs:
     resource_class: 'medium+'
     steps:
       - checkout
+      - install_js
       - run:
           name: Resolve typescript version
           command: |
             pnpm add typescript@next -d -w
             # log a patch for maintainers who want to check out this change
             git --no-pager diff HEAD
-      - install_js
       - run:
           name: Tests TypeScript definitions
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -839,10 +839,6 @@ workflows:
           <<: *default-context
           requires:
             - checkout
-      - test_types_next:
-          <<: *default-context
-          requires:
-            - checkout
   e2e-website:
     when:
       equal: [e2e-website, << pipeline.parameters.workflow >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,7 +356,7 @@ jobs:
       - run:
           name: Resolve typescript version
           command: |
-            pnpm add typescript@next -d -w
+            pnpm update -r typescript@next
             # log a patch for maintainers who want to check out this change
             git --no-pager diff HEAD
       - run:


### PR DESCRIPTION
The `typescript-next` CircleCI workflow is failing due to a mismatch of the pnpm version installed vs the one defined in package.json engines. Example failure: https://app.circleci.com/pipelines/github/mui/material-ui/136842/workflows/2ee9d991-0807-4242-b5ae-f8911336ccb7/jobs/738034?invite=true#step-102-6

To solve the issue, we need to run corepack before pnpm gets used. Also modifying the typescript install script so we update all packages and not only the root package.json