### PR TITLE
[examples] Add missing `clsx` dependency

### DIFF
--- a/examples/material-ui-nextjs-pages-router-ts/package.json
+++ b/examples/material-ui-nextjs-pages-router-ts/package.json
@@ -17,6 +17,7 @@
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
     "@mui/material-nextjs": "latest",
+    "clsx": "latest",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"

--- a/examples/material-ui-nextjs-pages-router/package.json
+++ b/examples/material-ui-nextjs-pages-router/package.json
@@ -17,6 +17,7 @@
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
     "@mui/material-nextjs": "latest",
+    "clsx": "latest",
     "next": "latest",
     "prop-types": "latest",
     "react": "latest",

--- a/examples/material-ui-nextjs-ts-v4-v5-migration/package.json
+++ b/examples/material-ui-nextjs-ts-v4-v5-migration/package.json
@@ -20,6 +20,7 @@
     "@mui/styles": "latest",
     "autoprefixer": "latest",
     "clean-css": "latest",
+    "clsx": "latest",
     "next": "latest",
     "postcss": "latest",
     "react": "latest",


### PR DESCRIPTION
These examples have a `Link` component that uses `clsx` but the dependency is not defined.

Found while testing https://github.com/mui/material-ui/pull/43264