### PR TITLE
[docs] Fix use of absolute URLs

### DIFF
--- a/docs/data/base/components/transitions/transitions.md
+++ b/docs/data/base/components/transitions/transitions.md
@@ -68,7 +68,7 @@ See the examples below.
 
 ### Material UI (React Transition Group)
 
-You can use any of the [transitions from Material UI](https://mui.com/material-ui/transitions/), or custom transitions built with React Transition Group, using an adapter shown in the following demo.
+You can use any of the [transitions from Material UI](/material-ui/transitions/), or custom transitions built with React Transition Group, using an adapter shown in the following demo.
 
 {{"demo": "ReactTransitionGroup.js"}}
 

--- a/docs/data/joy/components/alert/alert.md
+++ b/docs/data/joy/components/alert/alert.md
@@ -20,7 +20,7 @@ The Alert component can be used to provide important and potentially time-sensit
 
 :::info
 Alerts should not be confused with alert _dialogs_ ([ARIA](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/)), which _are_ intended to interrupt the user to obtain a response.
-Use the Joy UI [Modal](https://mui.com/joy-ui/react-modal/) if you need the behavior of a dialog.
+Use the Joy UI [Modal](/joy-ui/react-modal/) if you need the behavior of a dialog.
 :::
 
 ## Basics

--- a/docs/data/joy/components/css-baseline/css-baseline.md
+++ b/docs/data/joy/components/css-baseline/css-baseline.md
@@ -135,7 +135,7 @@ function App() {
 
 ### ScopedCssBaseline
 
-You can customize it using the [themed components](https://mui.com/joy-ui/customization/themed-components/) approach. The component identifier is `JoyScopedCssBaseline` which contains only the `root` slot.
+You can customize it using the [themed components](/joy-ui/customization/themed-components/) approach. The component identifier is `JoyScopedCssBaseline` which contains only the `root` slot.
 
 ```js
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';

--- a/docs/data/joy/components/radio-button/radio-button.md
+++ b/docs/data/joy/components/radio-button/radio-button.md
@@ -150,7 +150,7 @@ This example demonstrates the composition of the components, and was inspired by
 
 ### Alignment buttons
 
-This example uses icons as labels for a group of Radio buttons to recreate the form and function of [Toggle Buttons](https://mui.com/material-ui/react-toggle-button/).
+This example uses icons as labels for a group of Radio buttons to recreate the form and function of [Toggle Buttons](/material-ui/react-toggle-button/).
 In this case, you must provide an `aria-label` to the input slot for users who rely on screen readers.
 
 {{"demo": "ExampleAlignmentButtons.js"}}

--- a/docs/data/material/components/alert/alert.md
+++ b/docs/data/material/components/alert/alert.md
@@ -29,7 +29,7 @@ This component is no longer documented in the [Material Design guidelines](https
 
 A key trait of the alert pattern is that [it should not interrupt the user's experience](https://www.w3.org/WAI/ARIA/apg/patterns/alert/) of the app.
 Alerts should not be confused with alert _dialogs_ ([ARIA](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/)), which _are_ intended to interrupt the user to obtain a response.
-Use the Material UI [Dialog](https://mui.com/material-ui/react-dialog/) component if you need this behavior.
+Use the Material UI [Dialog](/material-ui/react-dialog/) component if you need this behavior.
 
 ## Basics
 

--- a/docs/data/material/components/dialogs/dialogs.md
+++ b/docs/data/material/components/dialogs/dialogs.md
@@ -27,7 +27,7 @@ Dialogs are implemented using a collection of related components:
 - Dialog Actions: an optional container for a Dialog's Buttons.
 - Dialog Content: an optional container for displaying the Dialog's content.
 - Dialog Content Text: a wrapper for text inside of `<DialogContent />`.
-- Slide: optional [Transition](https://mui.com/material-ui/transitions/#slide) used to slide the Dialog in from the edge of the screen.
+- Slide: optional [Transition](/material-ui/transitions/#slide) used to slide the Dialog in from the edge of the screen.
 
 {{"demo": "SimpleDialogDemo.js"}}
 

--- a/docs/data/material/components/rating/rating.md
+++ b/docs/data/material/components/rating/rating.md
@@ -59,7 +59,7 @@ The accessibility of this component relies on:
 - A radio group with its fields visually hidden.
   It contains six radio buttons, one for each star, and another for 0 stars that is checked by default. Be sure to provide a value for the `name` prop that is unique to the parent form.
 - Labels for the radio buttons containing actual text ("1 Star", "2 Stars", …).
-  Be sure to provide a suitable function to the `getLabelText` prop when the page is in a language other than English. You can use the [included locales](https://mui.com/material-ui/guides/localization/), or provide your own.
+  Be sure to provide a suitable function to the `getLabelText` prop when the page is in a language other than English. You can use the [included locales](/material-ui/guides/localization/), or provide your own.
 - A visually distinct appearance for the rating icons.
   By default, the rating component uses both a difference of color and shape (filled and empty icons) to indicate the value. In the event that you are using color as the only means to indicate the value, the information should also be also displayed as text, as in this demo. This is important to match [success Criterion 1.4.1](https://www.w3.org/TR/WCAG21/#use-of-color) of WCAG2.1.
 

--- a/docs/data/material/design-resources/material-ui-for-figma/material-ui-for-figma.md
+++ b/docs/data/material/design-resources/material-ui-for-figma/material-ui-for-figma.md
@@ -86,7 +86,7 @@ The video below shows how to add new columns by copying cells directly on the ma
 You can export theme tokens and component customizations to code using [the Sync plugin for Figma](/material-ui/design-resources/material-ui-sync/).
 The Design Kit has been built to be as close to the React components as possible, making it for a fluid integration with code.
 
-Learn more about the Material UI theme structure by visiting the [Theming](https://mui.com/material-ui/customization/theming/) and [Default theme viewer](https://mui.com/material-ui/customization/theming/) pages.
+Learn more about the Material UI theme structure by visiting the [Theming](/material-ui/customization/theming/) and [Default theme viewer](/material-ui/customization/theming/) pages.
 
 ## Using new design kit versions
 

--- a/docs/data/material/migration/migration-v3/migration-v3.md
+++ b/docs/data/material/migration/migration-v3/migration-v3.md
@@ -171,7 +171,7 @@ yarn add @material-ui/styles
   +  spacing: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
   ```
 
-  Going forward, you can use the theme to implement [a custom Grid spacing transformation function](https://mui.com/system/spacing/#transformation).
+  Going forward, you can use the theme to implement [a custom Grid spacing transformation function](/system/spacing/#transformation).
 
 - [Container] Moved from `@material-ui/lab` to `@material-ui/core`.
 

--- a/docs/data/system/experimental-api/css-theme-variables/css-theme-variables.md
+++ b/docs/data/system/experimental-api/css-theme-variables/css-theme-variables.md
@@ -12,7 +12,7 @@ If this is your first time encountering CSS variables, you should check out [the
 
 CSS theme variable support is a new feature in MUI System added in [`v5.0.5`](https://github.com/mui/material-ui/releases/tag/v5.0.5) as an experimental export. It tells the underlying Material UI, Joy UI or even custom UI library components to use the generated CSS theme variables instead of raw values. This provides significant improvements in developer experience related to theming and customization.
 With these variables, you can inject a theme into your app's stylesheet _at build time_ to apply the user's selected settings before the whole app is rendered.
-Learn more about the [advantages](https://mui.com/material-ui/customization/css-theme-variables/overview/#advantages) and [trade-offs](https://mui.com/material-ui/customization/css-theme-variables/overview/#trade-offs) of using CSS theme variables.
+Learn more about the [advantages](/material-ui/customization/css-theme-variables/overview/#advantages) and [trade-offs](/material-ui/customization/css-theme-variables/overview/#trade-offs) of using CSS theme variables.
 
 ### Advantages
 
@@ -40,7 +40,7 @@ The comparison described in the table above may not be applicable to large and c
 ## Usage
 
 The CSS variables API usage is exposed as a higher order function called `unstable_createCssVarsProvider` which can be called to create a theme provider and other utilities to share the theme config throughout your app. This is a very low-level function and has a lot of moving parts.
-If you're using [Material UI](https://mui.com/material-ui/customization/css-theme-variables/overview/) or [Joy UI](https://mui.com/joy-ui/customization/using-css-variables/), they expose their own `CssVarsProvider` component that you can use directly without configuring your theme.
+If you're using [Material UI](/material-ui/customization/css-theme-variables/overview/) or [Joy UI](/joy-ui/customization/using-css-variables/), they expose their own `CssVarsProvider` component that you can use directly without configuring your theme.
 
 We'll first define a minimal theme palette for light and dark modes.
 
@@ -185,8 +185,9 @@ Now, the Button's `backgroundColor`, `borderColor` and text `color` values will 
 ### Demo
 
 {{"demo": "CreateCssVarsProvider.js"}}
-For framework- or language-specific setup instructions, see [CSS theme variables—Usage—Server-side rendering](https://mui.com/material-ui/customization/css-theme-variables/usage/#server-side-rendering).
-For framework or language specific setup, see [this](https://mui.com/material-ui/customization/css-theme-variables/usage/#server-side-rendering)
+
+For framework- or language-specific setup instructions, see [CSS theme variables—Usage—Server-side rendering](/material-ui/customization/css-theme-variables/usage/).
+For framework or language specific setup, see [this](/material-ui/customization/css-theme-variables/usage/)
 
 See the complete usage of `createCssVarsProvider` in [Material UI](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/CssVarsProvider.tsx) and [Joy UI](https://github.com/mui/material-ui/blob/master/packages/mui-joy/src/styles/CssVarsProvider.tsx).
 


### PR DESCRIPTION
Those went through the reviews. We should prefer to use relative URLs so that once we version the content, those links continue to work. 

I noticed those in #43435.