### PR TITLE
[code-infra] Ensure `clock` is restored when using `clock.withFakeTimers`

### DIFF
--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -378,6 +378,7 @@ function createClock(defaultMode: 'fake' | 'real', config: ClockConfig): Clock {
 
   beforeEach(() => {
     if (mode === 'fake') {
+      console.log('Initializing fake timers in `beforeEach` hook.');
       clock = useFakeTimers({
         now: config,
         // useIsFocusVisible schedules a global timer that needs to persist regardless of whether components are mounted or not.
@@ -389,6 +390,7 @@ function createClock(defaultMode: 'fake' | 'real', config: ClockConfig): Clock {
   });
 
   afterEach(() => {
+    console.log('Restoring fake timers in `afterEach` hook.');
     clock?.restore();
     clock = null;
   });

--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -433,6 +433,7 @@ function createClock(defaultMode: 'fake' | 'real', config: ClockConfig): Clock {
       });
 
       after(() => {
+        console.log('DEBUG: Called `withFakeTimers` "after" hook.');
         mode = defaultMode;
         this.restore();
       });

--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -433,9 +433,8 @@ function createClock(defaultMode: 'fake' | 'real', config: ClockConfig): Clock {
       });
 
       after(() => {
-        console.log('DEBUG: Called `withFakeTimers` "after" hook.');
         mode = defaultMode;
-        this.restore();
+        clock?.restore();
       });
     },
     restore() {

--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -434,6 +434,7 @@ function createClock(defaultMode: 'fake' | 'real', config: ClockConfig): Clock {
 
       after(() => {
         mode = defaultMode;
+        this.restore();
       });
     },
     restore() {


### PR DESCRIPTION
A different approach in an effort to address: https://github.com/mui/mui-x/pull/14583

