### PR TITLE
[docs-infra] Fix GitHub source link redirection

### DIFF
--- a/packages/mui-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx
+++ b/packages/mui-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx
@@ -107,14 +107,13 @@ export function ComponentLinkHeader(props: ComponentLinkHeaderProps) {
             size="small"
             variant="outlined"
             rel="nofollow"
-            href={`${process.env.SOURCE_CODE_REPO}/blob/v${process.env.LIB_VERSION}/${headers.githubSource}`}
+            href={`${process.env.SOURCE_CODE_REPO}/tree/v${process.env.LIB_VERSION}/${headers.githubSource}`}
             icon={<GitHubIcon />}
             data-ga-event-category="ComponentLinkHeader"
             data-ga-event-action="click"
             data-ga-event-label="Source"
             data-ga-event-split="0.1"
             label="Source"
-            target="_blank"
           />
         </li>
       ) : null}


### PR DESCRIPTION
This is a quick follow-up on #43387.

This link creates a 301, which slows the user experience by about 200ms:

<img width="1044" alt="SCR-20240830-oiqr" src="https://github.com/user-attachments/assets/4073cc5b-32d8-4db2-8c64-82d50dc1119d">

I keep forgetting about tree (folder) vs. blob (file) in the URL to link in GitHub.

---

Also, none of the other chips have target blank, I got confused that it didn't open in the same window. I removed it for consistency of behavior. We could discuss adding to all the chips as well, but I think it's a bit beyond this scope.

Preview: https://deploy-preview-43534--material-ui.netlify.app/material-ui/react-alert/