### PR TITLE
[system][docs] Fix link to createCssVarsProvider

### DIFF
--- a/CHANGELOG.old.md
+++ b/CHANGELOG.old.md
@@ -4127,8 +4127,8 @@ A big thanks to the 17 contributors who made this release possible. Here are som
 
   ```diff
    import {
-      unstable_createCssVarsProvider as createCssVarsProvider,
-  +   unstable_createCssVarsTheme as createCssVarsTheme,
+     unstable_createCssVarsProvider as createCssVarsProvider,
+  +  unstable_createCssVarsTheme as createCssVarsTheme,
    } from '@mui/system';
 
    const { CssVarsProvider } = createCssVarsProvider({

--- a/docs/data/system/experimental-api/css-theme-variables/css-theme-variables.md
+++ b/docs/data/system/experimental-api/css-theme-variables/css-theme-variables.md
@@ -189,7 +189,7 @@ Now, the Button's `backgroundColor`, `borderColor` and text `color` values will 
 For framework- or language-specific setup instructions, see [CSS theme variables—Usage—Server-side rendering](/material-ui/customization/css-theme-variables/usage/).
 For framework or language specific setup, see [this](/material-ui/customization/css-theme-variables/usage/)
 
-See the complete usage of `createCssVarsProvider` in [Material UI](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/CssVarsProvider.tsx) and [Joy UI](https://github.com/mui/material-ui/blob/master/packages/mui-joy/src/styles/CssVarsProvider.tsx).
+See the complete usage of `createCssVarsProvider` in [Material UI](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/ThemeProviderWithVars.tsx) and [Joy UI](https://github.com/mui/material-ui/blob/master/packages/mui-joy/src/styles/CssVarsProvider.tsx).
 
 ## API
 

--- a/packages/mui-material/src/styles/ThemeProviderWithVars.tsx
+++ b/packages/mui-material/src/styles/ThemeProviderWithVars.tsx
@@ -41,17 +41,19 @@ let warnedOnce = false;
 // TODO: remove in v7
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function Experimental_CssVarsProvider(props: any) {
-  if (!warnedOnce) {
-    console.warn(
-      [
-        'MUI: The Experimental_CssVarsProvider component has been ported into ThemeProvider.',
-        '',
-        "You should use `import { ThemeProvider } from '@mui/material/styles'` instead.",
-        'For more details, check out https://mui.com/material-ui/customization/css-theme-variables/usage/',
-      ].join('\n'),
-    );
+  if (process.env.NODE_ENV !== 'production') {
+    if (!warnedOnce) {
+      console.warn(
+        [
+          'MUI: The Experimental_CssVarsProvider component has been ported into ThemeProvider.',
+          '',
+          "You should use `import { ThemeProvider } from '@mui/material/styles'` instead.",
+          'For more details, check out https://mui.com/material-ui/customization/css-theme-variables/usage/',
+        ].join('\n'),
+      );
 
-    warnedOnce = true;
+      warnedOnce = true;
+    }
   }
 
   return <InternalCssVarsProvider {...props} />;


### PR DESCRIPTION
Open https://mui.com/system/experimental-api/css-theme-variables/#demo and see the broken link. This was reported in 

https://app.ahrefs.com/site-audit/3524616/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2CcontentType%2Cdepth%2CincomingAllLinks&current=06-09-2024T022441&filterId=9b88587038fc9bb2e08e0ff143d5f328&issueId=c64d89a6-d0f4-11e7-8ed1-001e67ed4656&sorting=-pageRating

---

As a side note, I believe that we should move 80% of what's inside this `mui-material/styles` folder into MUI System #40594. The sooner, the better.