### PR TITLE
[bugfix] Refactor prop types generation and add import optimisation

### DIFF
--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -315,38 +315,6 @@ async function generateProptypes(
 }
 
 
-/**
- * Generates utils types for a given source file.
- *
- * @param {string} sourceFile - The path of the source file to generate utils types for.
- * @return {Promise<void>} - A Promise that resolves when the utils types are generated and written to the source file.
- * @throws {Error} - If unable to produce inject optimise TS imports into code.
- */
-async function optimiseImports(
-  sourceFile: string,
-): Promise<void> {
-
-  const sourceContent: string = await fse.readFile(sourceFile, 'utf8');
-
-
-  const result = sourceContent
-    .replace('import PropTypes from \'prop-types\';', 'import * as PropTypes from \'prop-types\';')
-
-  if (!result) {
-    throw new Error('Unable to produce inject optimise TS imports into code.');
-  }
-
-  const prettierConfig = await prettier.resolveConfig(process.cwd(), {
-    config: path.join(__dirname, '../prettier.config.js'),
-  });
-
-  const prettified = await prettier.format(result, { ...prettierConfig, filepath: sourceFile });
-  const formatted = fixBabelGeneratorIssues(prettified);
-  const correctedLineEndings = fixLineEndings(sourceContent, formatted);
-
-  await fse.writeFile(sourceFile, correctedLineEndings);
-}
-
 interface HandlerArgv {
   pattern: string;
 }
@@ -424,6 +392,37 @@ async function run(argv: HandlerArgv) {
 }
 
 
+/**
+ * Generates utils types for a given source file.
+ *
+ * @param {string} sourceFile - The path of the source file to generate utils types for.
+ * @return {Promise<void>} - A Promise that resolves when the utils types are generated and written to the source file.
+ * @throws {Error} - If unable to produce inject optimise TS imports into code.
+ */
+async function optimisePropTypesImports(
+  sourceFile: string,
+): Promise<void> {
+
+  const sourceContent: string = await fse.readFile(sourceFile, 'utf8');
+
+
+  const result = sourceContent
+    .replace('import PropTypes from \'prop-types\';', 'import * as PropTypes from \'prop-types\';')
+
+  if (!result) {
+    throw new Error('Unable to produce inject optimise TS imports into code.');
+  }
+
+  const prettierConfig = await prettier.resolveConfig(process.cwd(), {
+    config: path.join(__dirname, '../prettier.config.js'),
+  });
+
+  const prettified = await prettier.format(result, { ...prettierConfig, filepath: sourceFile });
+  const formatted = fixBabelGeneratorIssues(prettified);
+  const correctedLineEndings = fixLineEndings(sourceContent, formatted);
+
+  await fse.writeFile(sourceFile, correctedLineEndings);
+}
 
 /**
  * Optimises declaration files by removing unnecessary imports.
@@ -431,7 +430,7 @@ async function run(argv: HandlerArgv) {
  * @param {HandlerArgv} argv - The arguments object containing the pattern to match declaration files.
  * @returns {Promise<void>} - A promise that resolves when the optimisation is complete.
  */
