### PR TITLE
[blog] Fix broken link to purchase MUI X Pro

### DIFF
--- a/docs/pages/blog/mui-x-sep-2024-price-update.md
+++ b/docs/pages/blog/mui-x-sep-2024-price-update.md
@@ -68,7 +68,7 @@ You'll receive the discount per email, or by reaching out to our [sales team](ma
 
 ## Effective date
 
-The new pricing updates will take effect on September 1st, 2024. However, you can already purchase the new Pro plan today by visiting our [store](https://mui.com/store/items/mui-x-pro-q3-2024/).
+The new pricing updates will take effect on September 1st, 2024.
 
 ## We value your feedback
 


### PR DESCRIPTION
See https://mui.com/blog/mui-x-sep-2024-price-update/#effective-date to reproduce the issue, it links to https://mui.com/store/items/mui-x-pro-q3-2024/. It has been broken for a week or so? Since the plan is live, we don't need this anymore.

By the way, I'm confused about the state of the products in https://store-wp.mui.com/wp-admin/edit.php?s&post_status=all&post_type=product&action=-1&product_cat=mui-x&product_type&stock_status&filter_action=Filter&paged=1&action2=-1. It looks like we have a bit of cleanup to do. If we happen to change the URL slugs, we will need to add 404 as old emails have been sent with the older URLs. Otherwise, I saw nothing broken, it seems to just be about a couple of draft products that seem a bit orphan.