### PR TITLE
[code-infra] Remove permissions in publish-canaries.yml

### DIFF
--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -3,6 +3,8 @@ name: Publish canary packages to npm
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It looks like this GitHub action doesn't need GITHUB_TOKEN with permissions to our GitHub repository APIs. Flagged in https://github.com/mui/material-ui/security/code-scanning/69.