### PR TITLE
[docs] Restore search on v5

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -449,7 +449,7 @@ export default function AppSearch(props) {
             apiKey="8177dfb3e2be72b241ffb8c5abafa899"
             indexName="material-ui"
             searchParameters={{
-              facetFilters: ['version:master', facetFilterLanguage],
+              facetFilters: ['version:v5', facetFilterLanguage],
               optionalFilters,
               attributesToRetrieve: [
                 // Copied from https://github.com/algolia/docsearch/blob/ce0c865cd8767e961ce3088b3155fc982d4c2e2e/packages/docsearch-react/src/DocSearchModal.tsx#L231

--- a/docs/src/modules/components/Head.tsx
+++ b/docs/src/modules/components/Head.tsx
@@ -59,7 +59,7 @@ export default function Head(props: HeadProps) {
       {/* Algolia */}
       <meta name="docsearch:language" content={userLanguage} />
       {/* #major-version-switch */}
-      <meta name="docsearch:version" content="master" />
+      <meta name="docsearch:version" content="v5" />
       {disableAlternateLocale
         ? null
         : LANGUAGES_SSR.map((userLanguage2) => (


### PR DESCRIPTION
I imagine we want the search to continue to work on v5, it will help the migration. e.g. it works in https://v2.tailwindcss.com/docs.