### PR TITLE
[docs-infra] Fix axe issue scroll-to-top without landmark

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -167,9 +167,9 @@ export default function AppLayoutDocs(props) {
             <AppLayoutDocsFooter tableOfContents={toc} location={location} />
           </StyledAppContainer>
           {disableToc ? null : <AppTableOfContents toc={toc} />}
+          <BackToTop />
         </Main>
       </AdManager>
-      <BackToTop />
     </Layout>
   );
 }


### PR DESCRIPTION
A quick-win that I noticed. Opened a PR as seems more efficient than an issue. When running https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?pli=1 on after scrolling a bit the page on https://mui.com/material-ui/react-button/ or any others. We get this:

<img width="693" alt="SCR-20240908-sbjv" src="https://github.com/user-attachments/assets/fad8228f-b697-4c5f-b279-9677ce7a2c8f">

<img width="266" alt="SCR-20240909-twyi" src="https://github.com/user-attachments/assets/6a9678bc-c6ec-4525-801c-db28464a8133">

which they explain in https://dequeuniversity.com/rules/axe/4.10/region?application=AxeChrome.

Related issue: https://www.drupal.org/project/back_to_top/issues/3254713. I think it matters because we want our component to have no error, so if the docs-infra has one, it creates noise.

Preview: https://deploy-preview-43663--material-ui.netlify.app/material-ui/react-button/