### PR TITLE
[docs-infra] Fix use of process.env.DEPLOY_ENV

### DIFF
--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -81,7 +81,7 @@ function orderedPages(pages, current = []) {
 }
 
 async function postFeedback(data) {
-  const env = window.location.host.includes('mui.com') ? 'prod' : 'dev';
+  const env = process.env.DEPLOY_ENV === 'production' ? 'prod' : 'dev';
   try {
     const response = await fetch(`${process.env.FEEDBACK_URL}/${env}/feedback`, {
       method: 'POST',


### PR DESCRIPTION
That check looked wrong to me. We have an env variable for this, which is replaced at build-time, so less bundle size, and that is more predictable.

(Initially added by Matt)