### PR TITLE
[docs][material-ui] Fix getting started with CSS variables in theme example

### DIFF
--- a/docs/data/material/customization/css-theme-variables/usage.md
+++ b/docs/data/material/customization/css-theme-variables/usage.md
@@ -17,7 +17,7 @@ import { ThemeProvider, createTheme } from '@mui/material/styles';
 const theme = createTheme({ cssVariables: true });
 
 function App() {
-  return <ThemeProvider>{/* ...you app */}</ThemeProvider>;
+  return <ThemeProvider theme={theme}>{/* ...your app */}</ThemeProvider>;
 }
 ```
 


### PR DESCRIPTION
`theme` variable was not used and there was a typo in the example for the basic theme implementation

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
