### PR TITLE
[docs] Fix class in `<html/>` element when theme is toggled

### DIFF
--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -199,9 +199,13 @@ export function ThemeProvider(props) {
     if (paletteMode === 'dark') {
       document.body.classList.remove('mode-light');
       document.body.classList.add('mode-dark');
+      document.documentElement.classList.remove('light');
+      document.documentElement.classList.add('dark');
     } else {
       document.body.classList.remove('mode-dark');
       document.body.classList.add('mode-light');
+      document.documentElement.classList.remove('dark');
+      document.documentElement.classList.add('light');
     }
 
     const metas = document.querySelectorAll('meta[name="theme-color"]');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes: https://github.com/mui/material-ui/issues/43602

Issue shown below is bit different than problem shown in issue attached, but i think root cause is same both for issues that is `class` in `html` element not updating when theme is toggled

Before: 

https://github.com/user-attachments/assets/71519124-ccfd-4254-b131-360ece1bcf88


After: 

https://github.com/user-attachments/assets/8abb0417-af33-4ae0-a592-a20aa3388bfa




- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
