### PR TITLE
[blog] Update Material UI v6 blog post link to reflect correct section title

### DIFF
--- a/docs/pages/blog/material-ui-v6-is-out.md
+++ b/docs/pages/blog/material-ui-v6-is-out.md
@@ -38,7 +38,7 @@ It comes with new features, improvements, and an experimental integration for st
   - [Built-in `sx` prop support](#built-in-sx-prop-support)
 - [React 19 support](#react-19-support)
 - [Full-stack apps via Toolpad Core](#full-stack-apps-via-toolpad-core)
-- [What's next](#get-started-with-material-ui-v6)
+- [Get started with Material UI v6](#get-started-with-material-ui-v6)
 
 ## New features
 

--- a/docs/pages/blog/material-ui-v6-is-out.md
+++ b/docs/pages/blog/material-ui-v6-is-out.md
@@ -38,7 +38,7 @@ It comes with new features, improvements, and an experimental integration for st
   - [Built-in `sx` prop support](#built-in-sx-prop-support)
 - [React 19 support](#react-19-support)
 - [Full-stack apps via Toolpad Core](#full-stack-apps-via-toolpad-core)
-- [Get started with Material UI v6](#get-started-with-material-ui-v6)
+- [Get started with Material UI v6](#get-started-with-material-ui-v6)
 
 ## New features
 

--- a/docs/pages/blog/material-ui-v6-is-out.md
+++ b/docs/pages/blog/material-ui-v6-is-out.md
@@ -38,7 +38,7 @@ It comes with new features, improvements, and an experimental integration for st
   - [Built-in `sx` prop support](#built-in-sx-prop-support)
 - [React 19 support](#react-19-support)
 - [Full-stack apps via Toolpad Core](#full-stack-apps-via-toolpad-core)
-- [What's next](#whats-next)
+- [What's next](#get-started-with-material-ui-v6)
 
 ## New features
 


### PR DESCRIPTION
fix: Update "What's next" link in material-ui-v6 blog post

Closes: #43525

Preview: https://deploy-preview-43535--material-ui.netlify.app/blog/material-ui-v6-is-out/
