### PR TITLE
[docs] Fix MUI Treasury Layout broken links

### DIFF
--- a/docs/data/material/discover-more/related-projects/related-projects.md
+++ b/docs/data/material/discover-more/related-projects/related-projects.md
@@ -25,7 +25,7 @@ Feel free to submit a pull request!
 
 ### Layout
 
-- [MUI Treasury Layout](https://mui-treasury.com/?path=/docs/layout-introduction--docs): Components to handle the overall layout of a page. Check out examples such as [a legacy.reactjs.org clone](https://mui-treasury.com/?path=/story/layout-app-reactlegacy--react-legacy).
+- [MUI Treasury Layout](https://mui-treasury.com/?path=/docs/layout-v6-introduction--docs): Components to handle the overall layout of a page. Check out examples such as [a legacy.reactjs.org clone](https://mui-treasury.com/?path=/story/layout-v6-app-react-legacy--react-legacy).
 
 ### Image
 


### PR DESCRIPTION
It looks like this was broken in https://github.com/siriwatknp/mui-treasury/pull/1229.