### PR TITLE
[Skeleton] Fix wave animation for styled-components

### DIFF
--- a/packages/mui-material/src/Skeleton/Skeleton.js
+++ b/packages/mui-material/src/Skeleton/Skeleton.js
@@ -68,7 +68,9 @@ const pulseAnimation =
 const waveAnimation =
   typeof waveKeyframe !== 'string'
     ? css`
-        animation: ${waveKeyframe} 2s linear 0.5s infinite;
+        &::after {
+          animation: ${waveKeyframe} 2s linear 0.5s infinite;
+        }
       `
     : null;
 
@@ -192,8 +194,8 @@ const SkeletonRoot = styled('span', {
           props: {
             animation: 'wave',
           },
-          style: {
-            '&::after': waveAnimation || {
+          style: waveAnimation || {
+            '&::after': {
               animation: `${waveKeyframe} 2s linear 0.5s infinite`,
             },
           },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #43611

## Root cause

The animation wrapped in `css` is used within an object. This is not allowed:

```js
style: {
  '&::after': css`
    animation: ${keyframe} …
  `,
}
```

The fix is to move the `&::after` inside the `css`:

```js
const waveAnimation = css`
  &::after {
    animation: ${keyframe} …
  }
`

style: waveAnimation
```

Note: I check the rest of the components that has animation, all of them are using the right approach.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
