### PR TITLE
[docs-infra] Use embed as the default for opening CodeSandbox

### DIFF
--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -24,10 +24,11 @@ function openSandbox({ files, codeVariant, initialFile }: any) {
   form.target = '_blank';
   form.action = 'https://codesandbox.io/api/v1/sandboxes/define';
   addHiddenInput(form, 'parameters', parameters);
+  addHiddenInput(form, 'embed', '1');
   addHiddenInput(
     form,
     'query',
-    `file=${initialFile}${initialFile.match(/(\.tsx|\.ts|\.js)$/) ? '' : extension}`,
+    `module=${initialFile}${initialFile.match(/(\.tsx|\.ts|\.js)$/) ? '' : extension}`,
   );
   document.body.appendChild(form);
   form.submit();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**Before**:

It opens a devbox experience. The loading time is longer than the embed version. It takes ~12sec to see the demo.
Note that the devbox cannot be open with an initial file.

https://github.com/user-attachments/assets/d95f88d9-1b43-444a-8094-d3b2861a29ee

**After**:

The embed version is editable and feels faster. It takes ~4sec to see the demo. By changing to embed mode, we can target the initial file to open.

https://github.com/user-attachments/assets/6c5f58ed-4e0f-489f-b588-a633800de1ad


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
