### PR TITLE
[docs][material-ui][Dialog] Update confirmation dialog description

### DIFF
--- a/docs/data/material/components/dialogs/dialogs.md
+++ b/docs/data/material/components/dialogs/dialogs.md
@@ -113,7 +113,7 @@ function MyComponent() {
 Confirmation dialogs require users to explicitly confirm their choice before an option is committed.
 For example, users can listen to multiple ringtones but only make a final selection upon touching "OK".
 
-Touching "Cancel" in a confirmation dialog, or pressing Back, cancels the action, discards any changes, and closes the dialog.
+Touching "Cancel" in a confirmation dialog, cancels the action, discards any changes, and closes the dialog.
 
 {{"demo": "ConfirmationDialog.js"}}
 


### PR DESCRIPTION
The commit modifies wording of the confirmation dialog by removing the option to close the dialog by pressing the "Back" button. This ensures that users can only cancel the action by touching the "Cancel" button.

Closes [41398](https://github.com/mui/material-ui/issues/41398)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
