### PR TITLE
[typescript] Fix missing `Theme` generic

### DIFF
--- a/packages/mui-material/src/Popover/Popover.spec.tsx
+++ b/packages/mui-material/src/Popover/Popover.spec.tsx
@@ -16,3 +16,12 @@ function Test() {
     </React.Fragment>
   );
 }
+
+<Popover
+  open
+  slotProps={{
+    paper: {
+      sx: (theme) => ({ backgroundColor: theme.palette.primary.main }),
+    },
+  }}
+/>;

--- a/packages/mui-material/src/utils/types.ts
+++ b/packages/mui-material/src/utils/types.ts
@@ -1,5 +1,6 @@
 import { SxProps } from '@mui/system';
 import { SlotComponentProps } from '@mui/utils';
+import { Theme } from '../styles';
 
 export type {
   EventHandlers,
@@ -10,7 +11,7 @@ export type {
 
 export type SlotCommonProps = {
   component?: React.ElementType;
-  sx?: SxProps;
+  sx?: SxProps<Theme>;
 };
 
 export type SlotProps<


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #43522

The `SxProps` is missing generic so it's not working with callback signature.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
