### PR TITLE
[code-infra] Allow overriding all `options` of `useFakeTimers` function

### DIFF
--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -371,7 +371,11 @@ export interface Clock {
 
 export type ClockConfig = undefined | number | Date;
 
-function createClock(defaultMode: 'fake' | 'real', config: ClockConfig): Clock {
+function createClock(
+  defaultMode: 'fake' | 'real',
+  config: ClockConfig,
+  options?: Exclude<Parameters<typeof useFakeTimers>[0], number | Date>,
+): Clock {
   let clock: ReturnType<typeof useFakeTimers> | null = null;
 
   let mode = defaultMode;
@@ -384,6 +388,7 @@ function createClock(defaultMode: 'fake' | 'real', config: ClockConfig): Clock {
         // Technically we'd want to reset all modules between tests but we don't have that technology.
         // In the meantime just continue to clear native timers like with did for the past years when using `sinon` < 8.
         shouldClearNativeTimers: true,
+        ...options,
       });
     }
   });
@@ -457,6 +462,7 @@ export interface CreateRendererOptions extends Pick<RenderOptions, 'strict' | 's
    */
   clock?: 'fake' | 'real';
   clockConfig?: ClockConfig;
+  clockOptions?: Parameters<typeof createClock>[2];
 }
 
 export function createRenderer(globalOptions: CreateRendererOptions = {}): Renderer {
@@ -465,10 +471,11 @@ export function createRenderer(globalOptions: CreateRendererOptions = {}): Rende
     clockConfig,
     strict: globalStrict = true,
     strictEffects: globalStrictEffects = globalStrict,
+    clockOptions,
   } = globalOptions;
   // save stack to re-use in test-hooks
   const { stack: createClientRenderStack } = new Error();
-  const clock = createClock(clockMode, clockConfig);
+  const clock = createClock(clockMode, clockConfig, clockOptions);
 
   /**
    * Flag whether `createRenderer` was called in a suite i.e. describe() block.


### PR DESCRIPTION
Improve the extensibility of the `useFakeTimers` function by allowing override of all options.
This might be most useful in providing a `toFake` ([doc](https://github.com/sinonjs/fake-timers?tab=readme-ov-file#var-clock--faketimersinstallconfig:~:text=specified%20unix%20epoch-,config.toFake,-String%5B%5D)) option to limit what is mocked.