-async function optimise(argv: HandlerArgv) {
+async function optimisePropTypes(argv: HandlerArgv) {
   const { pattern } = argv;
 
   const filePattern = new RegExp(pattern);
@@ -471,7 +470,102 @@ async function optimise(argv: HandlerArgv) {
   const promises = builtFiles
     .map<Promise<void>>(async (file: string): Promise<void> => {
       try {
-        await optimiseImports(file);
+        await optimisePropTypesImports(file);
+      } catch (error: any) {
+        error.message = `${file}: ${error.message}`;
+        throw error;
+      }
+    });
+
+  const results = await Promise.allSettled(promises);
+
+  const fails: PromiseRejectedResult[] = results.filter((result): result is PromiseRejectedResult => {
+    return result.status === 'rejected';
+  });
+
+  fails.forEach((result: PromiseRejectedResult) => {
+    console.error(result.reason);
+  });
+  if (fails.length > 0) {
+    process.exit(1);
+  }
+}
+
+/**
+ * Generates utils types for a given source file.
+ *
+ * @param {string} sourceFile - The path of the source file to generate utils types for.
+ * @return {Promise<void>} - A Promise that resolves when the utils types are generated and written to the source file.
+ * @throws {Error} - If unable to produce inject optimise TS imports into code.
+ */
+async function optimiseTsImports(
+  sourceFile: string,
+): Promise<void> {
+
+  const sourceContent: string = await fse.readFile(sourceFile, 'utf8');
+
+
+  const result = sourceContent
+    .replace('export { default } from \'./shadows\';', 'export * from \'./shadows\';')
+    .replace(/export \{ default } from '.\/([a-z]+)';/, '\n');
+
+
+  if (!result) {
+    throw new Error('Unable to produce inject optimise TS imports into code.');
+  }
+
+  const prettierConfig = await prettier.resolveConfig(process.cwd(), {
+    config: path.join(__dirname, '../prettier.config.js'),
+  });
+
+  const prettified = await prettier.format(result, { ...prettierConfig, filepath: sourceFile });
+  const formatted = fixBabelGeneratorIssues(prettified);
+  const correctedLineEndings = fixLineEndings(sourceContent, formatted);
+
+  await fse.writeFile(sourceFile, correctedLineEndings);
+}
+
+/**
+ * Optimises TypeScript declaration files.
+ *
+ * @param {*} argv - The command line arguments.
+ */
+async function optimiseTs(argv: HandlerArgv) {
+  const { pattern } = argv;
+
+  const filePattern = new RegExp(pattern);
+  if (pattern.length > 0) {
+    console.log(`Only considering declaration files matching ${filePattern}`);
+  }
+
+  const allBuiltFiles = await Promise.all(
+    [
+      path.resolve(__dirname, '../packages/mui-system/build'),
+    ].map((folderPath) => {
+      return glob('+([a-z]+)/+([index.d.ts])', {
+        absolute: true,
+        cwd: folderPath,
+      });
+    }),
+  );
+
+  const builtFiles = _.flatten(allBuiltFiles)
+    .filter((filePath) => {
+      // Filter out files where the directory name and filename doesn't match
+      // Example: shadows/index.d.ts
+      const fileName = path.basename(filePath).replace(/(\.d\.ts)/g, '');
+      console.log('fileName: ', fileName);
+
+      return fileName === 'index';
+    })
+    .filter((filePath: string) => filePattern.test(filePath));
+
+  console.log('builtFiles: ', builtFiles);
+
+  const promises = builtFiles
+    .map<Promise<void>>(async (file: string): Promise<void> => {
+      try {
+        await optimiseTsImports(file);
       } catch (error: any) {
         error.message = `${file}: ${error.message}`;
         throw error;
@@ -507,7 +601,7 @@ yargs
   })
   .command<HandlerArgv>({
     command: '$0',
-    describe: 'Optimise Utils PropTypes from TypeScript declarations',
+    describe: 'Optimise Utils PropTypes for TypeScript declarations',
     builder: (command) => {
       return command.option('pattern', {
         default: '',
@@ -515,7 +609,19 @@ yargs
         type: 'string',
       });
     },
-    handler: optimise,
+    handler: optimisePropTypes,
+  })
+  .command<HandlerArgv>({
+    command: '$0',
+    describe: 'Optimise System Types for TypeScript declarations',
+    builder: (command) => {
+      return command.option('pattern', {
+        default: '',
+        describe: 'Only considers declaration files matching this pattern.',
+        type: 'string',
+      });
+    },
+    handler: optimiseTs,
   })
   .help()
   .strict(true)

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -458,8 +458,8 @@ async function optimise(argv: HandlerArgv) {
       const fileName = path.basename(filePath).replace(/(\.d\.ts)/g, '');
 
       // An exception is if the folder name starts with Unstable_/unstable_
-      // Example: unstable_refType/refType.tsx
-      // @note: Consider whether it can have no value for utils
+      // Example: unstable_refType/refType.d.ts
+      // @note: whether utils might not require this value
       if (/(u|U)nstable_/g.test(folderName)) {
         folderName = folderName.slice(9);
       }


### PR DESCRIPTION
Add type annotations to enhance the robustness of prop type generation. Introduce a new `optimiseImports` function to standardise import formats. Implement an `optimise` command for removing unnecessary imports in declaration files.

Replaced all occurrences of `import PropTypes from 'prop-types';` with `import * as PropTypes from 'prop-types';` in the Material UI codebase related to `@mui/utils`

Bug Report: [[Error] Incorrect Import of PropTypes Causes Compilation Error](https://github.com/mui/material-ui/issues/43700)


This represents an initial step towards a solution for the TypeScript `tsc` compiler

This improvement offers a viable solution for the `tsc` compiler by organising utility functions across all files. While handling internal refactoring of just built/generated files may seem impractical, it’s worth considering. It appears there are more adaptable solutions, but they often generate incorrect outputs for TypeScript, as previously mentioned https://github.com/mui/material-ui/pull/43701, https://github.com/mui/material-ui/pull/43701#issuecomment-2345638447, https://github.com/mui/material-ui/pull/43701#issuecomment-2346092950. Notably, the `prop-types` package remains unchanged. Therefore, this proposal represents the initial step in addressing the `tsc` compiler issue.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
