### PR TITLE
[bugfix] Refactor default exports to named exports

### DIFF
--- a/packages/mui-system/src/borders/index.ts
+++ b/packages/mui-system/src/borders/index.ts
@@ -1,2 +1,1 @@
-export { default } from './borders';
 export * from './borders';

--- a/packages/mui-system/src/cssGrid/index.ts
+++ b/packages/mui-system/src/cssGrid/index.ts
@@ -1,2 +1,1 @@
-export { default } from './cssGrid';
 export * from './cssGrid';

--- a/packages/mui-system/src/display/index.ts
+++ b/packages/mui-system/src/display/index.ts
@@ -1,2 +1,1 @@
-export { default } from './display';
 export * from './display';

--- a/packages/mui-system/src/flexbox/index.ts
+++ b/packages/mui-system/src/flexbox/index.ts
@@ -1,2 +1,1 @@
-export { default } from './flexbox';
 export * from './flexbox';

--- a/packages/mui-system/src/palette/index.ts
+++ b/packages/mui-system/src/palette/index.ts
@@ -1,2 +1,1 @@
-export { default } from './palette';
 export * from './palette';

--- a/packages/mui-system/src/positions/index.ts
+++ b/packages/mui-system/src/positions/index.ts
@@ -1,2 +1,1 @@
-export { default } from './positions';
 export * from './positions';

--- a/packages/mui-system/src/shadows/index.ts
+++ b/packages/mui-system/src/shadows/index.ts
@@ -1,1 +1,1 @@
-export { default } from './shadows';
+export * from './shadows';

--- a/packages/mui-system/src/sizing/index.ts
+++ b/packages/mui-system/src/sizing/index.ts
@@ -1,2 +1,1 @@
-export { default } from './sizing';
 export * from './sizing';

--- a/packages/mui-system/src/spacing/index.ts
+++ b/packages/mui-system/src/spacing/index.ts
@@ -1,2 +1,1 @@
-export { default } from './spacing';
 export * from './spacing';

--- a/packages/mui-system/src/style/index.ts
+++ b/packages/mui-system/src/style/index.ts
@@ -1,2 +1,1 @@
-export { default } from './style';
 export * from './style';

--- a/packages/mui-system/src/typography/index.ts
+++ b/packages/mui-system/src/typography/index.ts
@@ -1,2 +1,1 @@
-export { default } from './typography';
 export * from './typography';


### PR DESCRIPTION
The TypeScript compiler complete without errors now, allowing for the proper usage of the `@mui/system` package components.

Replaced all default exports with named exports to improve module consistency and tree-shaking capabilities. This change ensures uniform export style across the codebase and aids in better maintainability and IDE auto-completion.

Removed `export { default } from './typography';` and other undefined exports highlighted into a bug report.

Bug Report: [Error in @mui/system: Modules ./typography and others have no exported member default](https://github.com/mui/material-ui/issues/43685)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
