### PR TITLE
[docs][table] Make the data grid blend in

### DIFF
--- a/docs/data/material/components/table/DataTable.js
+++ b/docs/data/material/components/table/DataTable.js
@@ -34,17 +34,15 @@ const rows = [
   { id: 9, lastName: 'Roxie', firstName: 'Harvey', age: 65 },
 ];
 
+const paginationModel = { page: 0, pageSize: 5 };
+
 export default function DataTable() {
   return (
     <Paper sx={{ height: 400, width: '100%' }}>
       <DataGrid
         rows={rows}
         columns={columns}
-        initialState={{
-          pagination: {
-            paginationModel: { page: 0, pageSize: 5 },
-          },
-        }}
+        initialState={{ pagination: { paginationModel } }}
         pageSizeOptions={[5, 10]}
         checkboxSelection
         sx={{ border: 0 }}

--- a/docs/data/material/components/table/DataTable.js
+++ b/docs/data/material/components/table/DataTable.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DataGrid } from '@mui/x-data-grid';
+import Paper from '@mui/material/Paper';
 
 const columns = [
   { field: 'id', headerName: 'ID', width: 70 },
@@ -35,7 +36,7 @@ const rows = [
 
 export default function DataTable() {
   return (
-    <div style={{ height: 400, width: '100%' }}>
+    <Paper sx={{ height: 400, width: '100%' }}>
       <DataGrid
         rows={rows}
         columns={columns}
@@ -46,8 +47,8 @@ export default function DataTable() {
         }}
         pageSizeOptions={[5, 10]}
         checkboxSelection
-        sx={{ overflow: 'clip' }}
+        sx={{ border: 0 }}
       />
-    </div>
+    </Paper>
   );
 }

--- a/docs/data/material/components/table/DataTable.tsx
+++ b/docs/data/material/components/table/DataTable.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import Paper from '@mui/material/Paper';
 
 const columns: GridColDef[] = [
   { field: 'id', headerName: 'ID', width: 70 },
@@ -35,7 +36,7 @@ const rows = [
 
 export default function DataTable() {
   return (
-    <div style={{ height: 400, width: '100%' }}>
+    <Paper sx={{ height: 400, width: '100%' }}>
       <DataGrid
         rows={rows}
         columns={columns}
@@ -46,8 +47,8 @@ export default function DataTable() {
         }}
         pageSizeOptions={[5, 10]}
         checkboxSelection
-        sx={{ overflow: 'clip' }}
+        sx={{ border: 0 }}
       />
-    </div>
+    </Paper>
   );
 }

--- a/docs/data/material/components/table/DataTable.tsx
+++ b/docs/data/material/components/table/DataTable.tsx
@@ -34,17 +34,15 @@ const rows = [
   { id: 9, lastName: 'Roxie', firstName: 'Harvey', age: 65 },
 ];
 
+const paginationModel = { page: 0, pageSize: 5 };
+
 export default function DataTable() {
   return (
     <Paper sx={{ height: 400, width: '100%' }}>
       <DataGrid
         rows={rows}
         columns={columns}
-        initialState={{
-          pagination: {
-            paginationModel: { page: 0, pageSize: 5 },
-          },
-        }}
+        initialState={{ pagination: { paginationModel } }}
         pageSizeOptions={[5, 10]}
         checkboxSelection
         sx={{ border: 0 }}

--- a/docs/data/material/components/table/DataTable.tsx.preview
+++ b/docs/data/material/components/table/DataTable.tsx.preview
@@ -1,12 +1,10 @@
-<DataGrid
-  rows={rows}
-  columns={columns}
-  initialState={{
-    pagination: {
-      paginationModel: { page: 0, pageSize: 5 },
-    },
-  }}
-  pageSizeOptions={[5, 10]}
-  checkboxSelection
-  sx={{ overflow: 'clip' }}
-/>
+<Paper sx={{ height: 400, width: '100%' }}>
+  <DataGrid
+    rows={rows}
+    columns={columns}
+    initialState={{ pagination: { paginationModel } }}
+    pageSizeOptions={[5, 10]}
+    checkboxSelection
+    sx={{ border: 0 }}
+  />
+</Paper>

--- a/docs/data/material/components/table/table.md
+++ b/docs/data/material/components/table/table.md
@@ -34,7 +34,7 @@ This constraint makes building rich data tables challenging.
 The [`DataGrid` component](/x/react-data-grid/) is designed for use-cases that are focused on handling large amounts of tabular data.
 While it comes with a more rigid structure, in exchange, you gain more powerful features.
 
-{{"demo": "DataTable.js", "bg": "outlined"}}
+{{"demo": "DataTable.js", "bg": true}}
 
 ## Dense table
 


### PR DESCRIPTION
I have seen a designer ask when to use a table vs. a data grid: https://discord.com/channels/1131323012554174485/1131329358062178324/1273813466347602082. I believe it should purely be a technical decision, so here is a continuation of #43072 to make the data grid blend in.

Before: https://mui.com/material-ui/react-table/#data-table
After: https://deploy-preview-43489--material-ui.netlify.app/material-ui/react-table/#data-table

<img width="232" alt="SCR-20240828-cloj" src="https://github.com/user-attachments/assets/57d823f4-3ef0-4e75-9832-5f517cbc98d1">
