### PR TITLE
[docs-infra] Crash on invalid callout type

### DIFF
--- a/docs/pages/experiments/docs/callouts.md
+++ b/docs/pages/experiments/docs/callouts.md
@@ -110,31 +110,6 @@ It says, "You will fail if you don't heed this dire warning."
 :::
 ```
 
-## Empty
-
-Should not be used, here just to ensure forgetting the token is not a big deal.
-
-:::
-This is a callout.
-It says, "You will fail if you don't heed this dire warning."
-
-- emphasised: **bold text**
-- some code `<div/>`
-- a [link](#link).
-
-:::
-
-```markup
-:::
-This is a callout.
-It says, "You will fail if you don't heed this dire warning."
-
-- emphasised: **bold text**
-- some code `<div/>`
-- a [link](#link).
-:::
-```
-
 ## With code
 
 :::info

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -458,22 +458,20 @@ function createRender(context) {
             }
             return undefined;
           },
-
           renderer(token) {
-            return `<aside class="MuiCallout-root MuiCallout-${token.severity}">
-            ${
-              ['info', 'success', 'warning', 'error'].includes(token.severity)
-                ? [
-                    '<div class="MuiCallout-icon-container">',
-                    '<svg focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="ContentCopyRoundedIcon">',
-                    `<use class="MuiCode-copied-icon" xlink:href="#${token.severity}-icon" />`,
-                    '</svg>',
-                    '</div>',
-                  ].join('\n')
-                : ''
+            if (!['info', 'success', 'warning', 'error'].includes(token.severity)) {
+              throw new Error(`docs-infra: Callout :::${token.severity} is not supported`);
             }
-            <div class="MuiCallout-content">
-            ${this.parser.parse(token.tokens)}\n</div></aside>`;
+
+            return `<aside class="MuiCallout-root MuiCallout-${token.severity}">${[
+              '<div class="MuiCallout-icon-container">',
+              '<svg focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="ContentCopyRoundedIcon">',
+              `<use class="MuiCode-copied-icon" xlink:href="#${token.severity}-icon" />`,
+              '</svg>',
+              '</div>',
+            ].join(
+              '\n',
+            )}<div class="MuiCallout-content">${this.parser.parse(token.tokens)}</div></aside>`;
           },
         },
       ],


### PR DESCRIPTION
Crash if using an invalid callout type. I made this mistake in #43543.

Similar to https://github.com/mui/material-ui/blob/abbfbd5dff2cc741fe8d867e7139956874d65f81/packages/markdown/prism.js#L24-L26. 