### PR TITLE
[docs][material-ui][Autocomplete] Fix GitHubLabel demo input background color 

### DIFF
--- a/docs/data/material/components/autocomplete/GitHubLabel.js
+++ b/docs/data/material/components/autocomplete/GitHubLabel.js
@@ -80,7 +80,7 @@ const StyledInput = styled(InputBase)(({ theme }) => ({
   borderBottom: `1px solid ${'#30363d'}`,
   '& input': {
     borderRadius: 4,
-    backgroundColor: '#0d1117',
+    backgroundColor: '#fff',
     border: `1px solid ${'#30363d'}`,
     padding: 8,
     transition: theme.transitions.create(['border-color', 'box-shadow']),
@@ -94,7 +94,7 @@ const StyledInput = styled(InputBase)(({ theme }) => ({
       }),
     },
     ...theme.applyStyles('dark', {
-      backgroundColor: '#fff',
+      backgroundColor: '#0d1117',
       border: `1px solid ${'#eaecef'}`,
     }),
   },

--- a/docs/data/material/components/autocomplete/GitHubLabel.tsx
+++ b/docs/data/material/components/autocomplete/GitHubLabel.tsx
@@ -84,7 +84,9 @@ const StyledInput = styled(InputBase)(({ theme }) => ({
   borderBottom: `1px solid ${'#30363d'}`,
   '& input': {
     borderRadius: 4,
-    backgroundColor: '#0d1117',
+    ...theme.applyStyles('dark', {
+      backgroundColor: '#0d1117',
+    }),
     border: `1px solid ${'#30363d'}`,
     padding: 8,
     transition: theme.transitions.create(['border-color', 'box-shadow']),

--- a/docs/data/material/components/autocomplete/GitHubLabel.tsx
+++ b/docs/data/material/components/autocomplete/GitHubLabel.tsx
@@ -84,9 +84,7 @@ const StyledInput = styled(InputBase)(({ theme }) => ({
   borderBottom: `1px solid ${'#30363d'}`,
   '& input': {
     borderRadius: 4,
-    ...theme.applyStyles('dark', {
-      backgroundColor: '#0d1117',
-    }),
+    backgroundColor:   '#fff',
     border: `1px solid ${'#30363d'}`,
     padding: 8,
     transition: theme.transitions.create(['border-color', 'box-shadow']),
@@ -100,7 +98,7 @@ const StyledInput = styled(InputBase)(({ theme }) => ({
       }),
     },
     ...theme.applyStyles('dark', {
-      backgroundColor: '#fff',
+      backgroundColor: '#0d1117',
       border: `1px solid ${'#eaecef'}`,
     }),
   },

--- a/docs/data/material/components/autocomplete/GitHubLabel.tsx
+++ b/docs/data/material/components/autocomplete/GitHubLabel.tsx
@@ -84,7 +84,7 @@ const StyledInput = styled(InputBase)(({ theme }) => ({
   borderBottom: `1px solid ${'#30363d'}`,
   '& input': {
     borderRadius: 4,
-    backgroundColor:   '#fff',
+    backgroundColor: '#fff',
     border: `1px solid ${'#30363d'}`,
     padding: 8,
     transition: theme.transitions.create(['border-color', 'box-shadow']),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes https://github.com/mui/material-ui/issues/43600

### Preview: https://deploy-preview-43599--material-ui.netlify.app/material-ui/react-autocomplete/#githubs-picker

### Before: 
<img width="944" alt="image" src="https://github.com/user-attachments/assets/3b6e1bff-b78a-41f4-a8e7-03ce9a6c9f61">


### After: 
<img width="926" alt="image" src="https://github.com/user-attachments/assets/beb13d7e-7c1f-4910-8a36-6ac187d7399f">



- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
