### PR TITLE
[core] Allow `^6.0.0` for `@mui/` dependencies in `@mui/docs`

### DIFF
--- a/packages/mui-docs/package.json
+++ b/packages/mui-docs/package.json
@@ -53,9 +53,9 @@
   },
   "peerDependencies": {
     "@mui/base": "*",
-    "@mui/icons-material": "^5.0.0",
-    "@mui/material": "^5.0.0",
-    "@mui/system": "^5.0.0",
+    "@mui/icons-material": "^5.0.0 || ^6.0.0",
+    "@mui/material": "^5.0.0 || ^6.0.0",
+    "@mui/system": "^5.0.0 || ^6.0.0",
     "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "chai": "^4.4.1",
     "csstype": "^3.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1421,7 +1421,7 @@ importers:
         specifier: workspace:^
         version: link:../markdown
       '@mui/system':
-        specifier: ^5.0.0
+        specifier: ^5.0.0 || ^6.0.0
         version: 5.16.5(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1)
       chai:
         specifier: ^4.4.1


### PR DESCRIPTION
Noticed this when testing `@mui/material@6` on the `mui-x` repo, which has a `@mui/docs` dependency.
Should be merged before the stable release.