### PR TITLE
[ButtonBase] Export types used in ButtonBase props

### DIFF
--- a/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
@@ -5,6 +5,8 @@ import { TouchRippleActions, TouchRippleProps } from './TouchRipple';
 import { OverrideProps, OverridableComponent, OverridableTypeMap } from '../OverridableComponent';
 import { ButtonBaseClasses } from './buttonBaseClasses';
 
+export { TouchRippleActions, TouchRippleProps };
+
 export interface ButtonBaseOwnProps {
   /**
    * A ref for imperative actions.


### PR DESCRIPTION
Allows X to avoid deeply nested imports in X https://github.com/mui/mui-x/blob/1a9426021bd72b5a1cc18e2c78a5a063d27be541/docs/data/data-grid/column-definition/RenderCellGrid.tsx#L4

In fact it would make sense to export all types that are referenced by public API. But that's another story 🙂 

These imports will break once we put a hard limit on what is exported from the package