### PR TITLE
[examples] Fix CDN live preview demo

### DIFF
--- a/examples/material-ui-via-cdn/README.md
+++ b/examples/material-ui-via-cdn/README.md
@@ -23,7 +23,7 @@ The client has to download the entire library, regardless of which components ar
 
 <!-- #default-branch-switch -->
 
-[The live preview.](https://rawcdn.githack.com/mui/material-ui/master/examples/material-ui-via-cdn/index.html)
+[The live preview.](https://raw.githack.com/mui/material-ui/master/examples/material-ui-via-cdn/index.html)
 
 ## What's next?
 


### PR DESCRIPTION
### Problem

https://github.com/mui/material-ui/blob/master/examples/material-ui-via-cdn/README.md preview is broken.

<img width="868" alt="SCR-20240908-cjjy" src="https://github.com/user-attachments/assets/db4c831f-7572-49a6-b7ec-ab156f35fd44">

### Solution

See https://raw.githack.com/faq#diff-between-rawgithack-and-cdn for why this fixes the problem. Since it's only for demo purposes, we don't care about having our demo production ready.

> Requests to CDN are routed through CloudFlare's content delivery network, and are **cached for an year** the first time they're loaded. This results in the best performance and reduces load on raw.githack.com and on underlying service, but it means that reloading won't fetch new changes

### Context

It's another follow-up on #42172. The problem got more visible with v6.x release. I noticed this trying some of the examples that we have (since it's a critical part of the user journey, wanted to experience it as a new user).

Since it was quick to fix, I skipped the opening an issue step and went to PR (It will be better to only open issues in the future, but they tend to be not solved, e.g. #42423 so this should be more effective, until we figure a way to make it work).