### PR TITLE
[docs-infra] Fix missing dependencies in multi-tab demos

### DIFF
--- a/docs/pages/experiments/docs/DemoMultiTabs.js
+++ b/docs/pages/experiments/docs/DemoMultiTabs.js
@@ -91,7 +91,7 @@ const columns = [
       if (!value || typeof value !== 'number') {
         return value;
       }
-      return `${value.toLocaleString()}$`;
+      return '$'.concat(value.toLocaleString());
     },
     editable: true,
   },

--- a/docs/pages/experiments/docs/DemoMultiTabs.js
+++ b/docs/pages/experiments/docs/DemoMultiTabs.js
@@ -91,7 +91,7 @@ const columns = [
       if (!value || typeof value !== 'number') {
         return value;
       }
-      return '$'.concat(value.toLocaleString());
+      return `$${value.toLocaleString()}`;
     },
     editable: true,
   },

--- a/docs/src/modules/sandbox/Dependencies.ts
+++ b/docs/src/modules/sandbox/Dependencies.ts
@@ -1,5 +1,4 @@
 import { CODE_VARIANTS } from 'docs/src/modules/constants';
-import type { MuiProductId } from 'docs/src/modules/utils/getProductInfoFromUrl';
 import { DemoData } from './types';
 
 const packagesWithBundledTypes = [

--- a/docs/src/modules/sandbox/Dependencies.ts
+++ b/docs/src/modules/sandbox/Dependencies.ts
@@ -1,5 +1,6 @@
 import { CODE_VARIANTS } from 'docs/src/modules/constants';
 import type { MuiProductId } from 'docs/src/modules/utils/getProductInfoFromUrl';
+import { DemoData } from './types';
 
 const packagesWithBundledTypes = [
   'date-fns',
@@ -37,14 +38,9 @@ function addTypeDeps(deps: Record<string, string>): void {
   });
 }
 
-export default function SandboxDependencies(
-  demo: {
-    raw: string;
-    productId?: MuiProductId;
-    codeVariant: keyof typeof CODE_VARIANTS;
-  },
-  options?: { commitRef?: string },
-) {
+type Demo = Pick<DemoData, 'productId' | 'raw' | 'codeVariant' | 'relativeModules'>;
+
+export default function SandboxDependencies(demo: Demo, options?: { commitRef?: string }) {
   const { commitRef } = options || {};
 
   /**
@@ -63,7 +59,7 @@ export default function SandboxDependencies(
     return `https://pkg.csb.dev/mui/material-ui/commit/${shortSha}/@mui/${packageName}`;
   }
 
-  function extractDependencies(raw: string) {
+  function extractDependencies(demo: Demo) {
     const muiDocConfig = (window as any).muiDocConfig;
 
     function includePeerDependencies(
@@ -121,32 +117,37 @@ export default function SandboxDependencies(
     }
 
     const re = /^import\s'([^']+)'|import\s[\s\S]*?\sfrom\s+'([^']+)/gm;
-    let m: RegExpExecArray | null = null;
-    // eslint-disable-next-line no-cond-assign
-    while ((m = re.exec(raw))) {
-      const fullName = m[2] ?? m[1];
-      // handle scope names
-      const name =
-        fullName.charAt(0) === '@' ? fullName.split('/', 2).join('/') : fullName.split('/', 1)[0];
+    const extractImportedDependencies = (raw: string) => {
+      let m: RegExpExecArray | null = null;
+      // eslint-disable-next-line no-cond-assign
+      while ((m = re.exec(raw))) {
+        const fullName = m[2] ?? m[1];
+        // handle scope names
+        const name =
+          fullName.charAt(0) === '@' ? fullName.split('/', 2).join('/') : fullName.split('/', 1)[0];
 
-      if (!deps[name] && !name.startsWith('.')) {
-        deps[name] = versions[name] ?? 'latest';
-      }
+        if (!deps[name] && !name.startsWith('.')) {
+          deps[name] = versions[name] ?? 'latest';
+        }
 
-      if (muiDocConfig && muiDocConfig.postProcessImport) {
-        const resolvedDep = muiDocConfig.postProcessImport(fullName);
-        if (resolvedDep) {
-          deps = { ...deps, ...resolvedDep };
+        if (muiDocConfig && muiDocConfig.postProcessImport) {
+          const resolvedDep = muiDocConfig.postProcessImport(fullName);
+          if (resolvedDep) {
+            deps = { ...deps, ...resolvedDep };
+          }
         }
       }
-    }
+    };
+
+    extractImportedDependencies(demo.raw);
+    demo.relativeModules?.forEach(({ raw }) => extractImportedDependencies(raw));
 
     deps = includePeerDependencies(deps, versions);
 
     return deps;
   }
 
-  const dependencies = extractDependencies(demo.raw);
+  const dependencies = extractDependencies(demo);
 
   if (demo.codeVariant === CODE_VARIANTS.TS) {
     addTypeDeps(dependencies);

--- a/docs/src/modules/sandbox/Dependencies.ts
+++ b/docs/src/modules/sandbox/Dependencies.ts
@@ -59,7 +59,7 @@ export default function SandboxDependencies(demo: Demo, options?: { commitRef?: 
     return `https://pkg.csb.dev/mui/material-ui/commit/${shortSha}/@mui/${packageName}`;
   }
 
-  function extractDependencies(demo: Demo) {
+  function extractDependencies() {
     const muiDocConfig = (window as any).muiDocConfig;
 
     function includePeerDependencies(
@@ -147,7 +147,7 @@ export default function SandboxDependencies(demo: Demo, options?: { commitRef?: 
     return deps;
   }
 
-  const dependencies = extractDependencies(demo);
+  const dependencies = extractDependencies();
 
   if (demo.codeVariant === CODE_VARIANTS.TS) {
     addTypeDeps(dependencies);


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/pull/13695#issuecomment-2338738327

When multi-tab demos are opened in Stackblitz/Codesandbox, we need to extract imported dependencies from all the files, not only the main ones.

Before: https://deploy-preview-43696--material-ui-apps.netlify.app/experiments/docs/demos/#multiple-tabs-demo
After: https://deploy-preview-43713--material-ui-apps.netlify.app/experiments/docs/demos/#multiple-tabs-demo

### TODO
- [x] Fix content leaking in the side panel in CodeSandbox (reported in https://github.com/codesandbox/codesandbox-client/issues/8607)
	<img width="686" src="https://github.com/user-attachments/assets/42bd3283-bea5-48c5-9b1b-9879ded0ca3e">
