### PR TITLE
[system] Warn/use color scheme

### DIFF
--- a/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
+++ b/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
@@ -1,8 +1,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, screen } from '@mui/internal-test-utils';
+import { createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
 import Box from '@mui/material/Box';
-import { CssVarsProvider, extendTheme, useTheme } from '@mui/material/styles';
+import {
+  CssVarsProvider,
+  extendTheme,
+  useTheme,
+  ThemeProvider,
+  createTheme,
+  useColorScheme,
+} from '@mui/material/styles';
 
 describe('[Material UI] ThemeProviderWithVars', () => {
   let originalMatchmedia;
@@ -359,5 +366,25 @@ describe('[Material UI] ThemeProviderWithVars', () => {
       borderBottomLeftRadius: '16px',
       borderBottomRightRadius: '16px',
     });
+  });
+
+  it('show warning when using `setMode` without configuring `colorSchemeSelector`', () => {
+    function Test() {
+      const { setMode } = useColorScheme();
+      return <button onClick={() => setMode('dark')}>Dark</button>;
+    }
+    render(
+      <ThemeProvider
+        theme={createTheme({ cssVariables: true, colorSchemes: { light: true, dark: true } })}
+      >
+        <Test />
+      </ThemeProvider>,
+    );
+
+    expect(() => {
+      fireEvent.click(screen.getByText('Dark'));
+    }).toErrorDev([
+      'MUI: The `setMode` function has no effect if `colorSchemeSelector` is not configured.\nPlease set `cssVariables.colorSchemeSelector` to `"class"` or `"data"`.\nTo learn more, visit https://mui.com/material-ui/customization/css-theme-variables/configuration/#toggling-dark-mode-manually',
+    ]);
   });
 });

--- a/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
+++ b/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
@@ -384,7 +384,7 @@ describe('[Material UI] ThemeProviderWithVars', () => {
     expect(() => {
       fireEvent.click(screen.getByText('Dark'));
     }).toErrorDev([
-      'MUI: The `setMode` function has no effect if `colorSchemeSelector` is not configured.\nPlease set `cssVariables.colorSchemeSelector` to `"class"` or `"data"`.\nTo learn more, visit https://mui.com/material-ui/customization/css-theme-variables/configuration/#toggling-dark-mode-manually',
+      'MUI: The `setMode` function has no effect if `colorSchemeSelector` is not configured.\nPlease create a theme with `createTheme({ cssVariables: { colorSchemeSelector: "class" | "data" } })`.\nTo learn more, visit https://mui.com/material-ui/customization/css-theme-variables/configuration/#toggling-dark-mode-manually',
     ]);
   });
 });

--- a/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
+++ b/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
@@ -384,7 +384,7 @@ describe('[Material UI] ThemeProviderWithVars', () => {
     expect(() => {
       fireEvent.click(screen.getByText('Dark'));
     }).toErrorDev([
-      'MUI: The `setMode` function has no effect if `colorSchemeSelector` is not configured.\nPlease create a theme with `createTheme({ cssVariables: { colorSchemeSelector: "class" | "data" } })`.\nTo learn more, visit https://mui.com/material-ui/customization/css-theme-variables/configuration/#toggling-dark-mode-manually',
+      'MUI: The `setMode` function has no effect if `colorSchemeSelector` is not configured.\nTo toggle the mode manually, please configure `colorSchemeSelector` to use a class or data attribute.\nTo learn more, visit https://mui.com/material-ui/customization/css-theme-variables/configuration/#toggling-dark-mode-manually',
     ]);
   });
 });

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -249,7 +249,7 @@ export default function createCssVarsProvider(options) {
                   console.error(
                     [
                       'MUI: The `setMode` function has no effect if `colorSchemeSelector` is not configured.',
-                      'Please create a theme with `createTheme({ cssVariables: { colorSchemeSelector: "class" | "data" } })`.',
+                      'To toggle the mode manually, please configure `colorSchemeSelector` to use a class or data attribute.',
                       'To learn more, visit https://mui.com/material-ui/customization/css-theme-variables/configuration/#toggling-dark-mode-manually',
                     ].join('\n'),
                   );

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -241,7 +241,21 @@ export default function createCssVarsProvider(options) {
         lightColorScheme,
         mode,
         setColorScheme,
-        setMode,
+        setMode:
+          process.env.NODE_ENV === 'production'
+            ? setMode
+            : (newMode) => {
+                if (theme.colorSchemeSelector === 'media') {
+                  console.error(
+                    [
+                      'MUI: The `setMode` function has no effect if `colorSchemeSelector` is not configured.',
+                      'Please set `cssVariables.colorSchemeSelector` to `"class"` or `"data"`.',
+                      'To learn more, visit https://mui.com/material-ui/customization/css-theme-variables/configuration/#toggling-dark-mode-manually',
+                    ].join('\n'),
+                  );
+                }
+                setMode(newMode);
+              },
         systemMode,
       }),
       [
@@ -253,6 +267,7 @@ export default function createCssVarsProvider(options) {
         setColorScheme,
         setMode,
         systemMode,
+        theme.colorSchemeSelector,
       ],
     );
 

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -249,7 +249,7 @@ export default function createCssVarsProvider(options) {
                   console.error(
                     [
                       'MUI: The `setMode` function has no effect if `colorSchemeSelector` is not configured.',
-                      'Please set `cssVariables.colorSchemeSelector` to `"class"` or `"data"`.',
+                      'Please create a theme with `createTheme({ cssVariables: { colorSchemeSelector: "class" | "data" } })`.',
                       'To learn more, visit https://mui.com/material-ui/customization/css-theme-variables/configuration/#toggling-dark-mode-manually',
                     ].join('\n'),
                   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

From https://github.com/mui/material-ui/issues/43533#issuecomment-2352184129

Currently with CSS theme variables enabled, calling `setMode` has no effect if `colorSchemeSelector` is not configured. Technically, this is correct because the default method is `@media (prefers-color-scheme)`, so user cannot toggle mode manually.

However, from the DX perspective, it's confusion of why it does not work. This PR added a warning if calling `setMode` without configuring `colorSchemeSelector`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
