### PR TITLE
[test][docs] Improve demos for better regression screenshots

### DIFF
--- a/docs/data/joy/components/radio-button/ExampleAlignmentButtons.js
+++ b/docs/data/joy/components/radio-button/ExampleAlignmentButtons.js
@@ -17,6 +17,7 @@ export default function ExampleAlignmentButtons() {
       variant="outlined"
       value={alignment}
       onChange={(event) => setAlignment(event.target.value)}
+      sx={{ display: 'inline-flex' }}
     >
       {['left', 'center', 'right', 'justify'].map((item) => (
         <Box

--- a/docs/data/joy/components/radio-button/ExampleAlignmentButtons.tsx
+++ b/docs/data/joy/components/radio-button/ExampleAlignmentButtons.tsx
@@ -19,6 +19,7 @@ export default function ExampleAlignmentButtons() {
       onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
         setAlignment(event.target.value)
       }
+      sx={{ display: 'inline-flex' }}
     >
       {['left', 'center', 'right', 'justify'].map((item) => (
         <Box

--- a/docs/data/joy/components/toggle-button-group/ToggleGroupToolbar.js
+++ b/docs/data/joy/components/toggle-button-group/ToggleGroupToolbar.js
@@ -22,7 +22,7 @@ export default function ToggleGroupToolbar() {
   return (
     <Sheet
       variant="outlined"
-      sx={{ borderRadius: 'md', display: 'flex', gap: 2, p: 0.5 }}
+      sx={{ borderRadius: 'md', display: 'inline-flex', gap: 2, p: 0.5 }}
     >
       <ToggleButtonGroup
         variant="plain"

--- a/docs/data/joy/components/toggle-button-group/ToggleGroupToolbar.tsx
+++ b/docs/data/joy/components/toggle-button-group/ToggleGroupToolbar.tsx
@@ -22,7 +22,7 @@ export default function ToggleGroupToolbar() {
   return (
     <Sheet
       variant="outlined"
-      sx={{ borderRadius: 'md', display: 'flex', gap: 2, p: 0.5 }}
+      sx={{ borderRadius: 'md', display: 'inline-flex', gap: 2, p: 0.5 }}
     >
       <ToggleButtonGroup
         variant="plain"

--- a/docs/data/material/components/dividers/FlexDivider.js
+++ b/docs/data/material/components/dividers/FlexDivider.js
@@ -8,7 +8,7 @@ export default function FlexDivider() {
   return (
     <Box
       sx={{
-        display: 'flex',
+        display: 'inline-flex',
         alignItems: 'center',
         border: '1px solid',
         borderColor: 'divider',

--- a/docs/data/material/components/dividers/FlexDivider.tsx
+++ b/docs/data/material/components/dividers/FlexDivider.tsx
@@ -8,7 +8,7 @@ export default function FlexDivider() {
   return (
     <Box
       sx={{
-        display: 'flex',
+        display: 'inline-flex',
         alignItems: 'center',
         border: '1px solid',
         borderColor: 'divider',


### PR DESCRIPTION
Follow up on https://github.com/mui/material-ui/pull/43656#issuecomment-2348446752

Some demos were using `flex` instead of `inline-flex` in their top-level elements, causing them to look off when rendered inside a `block` element instead of a `flex` element. For context, our demo wrapper uses `flex` but our visual regression wrapper uses `block` since https://github.com/mui/material-ui/pull/43656.

