### PR TITLE
[code-infra] Remove esModuleInterop

### DIFF
--- a/apps/pigment-css-next-app/tsconfig.json
+++ b/apps/pigment-css-next-app/tsconfig.json
@@ -6,7 +6,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,

--- a/docs/scripts/tsconfig.json
+++ b/docs/scripts/tsconfig.json
@@ -8,7 +8,7 @@
     "noUnusedLocals": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "types": ["node"]
   }
 }

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -10,7 +10,7 @@
     "noUnusedLocals": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "types": ["react", "mocha"],
     "incremental": true
   },

--- a/packages-internal/docs-utils/tsconfig.json
+++ b/packages-internal/docs-utils/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "types": ["node"],
     "strict": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "isolatedModules": true
   },
   "include": ["./src/**/*.ts"]

--- a/packages-internal/scripts/tsconfig.base.json
+++ b/packages-internal/scripts/tsconfig.base.json
@@ -11,7 +11,7 @@
     "sourceMap": true,
     "composite": true,
 
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "isolatedModules": true
   }
 }

--- a/packages-internal/scripts/typescript-to-proptypes/tsconfig.test.json
+++ b/packages-internal/scripts/typescript-to-proptypes/tsconfig.test.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "types": ["node", "mocha"],
     "strict": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "isolatedModules": true
   },
   "include": ["./src/*.ts", "./test/*.ts"],

--- a/packages-internal/test-utils/tsconfig.json
+++ b/packages-internal/test-utils/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "node",
     "types": ["node"],
     "strict": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "isolatedModules": true,
     "jsx": "react"
   },

--- a/packages/api-docs-builder/tsconfig.json
+++ b/packages/api-docs-builder/tsconfig.json
@@ -6,7 +6,7 @@
     "noUnusedLocals": false,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "types": ["node", "mocha"],
     "target": "ES2020",
     "module": "CommonJS",

--- a/packages/rsc-builder/tsconfig.json
+++ b/packages/rsc-builder/tsconfig.json
@@ -6,7 +6,7 @@
     "noUnusedLocals": false,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "types": ["node", "mocha"],
     "target": "ES2020",
     "module": "CommonJS",

--- a/scripts/buidApiDocs/tsconfig.json
+++ b/scripts/buidApiDocs/tsconfig.json
@@ -10,7 +10,7 @@
 
     "noEmit": true,
     "allowJs": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "noUnusedLocals": false,
     "skipLibCheck": true,
     "strict": true,

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "allowJs": true,
     "skipLibCheck": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "module": "Node16",
     "moduleResolution": "Node16",
     "types": ["mocha"]


### PR DESCRIPTION
Babel is adding those interop helpers, so his setting isn't affecting our output. But we may as well just enforce correct import semantics. Let's see what breaks

Related to https://github.com/mui/material-ui/issues/43700