### PR TITLE
[docs][figma] Clarity state or Figma Plugin component export

### DIFF
--- a/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
+++ b/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
@@ -54,7 +54,7 @@ After you've added your custom tokens, click on **Regenerate theme** to include 
 
 <img src="/static/material-ui/design-resources/sync-regenerate.png" style="width: 814px" alt="The Regenerate button in the Connect plugin UI." width="1628" height="400" />
 
-## Customizing components (experimental)
+## Customizing components
 
 The Sync plugin can also generate theme styles for customized components, enabling you to completely change their look and feel and create your custom design system from within Figma.
 

--- a/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
+++ b/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
@@ -58,7 +58,7 @@ After you've added your custom tokens, click on **Regenerate theme** to include 
 
 The Sync plugin can also generate theme styles for customized components, enabling you to completely change their look and feel and create your custom design system from within Figma.
 
-:::info
+:::warn
 This feature is currently experimental and limited to the Button, Switch, and Typography components.
 :::
 

--- a/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
+++ b/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
@@ -58,7 +58,7 @@ After you've added your custom tokens, click on **Regenerate theme** to include 
 
 The Sync plugin can also generate theme styles for customized components, enabling you to completely change their look and feel and create your custom design system from within Figma.
 
-:::warn
+:::warning
 This feature is currently experimental and limited to the Button, Switch, and Typography components.
 :::
 

--- a/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
+++ b/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
@@ -54,13 +54,12 @@ After you've added your custom tokens, click on **Regenerate theme** to include 
 
 <img src="/static/material-ui/design-resources/sync-regenerate.png" style="width: 814px" alt="The Regenerate button in the Connect plugin UI." width="1628" height="400" />
 
-## Customizing components
+## Customizing components (experimental)
 
 The Sync plugin can also generate theme styles for customized components, enabling you to completely change their look and feel and create your custom design system from within Figma.
 
 :::info
-This feature is currently limited to the Button, Switch, and Typography components.
-Support for more components is coming soon.
+This feature is currently experimental and limited to the Button, Switch, and Typography components.
 :::
 
 As an example, here's how to customize the checked state, medium size, and primary color of a Switch component to replicate the iOS look and feel:

--- a/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
+++ b/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
@@ -57,7 +57,7 @@ After you've added your custom tokens, click on **Regenerate theme** to include 
 ## Customizing components
 
 :::warning
-This feature is experimental and limited to the Button, Switch, and Typography components.
+This feature is experimental and limited to the **Button**, **Switch**, and **Typography** components.
 :::
 
 The Sync plugin can also generate theme styles for customized components, enabling you to completely change their look and feel and create your custom design system from within Figma.

--- a/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
+++ b/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
@@ -56,11 +56,11 @@ After you've added your custom tokens, click on **Regenerate theme** to include 
 
 ## Customizing components
 
-The Sync plugin can also generate theme styles for customized components, enabling you to completely change their look and feel and create your custom design system from within Figma.
-
 :::warning
-This feature is currently experimental and limited to the Button, Switch, and Typography components.
+This feature is experimental and limited to the Button, Switch, and Typography components.
 :::
+
+The Sync plugin can also generate theme styles for customized components, enabling you to completely change their look and feel and create your custom design system from within Figma.
 
 As an example, here's how to customize the checked state, medium size, and primary color of a Switch component to replicate the iOS look and feel:
 


### PR DESCRIPTION
I saw a couple of comments about this in https://www.figma.com/community/plugin/1336346114713490235/material-ui-sync, e.g. https://github.com/mui/mui-design-kits/issues/389 asking about

> why the theme only generates 3 components? 

A general thought, anytime we no a major, we should try to remove stuff aggressively: https://youtu.be/tRsxLLghL1k?si=sRhbVRHVLRR83pMX&t=574. This feature might be je trending toward being removed.

Before: https://mui.com/material-ui/design-resources/material-ui-sync/#customizing-components
After: https://deploy-preview-43543--material-ui.netlify.app/material-ui/design-resources/material-ui-sync/#customizing-components