### PR TITLE
[material-ui] Return styles directly if the selector is `&` when using `applyStyles`

### DIFF
--- a/packages/mui-material/src/styles/createTheme.test.js
+++ b/packages/mui-material/src/styles/createTheme.test.js
@@ -503,6 +503,12 @@ describe('createTheme', () => {
     });
   });
 
+  it('should return the styles directly when using applyStyles if the selector is `&`', function test() {
+    const theme = createTheme({ cssVariables: true, palette: { mode: 'dark' } });
+
+    expect(theme.applyStyles('dark', { color: 'red' })).to.deep.equal({ color: 'red' });
+  });
+
   it('Throw an informative error when the key `vars` is passed as part of `options` passed', () => {
     try {
       createTheme({

--- a/packages/mui-system/src/createTheme/applyStyles.test.ts
+++ b/packages/mui-system/src/createTheme/applyStyles.test.ts
@@ -69,4 +69,16 @@ describe('applyStyles', () => {
     const styles = { background: '#e5e5e5' };
     expect(applyStyles.call(theme, 'dark', styles)).to.deep.equal({});
   });
+
+  it('should return the styles directly if selector is &', () => {
+    const theme = {
+      vars: {},
+      colorSchemes: { light: true },
+      getColorSchemeSelector: () => {
+        return '&';
+      },
+    };
+    const styles = { background: '#e5e5e5' };
+    expect(applyStyles.call(theme, 'light', styles)).to.deep.equal(styles);
+  });
 });

--- a/packages/mui-system/src/createTheme/applyStyles.ts
+++ b/packages/mui-system/src/createTheme/applyStyles.ts
@@ -76,6 +76,9 @@ export default function applyStyles<K extends string>(key: K, styles: CSSObject)
     }
     // If CssVarsProvider is used as a provider, returns '*:where({selector}) &'
     let selector = theme.getColorSchemeSelector(key);
+    if (selector === '&') {
+      return styles;
+    }
     if (selector.includes('data-') || selector.includes('.')) {
       // '*' is required as a workaround for Emotion issue (https://github.com/emotion-js/emotion/issues/2836)
       selector = `*:where(${selector.replace(/\s*&$/, '')}) &`;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #43620

This is an edge case. It happens when using `cssVariables` with a single light or dark palette:

```js
createTheme({
  cssVariables: true,
  palette: { mode: 'dark' }
});
```

With a single color scheme, the `applyStyles('dark', styles)` return `{ '&': styles }`. Emotion treats it as a different `<style>`, so the [default styles of AppBar](https://github.com/siriwatknp/material-ui/blob/fix/apply-styles-css-vars-no-selector/packages/mui-material/src/AppBar/AppBar.js#L141) wins the one from the theme style overrides.

This PR fixes by returning the styles directly if the selector is `&` so that a new `<style>` is not created.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
