### PR TITLE
Prepare for moving to v5.x branch

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf .next && pnpm build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "next dev",
-    "deploy": "git push -f material-ui-docs master:latest",
+    "deploy": "git push -f material-ui-docs v5.x:v5",
     "icons": "rimraf --glob public/static/icons/* && node ./scripts/buildIcons.js",
     "start": "next start",
     "create-playground": "cpy --cwd=scripts playground.template.tsx ../../pages/playground --rename=index.tsx",

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -8,7 +8,7 @@
 /size-snapshot https://s3.eu-central-1.amazonaws.com/mui-org-ci/artifacts/master/latest/size-snapshot.json 200
 
 # To add when we finish work on v6
-# https://next.mui.com/* https://mui.com/:splat 301!
+https://next.mui.com/* https://mui.com/:splat 301!
 
 # For links that we can't edit later on, for example hosted in the code published on npm
 /r/styles-instance-warning /material-ui/getting-started/faq/#i-have-several-instances-of-styles-on-the-page 302
@@ -522,11 +522,12 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 ## MUI X
 ## Unlike the store that expect to be hosted under a subfolder,
 ## MUI X is configured to be hosted at the root.
-/static/x/* https://material-ui-x.netlify.app/static/x/:splat 200
-/x/_next/* https://material-ui-x.netlify.app/_next/:splat 200
-/x/* https://material-ui-x.netlify.app/x/:splat 200
-/r/x-* https://material-ui-x.netlify.app/r/x-:splat 200
-/:lang/x/* https://material-ui-x.netlify.app/:lang/x/:splat 200
+/static/x/* https://docs-v5--material-ui-x.netlify.app/static/x/:splat 200
+/static/* https://mui.com/static/:splat 200
+/x/_next/* https://docs-v5--material-ui-x.netlify.app/_next/:splat 200
+/x/* https://docs-v5--material-ui-x.netlify.app/x/:splat 200
+/r/x-* https://docs-v5--material-ui-x.netlify.app/r/x-:splat 200
+/:lang/x/* https://docs-v5--material-ui-x.netlify.app/:lang/x/:splat 200
 
 ## MUI Toolpad
 /static/toolpad/* https://mui-toolpad-docs.netlify.app/static/toolpad/:splat 200

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -13,7 +13,10 @@ export default function AppFrameBanner() {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const pageContext = React.useContext(PageContext);
   const productName = convertProductIdToName(pageContext) || 'MUI';
-  const message = `Influence ${productName}'s 2024 roadmap! Participate in the latest Developer Survey`;
+  if (pageContext.productId !== 'material-ui' && pageContext.productId !== 'system') {
+    return null;
+  }
+  const message = `🎉 ${productName} v6 is out now! Head to the upgrading guide to get started.`;
 
   if (process.env.NODE_ENV !== 'production') {
     if (message.length > 100) {
@@ -25,7 +28,7 @@ export default function AppFrameBanner() {
 
   return (
     <Link
-      href="https://tally.so/r/3Ex4PN?source=docs-banner"
+      href="https://mui.com/material-ui/migration/upgrade-to-v6/"
       target="_blank"
       variant="caption"
       sx={[

--- a/docs/src/components/banner/AppHeaderBanner.tsx
+++ b/docs/src/components/banner/AppHeaderBanner.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import Typography from '@mui/material/Typography';
 import { Link } from '@mui/docs/Link';
-import ROUTES from 'docs/src/route';
 import FEATURE_TOGGLE from 'docs/src/featureToggle';
 
 function getSurveyMessage() {
@@ -29,10 +28,9 @@ function getSurveyMessage() {
 function getDefaultHiringMessage() {
   return (
     <React.Fragment>
-      🚀&#160;&#160;We&apos;re hiring a Designer, Full-stack Engineer, React Community Engineer, and
-      more!&nbsp;&#160;
+      🎉&#160;Material UI v6 is out now! Check out the&#160;
       <Link
-        href={ROUTES.careers} // Fix me!
+        href="https://mui.com/blog/material-ui-v6-is-out"
         target="_blank"
         color="inherit"
         underline="always"
@@ -42,8 +40,9 @@ function getDefaultHiringMessage() {
           },
         }}
       >
-        Check the careers page →
+        announcement blog post →
       </Link>
+      .
     </React.Fragment>
   );
 }

--- a/docs/src/featureToggle.js
+++ b/docs/src/featureToggle.js
@@ -2,6 +2,6 @@
 module.exports = {
   enable_website_banner: false,
   enable_toc_banner: true,
-  enable_docsnav_banner: false,
+  enable_docsnav_banner: true,
   enable_job_banner: false,
 };

--- a/docs/src/featureToggle.js
+++ b/docs/src/featureToggle.js
@@ -1,6 +1,6 @@
 // need to use commonjs export so that @mui/internal-markdown can use
 module.exports = {
-  enable_website_banner: false,
+  enable_website_banner: true,
   enable_toc_banner: true,
   enable_docsnav_banner: true,
   enable_job_banner: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Turn on AppHeaderBanner and AppFrameBanner
- Update `docs:deploy` to publish v5 subdomain


---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
