### PR TITLE
[code-infra] Fix typing issues with `@mui-internal/api-docs-builder`

### DIFF
--- a/packages-internal/docs-utils/package.json
+++ b/packages-internal/docs-utils/package.json
@@ -15,8 +15,8 @@
   },
   "scripts": {
     "prebuild": "rimraf ./build",
-    "build": "tsc -b tsconfig.build.json",
-    "typescript": "tsc -b tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
+    "typescript": "tsc -p tsconfig.json",
     "release:publish": "pnpm build && pnpm publish --tag latest",
     "release:publish:dry-run": "pnpm build && pnpm publish --tag latest --registry=\"http://localhost:4873/\""
   },

--- a/packages-internal/test-utils/package.json
+++ b/packages-internal/test-utils/package.json
@@ -25,8 +25,8 @@
   },
   "scripts": {
     "prebuild": "rimraf ./build",
-    "build": "tsc -b tsconfig.build.json",
-    "typescript": "tsc -b tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
+    "typescript": "tsc -p tsconfig.json",
     "release:publish": "pnpm publish --tag latest",
     "release:publish:dry-run": "pnpm publish --tag latest --registry=\"http://localhost:4873/\""
   },

--- a/packages/api-docs-builder/tsconfig.json
+++ b/packages/api-docs-builder/tsconfig.json
@@ -14,7 +14,7 @@
     "strict": true,
     "baseUrl": "./",
     "paths": {
-      "@mui/internal-docs-utils": ["../docs-utils/src"]
+      "@mui/internal-docs-utils": ["../../packages-internal/docs-utils/src"]
     }
   },
   "include": ["./**/*.ts", "./**/*.js"],


### PR DESCRIPTION
This came up on https://github.com/mui/material-ui/pull/43264, example: https://app.circleci.com/pipelines/github/mui/material-ui/137522/workflows/fa1c6a26-2bb8-4c47-a680-b33ce62c6a08/jobs/741391
* `@mui-internal/api-docs-builder` has the wrong path configured for `@mui/internal-docs-utils`. (Not sure why it's not extending from the global tsconfig like the other projects, but honestly, I think I prefer to do this on a per project basis) 
* `@mui/internal-docs-utils` and `@mui/internal-test-utils` are using the `-b` flag. Not sure why, they don't have project references and we don't do this anywhere yet.