### PR TITLE
[docs-infra] Skip shadow DOM regression test

### DIFF
--- a/docs/data/material/customization/shadow-dom/ShadowDOMDemoNoSnap.js
+++ b/docs/data/material/customization/shadow-dom/ShadowDOMDemoNoSnap.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export default function ShadowDOMDemo() {
+export default function ShadowDOMDemoNoSnap() {
   return (
     <iframe
       title="codesandbox"

--- a/docs/data/material/customization/shadow-dom/shadow-dom.md
+++ b/docs/data/material/customization/shadow-dom/shadow-dom.md
@@ -68,4 +68,4 @@ const theme = createTheme({
 
 In the example below you can see that the component outside of the shadow DOM is affected by global styles, while the component inside of the shadow DOM is not:
 
-{{"demo": "ShadowDOMDemo.js", "hideToolbar": true, "bg": true}}
+{{"demo": "ShadowDOMDemoNoSnap.js", "hideToolbar": true, "bg": true}}

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -33,6 +33,8 @@ importRegressionFixtures.keys().forEach((path) => {
 }, []);
 
 const blacklist = [
+  // Excludes demos that we don't want
+  /^docs-(.*)(?<=NoSnap)\.png$/,
   // Blog template components and theme customizations
   'docs-getting-started-templates-blog/Blog.png',
   'docs-getting-started-templates-blog/TemplateFrame.png',

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -256,7 +256,7 @@ function excludeDemoFixture(suite, name) {
     }
 
     // assume regex
-    if (pattern.test(suite) || pattern.test(`${suite}/${name}.png`)) {
+    if (pattern.test(`${suite}/${name}.png`)) {
       unusedBlacklistPatterns.delete(pattern);
       return true;
     }

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -256,7 +256,7 @@ function excludeDemoFixture(suite, name) {
     }
 
     // assume regex
-    if (pattern.test(suite)) {
+    if (pattern.test(suite) || pattern.test(`${suite}/${name}.png`)) {
       unusedBlacklistPatterns.delete(pattern);
       return true;
     }


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/39766

Introducing the changes suggested in https://github.com/mui/material-ui/pull/42824#issuecomment-2313737544 to be able to skip certain demos regression tests and skipping the shadow DOM regression test.