### PR TITLE
[slider][docs] Polish Music player demo

### DIFF
--- a/docs/data/material/components/slider/slider.md
+++ b/docs/data/material/components/slider/slider.md
@@ -94,7 +94,7 @@ You can learn more about this in the [overrides documentation page](/material-ui
 
 ### Music player
 
-{{"demo": "MusicPlayerSlider.js"}}
+{{"demo": "MusicPlayerSlider.js", "bg": "inline"}}
 
 ## Vertical sliders
 


### PR DESCRIPTION
A quick polish on #43743. I thought this would look better and be denser, using less vertical space:

Before
![SCR-20240913-rjpk](https://github.com/user-attachments/assets/721919cd-4ce8-40f4-bd82-3f7cb2f57e5d)

After
![SCR-20240913-rjmt](https://github.com/user-attachments/assets/22035064-6571-417f-8691-0ad88a1de863)

This docs option is not used so often on Material UI. We use it a lot with the MUI X Data Grid though, e.g. https://mui.com/x/react-data-grid/#mit-license-free-forever