### PR TITLE
[material-ui][docs] Dark scroll bars in templates

### DIFF
--- a/docs/data/material/getting-started/templates/blog/Blog.tsx
+++ b/docs/data/material/getting-started/templates/blog/Blog.tsx
@@ -48,7 +48,7 @@ export default function Blog() {
       toggleColorMode={toggleColorMode}
     >
       <ThemeProvider theme={showCustomTheme ? blogTheme : defaultTheme}>
-        <CssBaseline />
+        <CssBaseline enableColorScheme />
 
         <AppAppBar />
         <Container

--- a/docs/data/material/getting-started/templates/checkout/Checkout.tsx
+++ b/docs/data/material/getting-started/templates/checkout/Checkout.tsx
@@ -78,7 +78,7 @@ export default function Checkout() {
       toggleColorMode={toggleColorMode}
     >
       <ThemeProvider theme={showCustomTheme ? checkoutTheme : defaultTheme}>
-        <CssBaseline />
+        <CssBaseline enableColorScheme />
 
         <Grid container sx={{ height: { xs: '100%', sm: '100dvh' } }}>
           <Grid

--- a/docs/data/material/getting-started/templates/dashboard/Dashboard.tsx
+++ b/docs/data/material/getting-started/templates/dashboard/Dashboard.tsx
@@ -53,7 +53,7 @@ export default function Dashboard() {
       toggleColorMode={toggleColorMode}
     >
       <ThemeProvider theme={showCustomTheme ? dashboardTheme : defaultTheme}>
-        <CssBaseline />
+        <CssBaseline enableColorScheme />
         <Box sx={{ display: 'flex' }}>
           <SideMenu />
           <AppNavbar />

--- a/docs/data/material/getting-started/templates/marketing-page/MarketingPage.tsx
+++ b/docs/data/material/getting-started/templates/marketing-page/MarketingPage.tsx
@@ -53,7 +53,7 @@ export default function MarketingPage() {
       toggleColorMode={toggleColorMode}
     >
       <ThemeProvider theme={showCustomTheme ? MPTheme : defaultTheme}>
-        <CssBaseline />
+        <CssBaseline enableColorScheme />
 
         <AppAppBar />
         <Hero />

--- a/docs/data/material/getting-started/templates/sign-in-side/SignInSide.tsx
+++ b/docs/data/material/getting-started/templates/sign-in-side/SignInSide.tsx
@@ -45,7 +45,7 @@ export default function SignInSide() {
       toggleColorMode={toggleColorMode}
     >
       <ThemeProvider theme={showCustomTheme ? SignInSideTheme : defaultTheme}>
-        <CssBaseline />
+        <CssBaseline enableColorScheme />
         <Stack
           direction="column"
           component="main"

--- a/docs/data/material/getting-started/templates/sign-in/SignIn.tsx
+++ b/docs/data/material/getting-started/templates/sign-in/SignIn.tsx
@@ -142,7 +142,7 @@ export default function SignIn() {
       toggleColorMode={toggleColorMode}
     >
       <ThemeProvider theme={showCustomTheme ? SignInTheme : defaultTheme}>
-        <CssBaseline />
+        <CssBaseline enableColorScheme />
         <SignInContainer direction="column" justifyContent="space-between">
           <Card variant="outlined">
             <SitemarkIcon />

--- a/docs/data/material/getting-started/templates/sign-up/SignUp.tsx
+++ b/docs/data/material/getting-started/templates/sign-up/SignUp.tsx
@@ -145,7 +145,7 @@ export default function SignUp() {
       toggleColorMode={toggleColorMode}
     >
       <ThemeProvider theme={showCustomTheme ? SignUpTheme : defaultTheme}>
-        <CssBaseline />
+        <CssBaseline enableColorScheme />
 
         <SignUpContainer direction="column" justifyContent="space-between">
           <Stack


### PR DESCRIPTION
Enable `color-scheme` so scroll bars look dark in dark mode.

|before|after|
|---|---|
|<img width="1327" alt="after" src="https://github.com/user-attachments/assets/eb61411a-20fa-45b7-9645-0d311181a395">|<img width="1327" alt="before" src="https://github.com/user-attachments/assets/08556285-fd80-41fe-ad66-6a2778b10450">|
