### PR TITLE
[material-ui] Bring back `GridProps` and `GridTypeMap`

### DIFF
--- a/packages/mui-material/src/Grid/Grid.d.ts
+++ b/packages/mui-material/src/Grid/Grid.d.ts
@@ -149,6 +149,9 @@ export interface GridOwnProps extends SystemProps<Theme>, Breakpoints {
   zeroMinWidth?: boolean;
 }
 
+/**
+ * @deprecated Use the [`Grid2`](https://mui.com/material-ui/react-grid2/) component instead.
+ */
 export interface GridTypeMap<
   AdditionalProps = {},
   RootComponent extends React.ElementType = 'div',
@@ -171,6 +174,9 @@ export interface GridTypeMap<
  */
 declare const Grid: OverridableComponent<GridTypeMap>;
 
+/**
+ * @deprecated Use the [`Grid2`](https://mui.com/material-ui/react-grid2/) component instead.
+ */
 export type GridProps<
   RootComponent extends React.ElementType = GridTypeMap['defaultComponent'],
   AdditionalProps = {},

--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -204,6 +204,7 @@ export { default as FormLabel } from './FormLabel';
 export * from './FormLabel';
 
 export { default as Grid } from './Grid';
+export { GridProps, GridTypeMap } from './Grid';
 
 export { default as Grid2 } from './Grid2';
 export * from './Grid2';


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/43686.

This was an oversight of https://github.com/mui/material-ui/pull/43054. This only brings back the types requested in [the issue](https://github.com/mui/material-ui/issues/43686), as there are some naming conflicts between the `Grid` and `Grid2` other types exports (`GridDirection`, `GridSpacing`, `GridWrap` and `GridSize`), so adding those back would be opening a bigger can of worms. Hopefully, no one is using them, but if someone is and opens an issue, we can discuss possible solutions then.
