### PR TITLE
[icons] Revert icons virtualization in the docs

### DIFF
--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { VirtuosoGrid } from 'react-virtuoso';
 import { styled } from '@mui/material/styles';
 import MuiPaper from '@mui/material/Paper';
 import copy from 'clipboard-copy';
@@ -129,56 +128,55 @@ const StyledSvgIcon = styled(SvgIcon)(({ theme }) => ({
   },
 }));
 
-const ListWrapper = React.forwardRef(({ style, children, ...props }, ref) => {
+const Icons = React.memo(function Icons(props) {
+  const { icons, handleOpenClick } = props;
+
+  const handleIconClick = (icon) => () => {
+    if (Math.random() < 0.1) {
+      window.gtag('event', 'material-icons', {
+        eventAction: 'click',
+        eventLabel: icon.name,
+      });
+      window.gtag('event', 'material-icons-theme', {
+        eventAction: 'click',
+        eventLabel: icon.theme,
+      });
+    }
+  };
+
+  const handleLabelClick = (event) => {
+    selectNode(event.currentTarget);
+  };
+
   return (
-    <div
-      ref={ref}
-      {...props}
-      style={{ display: 'flex', flexWrap: 'wrap', ...style }}
-    >
-      {children}
+    <div>
+      {icons.map((icon) => {
+        /* eslint-disable jsx-a11y/click-events-have-key-events */
+        return (
+          <StyledIcon key={icon.importName} onClick={handleIconClick(icon)}>
+            <StyledSvgIcon
+              component={icon.Component}
+              fontSize="large"
+              tabIndex={-1}
+              onClick={handleOpenClick}
+              title={icon.importName}
+            />
+            <div>
+              {/*  eslint-disable-next-line jsx-a11y/no-static-element-interactions -- TODO: a11y */}
+              <div onClick={handleLabelClick}>{icon.importName}</div>
+            </div>
+            {/* eslint-enable jsx-a11y/click-events-have-key-events */}
+          </StyledIcon>
+        );
+      })}
     </div>
   );
 });
 
-function Icon(handleOpenClick) {
-  return function itemContent(_, icon) {
-    const handleIconClick = () => {
-      if (Math.random() < 0.1) {
-        window.gtag('event', 'material-icons', {
-          eventAction: 'click',
-          eventLabel: icon.name,
-        });
-        window.gtag('event', 'material-icons-theme', {
-          eventAction: 'click',
-          eventLabel: icon.theme,
-        });
-      }
-    };
-
-    const handleLabelClick = (event) => {
-      selectNode(event.currentTarget);
-    };
-
-    return (
-      /* eslint-disable jsx-a11y/click-events-have-key-events */
-      <StyledIcon key={icon.importName} onClick={handleIconClick}>
-        <StyledSvgIcon
-          component={icon.Component}
-          fontSize="large"
-          tabIndex={-1}
-          onClick={handleOpenClick}
-          title={icon.importName}
-        />
-        <div>
-          {/*  eslint-disable-next-line jsx-a11y/no-static-element-interactions -- TODO: a11y */}
-          <div onClick={handleLabelClick}>{icon.importName}</div>
-        </div>
-        {/* eslint-enable jsx-a11y/click-events-have-key-events */}
-      </StyledIcon>
-    );
-  };
-}
+Icons.propTypes = {
+  handleOpenClick: PropTypes.func.isRequired,
+  icons: PropTypes.array.isRequired,
+};
 
 const ImportLink = styled(Link)(({ theme }) => ({
   textAlign: 'right',
@@ -439,7 +437,14 @@ DialogDetails.propTypes = {
   selectedIcon: PropTypes.object,
 };
 
+const Form = styled('form')({
+  position: 'sticky',
+  top: 80,
+});
+
 const Paper = styled(MuiPaper)(({ theme }) => ({
+  position: 'sticky',
+  top: 80,
   display: 'flex',
   alignItems: 'center',
   marginBottom: theme.spacing(2),
@@ -557,7 +562,7 @@ export default function SearchIcons() {
   return (
     <Grid container sx={{ minHeight: 500 }}>
       <Grid item xs={12} sm={3}>
-        <form>
+        <Form>
           <Typography fontWeight={500} sx={{ mb: 1 }}>
             Filter the style
           </Typography>
@@ -578,7 +583,7 @@ export default function SearchIcons() {
               },
             )}
           </RadioGroup>
-        </form>
+        </Form>
       </Grid>
       <Grid item xs={12} sm={9}>
         <Paper>
@@ -603,21 +608,13 @@ export default function SearchIcons() {
         <Typography sx={{ mb: 1 }}>{`${formatNumber(
           icons.length,
         )} matching results`}</Typography>
-        <VirtuosoGrid
-          style={{ height: 500 }}
-          data={icons}
-          components={{ List: ListWrapper }}
-          itemContent={Icon(handleOpenClick)}
-        />
+        <Icons icons={icons} handleOpenClick={handleOpenClick} />
       </Grid>
-      {/* Temporary fix for Dialog not closing sometimes and Backdrop stuck at opacity 0 (see issue https://github.com/mui/material-ui/issues/32286). One disadvantage is that the closing animation is not applied. */}
-      {selectedIcon ? (
-        <DialogDetails
-          open={!!selectedIcon}
-          selectedIcon={dialogSelectedIcon}
-          handleClose={handleClose}
-        />
-      ) : null}
+      <DialogDetails
+        open={!!selectedIcon}
+        selectedIcon={dialogSelectedIcon}
+        handleClose={handleClose}
+      />
     </Grid>
   );
 }


### PR DESCRIPTION
Revert icons page back to use deferred only (the changes as per https://github.com/mui/material-ui/pull/41330#issuecomment-1997454243)

See https://github.com/mui/material-ui/pull/41330#issuecomment-2323517472