### PR TITLE
[system] Fix composeClasses v6 behavior change

### DIFF
--- a/packages/mui-utils/src/composeClasses/composeClasses.test.ts
+++ b/packages/mui-utils/src/composeClasses/composeClasses.test.ts
@@ -13,8 +13,8 @@ describe('composeClasses', () => {
         undefined,
       ),
     ).to.deep.equal({
-      root: 'MuiTest-root MuiTest-standard ',
-      slot: 'MuiTest-slot ',
+      root: 'MuiTest-root MuiTest-standard',
+      slot: 'MuiTest-slot',
     });
   });
 
@@ -32,8 +32,8 @@ describe('composeClasses', () => {
         },
       ),
     ).to.deep.equal({
-      root: 'MuiTest-root MuiTest-standard standardOverride ',
-      slot: 'MuiTest-slot slotOverride ',
+      root: 'MuiTest-root MuiTest-standard standardOverride',
+      slot: 'MuiTest-slot slotOverride',
     });
   });
 
@@ -51,8 +51,8 @@ describe('composeClasses', () => {
         },
       ),
     ).to.deep.equal({
-      root: 'MuiTest-root MuiTest-standard standardOverride ',
-      slot: 'MuiTest-slot slotOverride ',
+      root: 'MuiTest-root MuiTest-standard standardOverride',
+      slot: 'MuiTest-slot slotOverride',
     });
   });
 });

--- a/packages/mui-utils/src/composeClasses/composeClasses.ts
+++ b/packages/mui-utils/src/composeClasses/composeClasses.ts
@@ -13,14 +13,16 @@ export default function composeClasses<ClassKey extends string>(
   for (const slotName in slots) {
     const slot = slots[slotName];
     let buffer = '';
+    let start = true;
 
     for (let i = 0; i < slot.length; i += 1) {
       const value = slot[i];
       if (value) {
-        buffer += getUtilityClass(value) + ' ';
+        buffer += (start === true ? '' : ' ') + getUtilityClass(value);
+        start = false;
 
         if (classes && classes[value]) {
-          buffer += classes[value] + ' ';
+          buffer += ' ' + classes[value];
         }
       }
     }


### PR DESCRIPTION
Fix the behavior change introduced in #43363. I worked on this PR because I was trying a button customize in the store and got frustrated in the DX to find the class names applied:

<img width="1461" alt="SCR-20240830-uqcw" src="https://github.com/user-attachments/assets/540e7f2a-109f-4d69-871d-7d150f5f9b70">

The performance win stays comparable as before https://jsben.ch/S3LCV

<img width="666" alt="SCR-20240831-biqm" src="https://github.com/user-attachments/assets/9aee2f82-e2b0-4c38-982d-8c87b4c9f07e">

A related design principle: https://www.usertesting.com/blog/gestalt-principles#principle-#3:-proximity.