### PR TITLE
[ci] Fix the release:changelog cmd

### DIFF
--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -206,7 +206,7 @@ yargs(process.argv.slice(2))
         })
         .option('release', {
           // #default-branch-switch
-          default: 'next',
+          default: 'master',
           describe: 'Ref which we want to release',
           type: 'string',
         })


### PR DESCRIPTION
The next branch no longer exists, so this command is failing the CI on all new PRs. 