### PR TITLE
[core] Remove Font Awesome visual regression tests

### DIFF
--- a/apps/pigment-css-vite-app/src/pages/material-ui/icons.tsx
+++ b/apps/pigment-css-vite-app/src/pages/material-ui/icons.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import MaterialUILayout from '../../Layout';
 import CreateSvgIcon from '../../../../../docs/data/material/components/icons/CreateSvgIcon.tsx';
-import FontAwesomeIcon from '../../../../../docs/data/material/components/icons/FontAwesomeIcon.tsx';
-import FontAwesomeIconSize from '../../../../../docs/data/material/components/icons/FontAwesomeIconSize.tsx';
-import FontAwesomeSvgIconDemo from '../../../../../docs/data/material/components/icons/FontAwesomeSvgIconDemo.tsx';
 import Icons from '../../../../../docs/data/material/components/icons/Icons.tsx';
 import SvgIconChildren from '../../../../../docs/data/material/components/icons/SvgIconChildren.tsx';
 import SvgIconsColor from '../../../../../docs/data/material/components/icons/SvgIconsColor.tsx';
@@ -18,24 +15,6 @@ export default function IconsPage() {
         <h2> Create Svg Icon</h2>
         <div className="demo-container">
           <CreateSvgIcon />
-        </div>
-      </section>
-      <section>
-        <h2> Font Awesome Icon</h2>
-        <div className="demo-container">
-          <FontAwesomeIcon />
-        </div>
-      </section>
-      <section>
-        <h2> Font Awesome Icon Size</h2>
-        <div className="demo-container">
-          <FontAwesomeIconSize />
-        </div>
-      </section>
-      <section>
-        <h2> Font Awesome Svg Icon Demo</h2>
-        <div className="demo-container">
-          <FontAwesomeSvgIconDemo />
         </div>
       </section>
       <section>


### PR DESCRIPTION
Demos that include Font Awesome are already skipped in:

https://github.com/mui/material-ui/blob/master/test/regressions/index.js#L146

As they rely on cascading network requests, and thus are flaky. We added them to the Pigment fixtures in https://github.com/mui/material-ui/pull/43280, and they're flaky as well:

- https://app.argos-ci.com/mui/material-ui/builds/31900/108029355
- https://app.argos-ci.com/mui/material-ui/builds/31895/107984073
- https://app.argos-ci.com/mui/material-ui/builds/31888/107922111

So this PR removes them.
