### PR TITLE
[docs-infra] Fix toolbar arrow order

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -539,7 +539,7 @@ export default function DemoToolbar(props) {
                   data-ga-event-label={demo.gaLabel}
                   data-ga-event-action="stackblitz"
                   onClick={() => stackBlitz.createReactApp(demoData).openSandbox()}
-                  {...getControlProps(5)}
+                  {...getControlProps(4)}
                   sx={{ borderRadius: 1 }}
                 >
                   <SvgIcon viewBox="0 0 19 28">
@@ -553,7 +553,7 @@ export default function DemoToolbar(props) {
                   data-ga-event-label={demo.gaLabel}
                   data-ga-event-action="codesandbox"
                   onClick={() => codeSandbox.createReactApp(demoData).openSandbox()}
-                  {...getControlProps(4)}
+                  {...getControlProps(5)}
                   sx={{ borderRadius: 1 }}
                 >
                   <SvgIcon viewBox="0 0 1024 1024">


### PR DESCRIPTION
The problem:

https://github.com/user-attachments/assets/b409c7ed-f8b4-42d1-9691-a00f8fe8b221

Source: https://deploy-preview-477--base-ui.netlify.app/base-ui/react-field/#labeling-and-descriptive-help-text. I broke this in #40832. It's a quick win, so I thought I might open a PR, faster than open an issue. The logic itself could likely be improved using Base UI components, but for now, we use what https://github.com/eps1lon setup.

@vladmoroz since you will help with the docs, I thought I would give you an easy PR to review, to give a bit of an introduction of the docs-infra that we have 😄

Preview: https://deploy-preview-43627--material-ui.netlify.app/material-ui/react-button/#basic-button