### PR TITLE
[test] Update font-awesome CSS file in regression tests fixture

### DIFF
--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -143,7 +143,6 @@ const blacklist = [
   'docs-components-grid/InteractiveGrid.png', // Redux isolation
   'docs-components-grid/SpacingGrid.png', // Needs interaction
   'docs-components-hidden', // Need to dynamically resize to test
-  'docs-components-icons/FontAwesomeIconSize.png', // Relies on cascading network requests
   'docs-components-image-list', // Image don't load
   'docs-components-masonry/ImageMasonry.png', // Image don't load
   'docs-components-material-icons/synonyms.png', // No component
@@ -363,7 +362,7 @@ function App(props) {
       },
       custom: {
         families: ['Font Awesome 5 Free:n9'],
-        urls: ['https://use.fontawesome.com/releases/v5.1.0/css/all.css'],
+        urls: ['https://use.fontawesome.com/releases/v5.14.0/css/all.css'],
       },
       timeout: 20000,
       active: () => {


### PR DESCRIPTION
Attempt at stabilizing the icons test. It looks like the referenced css has gone out of sync with the regression tests font loader.

Let's see if this does the trick.

Potentially closes https://github.com/mui/material-ui/pull/43684