### PR TITLE
[core] useAutocomplete should have 'use client'

### DIFF
--- a/packages/rsc-builder/buildRsc.ts
+++ b/packages/rsc-builder/buildRsc.ts
@@ -27,7 +27,6 @@ const PROJECTS: Project[] = [
       'packages/mui-material/src/PigmentContainer/PigmentContainer.tsx', // RSC compatible
       'packages/mui-material/src/PigmentGrid/PigmentGrid.tsx', // RSC compatible
       'packages/mui-material/src/PigmentStack/PigmentStack.tsx', // RSC compatible
-      'packages/mui-material/src/useAutocomplete/useAutocomplete.js', // RSC compatible
     ],
   },
   {


### PR DESCRIPTION
Fix https://github.com/mui/material-ui/pull/41956#discussion_r1752127870.

If from a server component, we import a hook, then different behaviors can happen:

- Next.js v15.0.0-rc.0
  - hook with "use client" 🔴 (seems to be a recent regression) <img width="441" alt="SCR-20240915-czvu" src="https://github.com/user-attachments/assets/b9f48cac-0617-479f-ba82-9d017ea39a45">
  - hook without "use client" 🟡 <img width="437" alt="SCR-20240915-daas" src="https://github.com/user-attachments/assets/d955e777-a1eb-4509-be77-ec7933e5ac60">
- Next.js (turbo pack) v15.0.0-rc.0
  - hook with "use client" 🟢 <img width="445" alt="SCR-20240915-czqh" src="https://github.com/user-attachments/assets/3cf75933-fd90-4ba8-9292-79ed1b68b8ae">
  - hook without "use client" 🟡 <img width="489" alt="SCR-20240915-cnjt" src="https://github.com/user-attachments/assets/010bf82b-1e5a-4b0d-b13b-8aaebfeed176">
- Waku v0.21.2
  - hook with "use client" 🟢 <img width="334" alt="SCR-20240915-datp" src="https://github.com/user-attachments/assets/7b87d164-26c3-464f-a663-feea0205fe23">
  - hook without "use client" 🔴 <img width="400" alt="SCR-20240915-dawq" src="https://github.com/user-attachments/assets/728557c1-2535-4c7a-b690-0c14d80fbe44">


Based on the different cases 🔴/🟡/🟢, it looks like we should have "use client" for hooks too. It yields the best DX.