### PR TITLE
[docs-infra] Fix API search link regression

### DIFF
--- a/docs/src/modules/components/ApiPage/list/ExpandableApiItem.tsx
+++ b/docs/src/modules/components/ApiPage/list/ExpandableApiItem.tsx
@@ -179,8 +179,6 @@ export default function ExpandableApiItem(props: ExpandableApiItemProps) {
     setIsExtended(displayOption === 'expanded');
   }, [displayOption]);
 
-  const anchorLabelId = React.useId();
-
   return (
     <Root
       ownerState={{ type }}
@@ -192,13 +190,12 @@ export default function ExpandableApiItem(props: ExpandableApiItemProps) {
       )}
     >
       <div className="MuiApi-item-header">
-        <a className="MuiApi-item-link-visual" href={`#${id}`} aria-labelledby={anchorLabelId}>
+        <a className="MuiApi-item-link-visual" href={`#${id}`} aria-labelledby={id}>
           <svg>
             <use xlinkHref="#anchor-link-icon" />
           </svg>
         </a>
         <span
-          id={anchorLabelId}
           className="MuiApi-item-title algolia-lvl3" // This className is used by Algolia
         >
           {title}

--- a/docs/src/modules/components/ApiPage/list/ExpandableApiItem.tsx
+++ b/docs/src/modules/components/ApiPage/list/ExpandableApiItem.tsx
@@ -16,14 +16,18 @@ const Root = styled('div')<{ ownerState: { type?: DescriptionType } }>(
   ({ theme }) => ({
     position: 'relative',
     marginBottom: 12,
-    scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
     '& .MuiApi-item-header': {
+      display: 'flex',
+      alignItems: 'center',
+      marginBottom: 8,
+      marginLeft: -38,
+      lineHeight: 1.5,
+    },
+    '& .MuiApi-item-header-link': {
       minHeight: 26,
       display: 'flex',
       alignItems: 'center',
-      marginLeft: -38,
-      marginBottom: 8,
-      lineHeight: 1.5,
+      scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
     },
     '& .MuiApi-item-link-visual': {
       display: 'none',
@@ -183,23 +187,24 @@ export default function ExpandableApiItem(props: ExpandableApiItemProps) {
     <Root
       ownerState={{ type }}
       {...other}
-      id={id}
       className={clsx(
-        `MuiApi-item-root ${isExtendable ? 'MuiApi-item-header-extendable' : ''}`,
+        `MuiApi-item-root${isExtendable ? ' MuiApi-item-header-extendable' : ''}`,
         className,
       )}
     >
       <div className="MuiApi-item-header">
-        <a className="MuiApi-item-link-visual" href={`#${id}`} aria-labelledby={id}>
-          <svg>
-            <use xlinkHref="#anchor-link-icon" />
-          </svg>
-        </a>
-        <span
-          className="MuiApi-item-title algolia-lvl3" // This className is used by Algolia
-        >
-          {title}
-        </span>
+        <div className="MuiApi-item-header-link" id={id}>
+          <a className="MuiApi-item-link-visual" href={`#${id}`} aria-labelledby={id}>
+            <svg>
+              <use xlinkHref="#anchor-link-icon" />
+            </svg>
+          </a>
+          <span
+            className="MuiApi-item-title algolia-lvl3" // This className is used by Algolia
+          >
+            {title}
+          </span>
+        </div>
         {note && <span className="MuiApi-item-note">{note}</span>}
         {isExtendable && (
           <IconButton


### PR DESCRIPTION
The change in #43292 breaks the search experience on the API pages that have the "View: Expanded" default layout, for example https://mui.com/x/api/data-grid/data-grid-pro/. Algolia returns URLs with the React useId, e.g. https://mui.com/x/api/data-grid/data-grid/#:R86ml5l6kud6:. I believe this will fix it.

Preview: https://deploy-preview-43662--material-ui.netlify.app/material-ui/api/button/#button-prop-color