### PR TITLE
[code-infra] Add missing @babel/runtime dependency to @mui/material-pigment-css

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -92,8 +92,7 @@ module.exports = function getBabelConfig(api) {
       '@babel/plugin-transform-runtime',
       {
         useESModules,
-        // any package needs to declare 7.4.4 as a runtime dependency. default is ^7.0.0
-        version: '^7.4.4',
+        version: process.env.MUI_BABEL_RUNTIME_VERSION || '^7.25.0',
       },
     ],
     [

--- a/packages/mui-material-pigment-css/package.json
+++ b/packages/mui-material-pigment-css/package.json
@@ -39,6 +39,7 @@
     "typescript:module-augmentation": "node scripts/testModuleAugmentation.js"
   },
   "dependencies": {
+    "@babel/runtime": "^7.25.0",
     "@mui/system": "workspace:*",
     "@pigment-css/react": "0.0.20"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1851,6 +1851,9 @@ importers:
 
   packages/mui-material-pigment-css:
     dependencies:
+      '@babel/runtime':
+        specifier: ^7.25.0
+        version: 7.25.0
       '@mui/system':
         specifier: workspace:*
         version: link:../mui-system/build

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -30,9 +30,9 @@ async function run(argv) {
   });
 
   const babelRuntimeVersion = pkg.dependencies['@babel/runtime'];
-  if (bundle === 'node' && !babelRuntimeVersion) {
+  if (!babelRuntimeVersion) {
     throw new Error(
-      'package.json needs to have a dependency on `@babel/runtime` when building for commonjs.',
+      'package.json needs to have a dependency on `@babel/runtime` when building with `@babel/plugin-transform-runtime`.',
     );
   }
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -25,10 +25,22 @@ async function run(argv) {
     );
   }
 
+  const { default: pkg } = await import(path.resolve('./package.json'), {
+    with: { type: 'json' },
+  });
+
+  const babelRuntimeVersion = pkg.dependencies['@babel/runtime'];
+  if (bundle === 'node' && !babelRuntimeVersion) {
+    throw new Error(
+      'package.json needs to have a dependency on `@babel/runtime` when building for commonjs.',
+    );
+  }
+
   const env = {
     NODE_ENV: 'production',
     BABEL_ENV: bundle,
     MUI_BUILD_VERBOSE: verbose,
+    MUI_BABEL_RUNTIME_VERSION: babelRuntimeVersion,
     ...(await getVersionEnvVariables()),
   };
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -3,6 +3,7 @@ import glob from 'fast-glob';
 import path from 'path';
 import { promisify } from 'util';
 import yargs from 'yargs';
+import * as fs from 'fs/promises';
 import { getVersionEnvVariables, getWorkspaceRoot } from './utils.mjs';
 
 const exec = promisify(childProcess.exec);
@@ -25,11 +26,10 @@ async function run(argv) {
     );
   }
 
-  const { default: pkg } = await import(path.resolve('./package.json'), {
-    with: { type: 'json' },
-  });
+  const packageJsonPath = path.resolve('./package.json');
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, { encoding: 'utf8' }));
 
-  const babelRuntimeVersion = pkg.dependencies['@babel/runtime'];
+  const babelRuntimeVersion = packageJson.dependencies['@babel/runtime'];
   if (!babelRuntimeVersion) {
     throw new Error(
       'package.json needs to have a dependency on `@babel/runtime` when building with `@babel/plugin-transform-runtime`.',


### PR DESCRIPTION
Discovered in https://github.com/mui/material-ui/pull/43264, where this was breaking a build. Took the opportunity to add a check for missing `@babel/runtime` dependencies. As suggested in https://github.com/mui/material-ui/pull/43243 I'm passing this version to babel config to be used in the build.