### PR TITLE
[docs-infra] Reduce description max-length

### DIFF
--- a/docs/pages/blog/material-ui-v6-is-out.md
+++ b/docs/pages/blog/material-ui-v6-is-out.md
@@ -1,6 +1,6 @@
 ---
 title: Material UI v6 is out now 🎉
-description: Material UI v6 ships with support for CSS variables, container queries, and advanced color schemes, as well as improved runtime performance and a reduced bundle size.
+description: Material UI v6 is now stable. It comes with new features, improvements, and an experimental integration for static CSS extraction.
 date: 2024-08-26T00:00:00.000Z
 authors:
   [

--- a/packages/markdown/prepareMarkdown.js
+++ b/packages/markdown/prepareMarkdown.js
@@ -91,7 +91,7 @@ function prepareMarkdown(config) {
         throw new Error(`docs-infra: Missing description in the page: ${location}\n`);
       }
 
-      if (description.length > 170) {
+      if (description.length > 165) {
         throw new Error(
           [
             `docs-infra: The description "${description}" is too long (${description.length} characters).`,

--- a/packages/markdown/prepareMarkdown.js
+++ b/packages/markdown/prepareMarkdown.js
@@ -91,7 +91,7 @@ function prepareMarkdown(config) {
         throw new Error(`docs-infra: Missing description in the page: ${location}\n`);
       }
 
-      if (description.length > 165) {
+      if (description.length > 160) {
         throw new Error(
           [
             `docs-infra: The description "${description}" is too long (${description.length} characters).`,


### PR DESCRIPTION
Enforce max length in code, from 170 down to 160. I suspect we should go as far as 150, but maybe for another time.

See https://www.reddit.com/r/SEO/comments/14rc47l/meta_description_too_long_advice/. Meta descriptions are not used for SEO, but to improve the CTR on the search result. So if they are truncated, it defeats their purpose; 

"nextjs 15 release", fits

<img width="624" alt="SCR-20240901-ofje" src="https://github.com/user-attachments/assets/c66beead-8afc-4412-a5aa-c87a0abb5f82">

"material ui v6 release", doesn't fit

<img width="589" alt="SCR-20240901-oftn" src="https://github.com/user-attachments/assets/f562fdc0-552a-4761-9ca1-a8a443426459">

I suspect that https://nextjs.org/blog/ are authors in the same underlying infra as https://vercel.com/blog/, but show in a different URL path. It's not a coincidence that all their posts's descriptions are short. This might look like a detail, but I think it's this kind of depth of execution difference that compounds and separates the great UX from the good ones.

Saw this from https://app.ahrefs.com/site-audit/2944028/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2Cdepth%2CmetaDescription%2CmetaDescriptionLength%2CnrMetaDescription%2Ccompliant&current=30-08-2024T023527&filterId=2864d4a78dbccdda9cf9629aa273bd61&issueId=c64d56c9-d0f4-11e7-8ed1-001e67ed4656.