### PR TITLE
[infra] Add closing message workflow

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   add-comment:
     name: Add closing message
-    uses: mui/mui-public/.github/workflows/reusable/add-closing-message-to-issue.yml@master
+    uses: mui/mui-public/.github/workflows/reusable/add-closing-message-to-issue.yml@04275a99fe10cee127ee417b8a872cfebc7d08e7
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -1,0 +1,17 @@
+name: Add closing message to issue
+
+on:
+  issues:
+    types:
+      - closed
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  add-comment:
+    name: Add closing message
+    uses: mui/mui-public/.github/workflows/reusable/add-closing-message-to-issue.yml@master
+    permissions:
+      contents: read
+      issues: write

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -11,6 +11,7 @@ permissions: {}
 jobs:
   add-comment:
     name: Add closing message
+    if: github.event.issue.state_reason == 'completed'
     uses: mui/mui-public/.github/workflows/reusable/add-closing-message-to-issue.yml@04275a99fe10cee127ee417b8a872cfebc7d08e7
     permissions:
       contents: read

--- a/.github/workflows/support-stackoverflow.yml
+++ b/.github/workflows/support-stackoverflow.yml
@@ -32,4 +32,5 @@ jobs:
             If you have a question on Stack Overflow, you are welcome to link to it here, it might help others.
             If your issue is subsequently confirmed as a bug, and the report follows the issue template, it can be reopened.
           close-issue: true
+          issue-close-reason: 'not planned'
           lock-issue: false


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Adds the reusable workflow of adding a message on closed issues (like in thew x repo)

<img width="1155" alt="Screenshot 2024-08-26 at 16 26 06" src="https://github.com/user-attachments/assets/3af56f37-ebee-4a2d-980a-a36c4f0a8838">

This is using a reusable workflow to decrease friction on changes.