### PR TITLE
[pigment-css][docs] Call out Pigment being in alpha

### DIFF
--- a/docs/data/material/experimental-api/pigment-css/pigment-css.md
+++ b/docs/data/material/experimental-api/pigment-css/pigment-css.md
@@ -2,6 +2,10 @@
 
 <p class="description">Learn how to get started customizing your components using Pigment CSS.</p>
 
+:::warning
+Pigment CSS is currently in the early alpha stage of development. We're actively working on improving its performance and stability. If you find any problem, please open a [GitHub issue](https://github.com/mui/pigment-css/issues).
+:::
+
 <iframe width="100%" height="400" src="https://www.youtube.com/embed/UVeDpUey5Es?si=w8OtdStXHtWWIODa" title="YouTube video player: Getting Started with Pigment CSS" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 [Pigment CSS](https://github.com/mui/pigment-css) is a zero-runtime CSS-in-JS library that pre-compiles at build time, making it compatible with React Server Components and providing you with significant performance improvements over other styling engines.

--- a/docs/data/material/migration/upgrade-to-v6/migrating-to-pigment-css.md
+++ b/docs/data/material/migration/upgrade-to-v6/migrating-to-pigment-css.md
@@ -2,6 +2,10 @@
 
 <p class="description">This guide helps you integrate Pigment CSS with Material UI v6.</p>
 
+:::warning
+Pigment CSS is currently in the early alpha stage of development. We're actively working on improving its performance and stability. If you find any problem, please open a [GitHub issue](https://github.com/mui/pigment-css/issues).
+:::
+
 Before going through this guide, make sure you have [upgraded to Material UI v6](/material-ui/migration/upgrade-to-v6/).
 
 ## Introduction


### PR DESCRIPTION
Add a callout in the "Getting started with Pigment CSS" and "Migrating to Pigment CSS" docs pages to clarify which phase Pigment CSS is in.

Preview:
- https://deploy-preview-43725--material-ui.netlify.app/material-ui/experimental-api/pigment-css/
- https://deploy-preview-43725--material-ui.netlify.app/material-ui/migration/migrating-to-pigment-css/