### PR TITLE
[docs] Fix MUI Treasury Layout broken links

### DIFF
--- a/docs/data/material/discover-more/related-projects/related-projects.md
+++ b/docs/data/material/discover-more/related-projects/related-projects.md
@@ -25,7 +25,7 @@ Feel free to submit a pull request!
 
 ### Layout
 
-- [MUI Treasury Layout](https://mui-treasury.com/?path=/docs/layout-introduction--docs): Components to handle the overall layout of a page. Check out examples such as [a legacy.reactjs.org clone](https://mui-treasury.com/?path=/story/layout-app-reactlegacy--react-legacy).
+- [MUI Treasury Layout](https://mui-treasury.com/?path=/docs/layout-v5-legacy-introduction--docs): Components to handle the overall layout of a page. Check out examples such as [a legacy.reactjs.org clone](https://mui-treasury.com/?path=/story/layout-v5-legacy-app-reactlegacy--react-legacy).
 
 ### Image
 


### PR DESCRIPTION
Same as #43752 but for v5 docs.

I wasn't sure if it's worth fixing in v5, but until we see this:

- https://analytics.google.com/analytics/web/#/analysis/p353089763/edit/6yK0GT2PQ3enmD2Isqu8qg
- https://tools-public.mui.com/prod/pages/npmVersion?package=@mui/material

I guess the answer is yes. 