### PR TITLE
[docs] Update version support range

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,14 +4,15 @@
 
 The versions of the project that are currently supported with security updates.
 
-| Material UI version | Release    | Supported            |
-| ------------------: | :--------- | :------------------- |
-|              ^5.0.0 | 2021-09-16 | ✅ Stable major      |
-|              ^4.0.0 | 2019-06-23 | ✅ Long-term support |
-|              ^3.0.0 | 2018-08-27 | ❌                   |
-|              ^2.0.0 | /          | ❌                   |
-|              ^1.0.0 | 2018-06-18 | ❌                   |
-|             <=1.0.0 | 2014-10-05 | ❌                   |
+| Material UI version | Release    | Supported                            |
+| ------------------: | :--------- | :----------------------------------- |
+|              ^6.0.0 | 2024-08-26 | :white_check_mark: Stable major      |
+|              ^5.0.0 | 2021-09-16 | :white_check_mark: Long-term support |
+|              ^4.0.0 | 2019-06-23 | :x:                                  |
+|              ^3.0.0 | 2018-08-27 | :x:                                  |
+|              ^2.0.0 | /          | :x:                                  |
+|              ^1.0.0 | 2018-06-18 | :x:                                  |
+|             <=1.0.0 | 2014-10-05 | :x:                                  |
 
 ## Reporting a vulnerability
 

--- a/docs/data/material/getting-started/support/support.md
+++ b/docs/data/material/getting-started/support/support.md
@@ -74,8 +74,9 @@ This includes issues introduced by external sources, like browser upgrades or ch
 
 | Material UI version | Release    | Supported                                                           |
 | ------------------: | :--------- | :------------------------------------------------------------------ |
-|              ^5.0.0 | 2021-09-16 | ✅ Stable major (Continuous support)                                |
-|              ^4.0.0 | 2019-06-23 | ⚠️ Long-term support (Support for security issues and regressions). |
+|              ^6.0.0 | 2024-08-26 | ✅ Stable major (Continuous support)                                |
+|              ^5.0.0 | 2021-09-16 | ⚠️ Long-term support (Support for security issues and regressions). |
+|              ^4.0.0 | 2019-06-23 | ❌                                                                  |
 |              ^3.0.0 | 2018-08-27 | ❌                                                                  |
 |              ^2.0.0 | /          | ❌                                                                  |
 |              ^1.0.0 | 2018-06-18 | ❌                                                                  |


### PR DESCRIPTION
We were missing this step in the guide https://www.notion.so/mui-org/Core-Major-version-release-process-7601e24709b84d5fa43f20a13f7526c6?pvs=4#8b9a7bcfbdb546699f497131aba1bfb6 added and PR done to illustrate it.