### PR TITLE
[website] Add disabled button styles to branding theme

### DIFF
--- a/docs/pages/experiments/website/branding-theme-test.tsx
+++ b/docs/pages/experiments/website/branding-theme-test.tsx
@@ -80,6 +80,32 @@ export default function BrandingThemeTest() {
               <GitHubIcon fontSize="small" />
             </IconButton>
           </Stack>
+          <Stack direction="row" spacing={2} useFlexGap sx={{ width: 'fit-content', mt: 8 }}>
+            <Button variant="contained" size="small" color="primary" disabled>
+              Contained primary
+            </Button>
+            <Button variant="contained" size="small" color="secondary" disabled>
+              Contained secondary
+            </Button>
+            <Button variant="outlined" size="small" color="primary" disabled>
+              Outlined primary
+            </Button>
+            <Button variant="outlined" size="small" color="secondary" disabled>
+              Outlined secondary
+            </Button>
+            <Button variant="text" size="small" disabled>
+              This button
+            </Button>
+            <IconButton color="primary">
+              <GitHubIcon fontSize="small" />
+            </IconButton>
+            <IconButton color="info">
+              <GitHubIcon fontSize="small" />
+            </IconButton>
+            <IconButton>
+              <GitHubIcon fontSize="small" />
+            </IconButton>
+          </Stack>
           <Stack direction="column" spacing={2} useFlexGap sx={{ width: 'fit-content', mt: 8 }}>
             <Button variant="contained" size="large" color="primary">
               Large

--- a/packages/mui-docs/src/branding/brandingTheme.ts
+++ b/packages/mui-docs/src/branding/brandingTheme.ts
@@ -635,6 +635,11 @@ export function getThemedComponents(): ThemeOptions {
                   borderColor: (theme.vars || theme).palette.primary[600],
                   boxShadow: `${alpha(theme.palette.primary[900], 0.7)} 0 1px 0 1px inset`,
                 },
+                '&.Mui-disabled': {
+                  color: theme.palette.grey[700],
+                  textShadow: 'none',
+                  borderColor: theme.palette.grey[400],
+                },
               }),
             ...(ownerState.variant === 'contained' &&
               ownerState.color === 'secondary' && {
@@ -653,6 +658,11 @@ export function getThemedComponents(): ThemeOptions {
                   backgroundColor: (theme.vars || theme).palette.primaryDark[700],
                   borderColor: (theme.vars || theme).palette.primaryDark[600],
                   boxShadow: `${alpha(theme.palette.primaryDark[900], 0.7)} 0 1px 0 1px inset`,
+                },
+                '&.Mui-disabled': {
+                  color: theme.palette.grey[700],
+                  textShadow: 'none',
+                  borderColor: theme.palette.grey[400],
                 },
               }),
             ...(ownerState.variant === 'text' &&

--- a/packages/mui-docs/src/branding/brandingTheme.ts
+++ b/packages/mui-docs/src/branding/brandingTheme.ts
@@ -588,6 +588,9 @@ export function getThemedComponents(): ThemeOptions {
                   '&:active': {
                     backgroundColor: (theme.vars || theme).palette.primaryDark[800],
                   },
+                  '&.Mui-disabled': {
+                    color: theme.palette.grey[500],
+                  },
                 }),
               }),
             ...(ownerState.variant === 'outlined' &&
@@ -618,6 +621,7 @@ export function getThemedComponents(): ThemeOptions {
                   '&.Mui-disabled': {
                     background: 'none',
                     backgroundColor: alpha(theme.palette.primaryDark[700], 0.2),
+                    color: theme.palette.grey[500],
                   },
                 }),
               }),
@@ -646,7 +650,7 @@ export function getThemedComponents(): ThemeOptions {
                 },
                 ...theme.applyDarkStyles({
                   '&.Mui-disabled': {
-                    color: theme.palette.grey[500],
+                    color: theme.palette.grey[400],
                     textShadow: 'none',
                     borderColor: theme.palette.grey[800],
                   },
@@ -677,7 +681,7 @@ export function getThemedComponents(): ThemeOptions {
                 },
                 ...theme.applyDarkStyles({
                   '&.Mui-disabled': {
-                    color: theme.palette.grey[500],
+                    color: theme.palette.grey[400],
                     textShadow: 'none',
                     borderColor: theme.palette.grey[800],
                   },
@@ -699,6 +703,9 @@ export function getThemedComponents(): ThemeOptions {
                   '&:active': {
                     backgroundColor: (theme.vars || theme).palette.primaryDark[700],
                   },
+                  '&.Mui-disabled': {
+                    color: theme.palette.grey[500],
+                  },
                 }),
               }),
             ...(ownerState.variant === 'text' &&
@@ -717,6 +724,9 @@ export function getThemedComponents(): ThemeOptions {
                   },
                   '&:active': {
                     backgroundColor: alpha(theme.palette.primary[900], 0.1),
+                  },
+                  '&.Mui-disabled': {
+                    color: theme.palette.grey[500],
                   },
                 }),
               }),

--- a/packages/mui-docs/src/branding/brandingTheme.ts
+++ b/packages/mui-docs/src/branding/brandingTheme.ts
@@ -615,6 +615,10 @@ export function getThemedComponents(): ThemeOptions {
                   '&:active': {
                     backgroundColor: alpha(theme.palette.primary[900], 0.3),
                   },
+                  '&.Mui-disabled': {
+                    background: 'none',
+                    backgroundColor: alpha(theme.palette.primaryDark[700], 0.2),
+                  },
                 }),
               }),
             ...(ownerState.variant === 'contained' &&
@@ -640,6 +644,13 @@ export function getThemedComponents(): ThemeOptions {
                   textShadow: 'none',
                   borderColor: theme.palette.grey[400],
                 },
+                ...theme.applyDarkStyles({
+                  '&.Mui-disabled': {
+                    color: theme.palette.grey[500],
+                    textShadow: 'none',
+                    borderColor: theme.palette.grey[800],
+                  },
+                }),
               }),
             ...(ownerState.variant === 'contained' &&
               ownerState.color === 'secondary' && {
@@ -664,6 +675,13 @@ export function getThemedComponents(): ThemeOptions {
                   textShadow: 'none',
                   borderColor: theme.palette.grey[400],
                 },
+                ...theme.applyDarkStyles({
+                  '&.Mui-disabled': {
+                    color: theme.palette.grey[500],
+                    textShadow: 'none',
+                    borderColor: theme.palette.grey[800],
+                  },
+                }),
               }),
             ...(ownerState.variant === 'text' &&
               ownerState.color === 'secondary' && {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


Add custom styles to disabled buttons on branding theme.

| Current | New |
|--------|--------|
| <img width="713" alt="Screenshot 2024-09-02 at 15 16 04" src="https://github.com/user-attachments/assets/da003864-99eb-4bdd-98d1-97049bc8486c"> | <img width="713" alt="Screenshot 2024-09-02 at 15 16 21" src="https://github.com/user-attachments/assets/6e382314-cfba-4a60-a481-26d242a4e75a"> | 

👉  https://deploy-preview-43577--material-ui.netlify.app/experiments/website/branding-theme-test/
