### PR TITLE
[docs-infra] Add comment about removing optimizeFonts Next.js config

### DIFF
--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -49,7 +49,7 @@ process.env.DEPLOY_ENV = DEPLOY_ENV;
 function withDocsInfra(nextConfig) {
   return {
     trailingSlash: true,
-    // Can be turned on when https://github.com/vercel/next.js/issues/24640 is fixed
+    // TODO: Remove when upgrading to Next.js 15, see https://github.com/vercel/next.js/pull/69137
     optimizeFonts: false,
     reactStrictMode: true,
     ...nextConfig,


### PR DESCRIPTION
Next.js v15 drops support for the `optimizeFonts` option (see https://github.com/vercel/next.js/pull/69137) and warns about this option being invalid. I'm adding a comment so we don't forget about it.


Next.js v15 build time warning:

<img width="420" alt="image" src="https://github.com/user-attachments/assets/56721742-3c0e-43fe-853c-3ee679148309">

