### PR TITLE
[button] Fix loading button regression

### DIFF
--- a/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
+++ b/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
@@ -365,10 +365,6 @@ As the `ListItem` no longer supports these props, the class names related to the
 +listItemButtonClasses.selected
 ```
 
-### Loading Button
-
-In v6, the `children` prop passed to the Loading Button component is now wrapped in a `<span>` tag to avoid [issues](https://github.com/mui/material-ui/issues/27853) when using tools to translate websites.
-
 ### Rating
 
 Previously, due to a bug, the `aria-label` attribute was "null Stars" when no value was set in the Rating component.

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -229,7 +229,7 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
     <LoadingButtonLoadingIndicator className={classes.loadingIndicator} ownerState={ownerState}>
       {loadingIndicator}
     </LoadingButtonLoadingIndicator>
-  ) : null;
+  ) : <span />;
 
   return (
     <LoadingButtonRoot
@@ -242,9 +242,7 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
       ownerState={ownerState}
     >
       {ownerState.loadingPosition === 'end' ? null : loadingButtonLoadingIndicator}
-      <React.Fragment>
-        {children}
-      </React.Fragment>
+      {children}
       {ownerState.loadingPosition === 'end' ? loadingButtonLoadingIndicator : null}
     </LoadingButtonRoot>
   );

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -241,17 +241,9 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
       classes={classes}
       ownerState={ownerState}
     >
-      {ownerState.loadingPosition === 'end' ? (
-        <span>{children}</span>
-      ) : (
-        loadingButtonLoadingIndicator
-      )}
-
-      {ownerState.loadingPosition === 'end' ? (
-        loadingButtonLoadingIndicator
-      ) : (
-        <span>{children}</span>
-      )}
+      {ownerState.loadingPosition === 'end' ? null : loadingButtonLoadingIndicator}
+      {children}
+      {ownerState.loadingPosition === 'end' ? loadingButtonLoadingIndicator : null}
     </LoadingButtonRoot>
   );
 });

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -242,7 +242,9 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
       ownerState={ownerState}
     >
       {ownerState.loadingPosition === 'end' ? null : loadingButtonLoadingIndicator}
-      {children}
+      <React.Fragment>
+        {children}
+      </React.Fragment>
       {ownerState.loadingPosition === 'end' ? loadingButtonLoadingIndicator : null}
     </LoadingButtonRoot>
   );

--- a/packages/mui-utils/src/composeClasses/composeClasses.ts
+++ b/packages/mui-utils/src/composeClasses/composeClasses.ts
@@ -17,10 +17,10 @@ export default function composeClasses<ClassKey extends string>(
     for (let i = 0; i < slot.length; i += 1) {
       const value = slot[i];
       if (value) {
-        buffer += getUtilityClass(value) + ' ';
+        buffer += (buffer === '' ? '' : ' ') + getUtilityClass(value);
 
         if (classes && classes[value]) {
-          buffer += classes[value] + ' ';
+          buffer += ' ' + classes[value];
         }
       }
     }


### PR DESCRIPTION
I saw this in https://github.com/mui/mui-private/pull/511#issuecomment-2301378760, I didn't understand why we didn't go with: https://github.com/mui/material-ui/issues/27853#issuecomment-903586113, so I tested it and it seems to work. https://martijnhols.nl/gists/everything-about-google-translate-crashing-react go more in-depth into the problem.

It's a follow-up on #35198

Preview: https://deploy-preview-43400--material-ui.netlify.app/material-ui/react-button/#LoadingButtonsTransition