### PR TITLE
[material-ui][Menu,Popover] Fix Backdrop props descriptions

### DIFF
--- a/docs/pages/material-ui/api/popover.json
+++ b/docs/pages/material-ui/api/popover.json
@@ -20,6 +20,17 @@
       },
       "default": "'anchorEl'"
     },
+    "BackdropComponent": {
+      "type": { "name": "elementType" },
+      "default": "styled(Backdrop, {\n  name: 'MuiModal',\n  slot: 'Backdrop',\n  overridesResolver: (props, styles) => {\n    return styles.backdrop;\n  },\n})({\n  zIndex: -1,\n})",
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slotProps.root.slots.backdrop</code> instead. While this prop currently works, it will be removed in the next major version."
+    },
+    "BackdropProps": {
+      "type": { "name": "object" },
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slotProps.root.slotProps.backdrop</code> instead."
+    },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },

--- a/docs/translations/api-docs/popover/popover.json
+++ b/docs/translations/api-docs/popover/popover.json
@@ -16,6 +16,12 @@
     "anchorReference": {
       "description": "This determines which anchor prop to refer to when setting the position of the popover."
     },
+    "BackdropComponent": {
+      "description": "A backdrop component. This prop enables custom backdrop rendering."
+    },
+    "BackdropProps": {
+      "description": "Props applied to the <a href=\"/material-ui/api/backdrop/\"><code>Backdrop</code></a> element."
+    },
     "children": { "description": "The content of the component." },
     "classes": { "description": "Override or extend the styles applied to the component." },
     "container": {

--- a/packages/mui-material/src/Popover/Popover.d.ts
+++ b/packages/mui-material/src/Popover/Popover.d.ts
@@ -1,12 +1,12 @@
-import * as React from 'react';
 import { SxProps } from '@mui/system';
-import { InternalStandardProps as StandardProps } from '..';
-import Paper, { PaperProps } from '../Paper';
+import * as React from 'react';
+import { BackdropProps, InternalStandardProps as StandardProps } from '..';
 import Modal, { ModalOwnerState, ModalProps } from '../Modal';
+import Paper, { PaperProps } from '../Paper';
 import { Theme } from '../styles';
 import { TransitionProps } from '../transitions/transition';
-import { PopoverClasses } from './popoverClasses';
 import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
+import { PopoverClasses } from './popoverClasses';
 
 export interface PopoverSlots {
   root?: React.ElementType;
@@ -39,7 +39,10 @@ interface PopoverVirtualElement {
 }
 
 export interface PopoverProps
-  extends StandardProps<Omit<ModalProps, 'slots' | 'slotProps'>, 'children'>,
+  extends StandardProps<
+      Omit<ModalProps, 'slots' | 'slotProps' | 'BackdropProps' | 'BackdropComponent'>,
+      'children'
+    >,
     PopoverSlotsAndSlotProps {
   /**
    * A ref for imperative actions.
@@ -82,6 +85,26 @@ export interface PopoverProps
    * @default 'anchorEl'
    */
   anchorReference?: PopoverReference;
+  /**
+   * A backdrop component. This prop enables custom backdrop rendering.
+   * @deprecated Use `slotProps.root.slots.backdrop` instead. While this prop currently works, it will be removed in the next major version.
+   * Use the `slotProps.root.slots.backdrop` prop to make your application ready for the next version of Material UI.
+   * @default styled(Backdrop, {
+   *   name: 'MuiModal',
+   *   slot: 'Backdrop',
+   *   overridesResolver: (props, styles) => {
+   *     return styles.backdrop;
+   *   },
+   * })({
+   *   zIndex: -1,
+   * })
+   */
+  BackdropComponent?: React.ElementType<BackdropProps>;
+  /**
+   * Props applied to the [`Backdrop`](/material-ui/api/backdrop/) element.
+   * @deprecated Use `slotProps.root.slotProps.backdrop` instead.
+   */
+  BackdropProps?: Partial<BackdropProps>;
   /**
    * The content of the component.
    */

--- a/packages/mui-material/src/Popover/Popover.d.ts
+++ b/packages/mui-material/src/Popover/Popover.d.ts
@@ -1,12 +1,12 @@
-import { SxProps } from '@mui/system';
 import * as React from 'react';
+import { SxProps } from '@mui/system';
 import { BackdropProps, InternalStandardProps as StandardProps } from '..';
-import Modal, { ModalOwnerState, ModalProps } from '../Modal';
 import Paper, { PaperProps } from '../Paper';
+import Modal, { ModalOwnerState, ModalProps } from '../Modal';
 import { Theme } from '../styles';
 import { TransitionProps } from '../transitions/transition';
-import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
 import { PopoverClasses } from './popoverClasses';
+import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
 
 export interface PopoverSlots {
   root?: React.ElementType;

--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -519,6 +519,26 @@ Popover.propTypes /* remove-proptypes */ = {
    */
   anchorReference: PropTypes.oneOf(['anchorEl', 'anchorPosition', 'none']),
   /**
+   * A backdrop component. This prop enables custom backdrop rendering.
+   * @deprecated Use `slotProps.root.slots.backdrop` instead. While this prop currently works, it will be removed in the next major version.
+   * Use the `slotProps.root.slots.backdrop` prop to make your application ready for the next version of Material UI.
+   * @default styled(Backdrop, {
+   *   name: 'MuiModal',
+   *   slot: 'Backdrop',
+   *   overridesResolver: (props, styles) => {
+   *     return styles.backdrop;
+   *   },
+   * })({
+   *   zIndex: -1,
+   * })
+   */
+  BackdropComponent: PropTypes.elementType,
+  /**
+   * Props applied to the [`Backdrop`](/material-ui/api/backdrop/) element.
+   * @deprecated Use `slotProps.root.slotProps.backdrop` instead.
+   */
+  BackdropProps: PropTypes.object,
+  /**
    * The content of the component.
    */
   children: PropTypes.node,


### PR DESCRIPTION
fix: update popover component with deprecated props and types

Closes: [43222](https://github.com/mui/material-ui/issues/43222)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
