### PR TITLE
[code-infra] Fix nextjs build cache

### DIFF
--- a/packages/netlify-plugin-cache-docs/index.js
+++ b/packages/netlify-plugin-cache-docs/index.js
@@ -10,41 +10,41 @@ function generateAbsolutePaths(context) {
   const workspaceRoot = path.dirname(constants.CONFIG_PATH);
   const docsWorkspacePath = path.join(workspaceRoot, 'docs');
 
-  const nextjsBuildDir = path.join(docsWorkspacePath, '.next');
-  const digests = [path.join(workspaceRoot, 'pnpm-lock.yaml')];
+  const nextjsCacheDir = path.join(docsWorkspacePath, '.next', 'cache');
 
-  return { digests, nextjsBuildDir };
+  return { nextjsCacheDir };
 }
 
 module.exports = {
   async onPreBuild(context) {
     const { constants, utils } = context;
-    const { nextjsBuildDir } = generateAbsolutePaths({ constants });
-    const success = await utils.cache.restore(nextjsBuildDir);
+    const { nextjsCacheDir } = generateAbsolutePaths({ constants });
 
-    console.log("'%s' exists: %s", nextjsBuildDir, String(fse.existsSync(nextjsBuildDir)));
+    const cacheDirExists = fse.existsSync(nextjsCacheDir);
+    console.log("'%s' exists: %s", nextjsCacheDir, String(cacheDirExists));
 
-    console.log(
-      "Restored the cached 'docs/.next' folder at the location '%s': %s",
-      nextjsBuildDir,
-      String(success),
-    );
+    const success = await utils.cache.restore(nextjsCacheDir);
+
+    console.log("Restored the cached '%s' folder: %s", nextjsCacheDir, String(success));
+
+    const restoredCacheDir = fse.existsSync(nextjsCacheDir);
+    console.log("'%s' exists: %s", nextjsCacheDir, String(restoredCacheDir));
   },
-  async onPostBuild(context) {
+  async onBuild(context) {
     const { constants, utils } = context;
-    const { digests, nextjsBuildDir } = generateAbsolutePaths({ constants });
+    const { nextjsCacheDir } = generateAbsolutePaths({ constants });
 
-    console.log("'%s' exists: %s", nextjsBuildDir, String(fse.existsSync(nextjsBuildDir)));
+    const cacheExists = fse.existsSync(nextjsCacheDir);
 
-    const success = await utils.cache.save(nextjsBuildDir, {
-      digests,
-    });
+    if (cacheExists) {
+      console.log("'%s' exists: %s", nextjsCacheDir, String(cacheExists));
 
-    console.log(
-      "Cached 'docs/.next' folder at the location '%s': %s",
-      nextjsBuildDir,
-      String(success),
-    );
+      const success = await utils.cache.save(nextjsCacheDir);
+
+      console.log("Cached '%s' folder: %s", nextjsCacheDir, String(success));
+    } else {
+      console.log("'%s' does not exist", nextjsCacheDir);
+    }
   },
   // debug
   // based on: https://github.com/netlify-labs/netlify-plugin-debug-cache/blob/v1.0.3/index.js

--- a/packages/netlify-plugin-cache-docs/index.js
+++ b/packages/netlify-plugin-cache-docs/index.js
@@ -16,6 +16,8 @@ function generateAbsolutePaths(context) {
 }
 
 module.exports = {
+  // Restore the `.next/cache` folder
+  // based on: https://github.com/netlify/next-runtime/blob/733a0219e5413aa1eea790af48c745322dbce917/src/index.ts
   async onPreBuild(context) {
     const { constants, utils } = context;
     const { nextjsCacheDir } = generateAbsolutePaths({ constants });
@@ -30,6 +32,9 @@ module.exports = {
     const restoredCacheDir = fse.existsSync(nextjsCacheDir);
     console.log("'%s' exists: %s", nextjsCacheDir, String(restoredCacheDir));
   },
+  // On build, cache the `.next/cache` folder
+  // based on: https://github.com/netlify/next-runtime/blob/733a0219e5413aa1eea790af48c745322dbce917/src/index.ts
+  // This hook is called immediately after the build command is executed.
   async onBuild(context) {
     const { constants, utils } = context;
     const { nextjsCacheDir } = generateAbsolutePaths({ constants });

--- a/packages/netlify-plugin-cache-docs/package.json
+++ b/packages/netlify-plugin-cache-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-plugin-cache-docs",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "private": true,
   "author": "MUI Team",
   "description": "Alternative to netlify-plugin-cache-nextjs",


### PR DESCRIPTION
Main changes:
- Cache only `docs/.next/cache` folder instead of the entire `docs/.next` folder
  - We were previously caching some files that could get stale. This is in-line with the official plugin
    https://github.com/netlify/next-runtime/blob/733a0219e5413aa1eea790af48c745322dbce917/src/build/cache.ts
- Remove `digest`
  - providing a digest could make it worse, since it was meant for `node_modules`-like folders, which contain an ungodly amount of files
    docs: https://github.com/netlify/build/blob/main/packages/cache-utils/README.md#digests
    save/restore impl: https://github.com/netlify/build/blob/main/packages/cache-utils/src/main.ts
    manifest impl: https://github.com/netlify/build/blob/main/packages/cache-utils/src/manifest.ts
- Move from `onPostBuild` to `onBuild` to be in par with the official next plugin. 
  - Not sure this is useful, but leaves us with a behaviour similar to the official plugin 🤷 
    https://github.com/netlify/next-runtime/blob/733a0219e5413aa1eea790af48c745322dbce917/src/index.ts 

> Note: Should I also update the version in package.json? 🤔 