### PR TITLE
Optimize user-event

### DIFF
--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -301,7 +301,7 @@ function render(
   );
   const result: MuiRenderResult = {
     ...testingLibraryRenderResult,
-    user: userEvent.setup(),
+    user: userEvent.setup({ delay: null }),
     forceUpdate() {
       traceSync('forceUpdate', () =>
         testingLibraryRenderResult.rerender(


### PR DESCRIPTION
See this [thread](https://github.com/mui/material-ui/pull/43757#discussion_r1763133261)

I've seen this reduce the time of running `userEvent.keyboard` by an order of magnitude.

_We should primarily optimize our tests for refactorability. Tests that require updates on every implementation detail change miss the mark. We should aim at tests that maximize interfacing with public API and minimize reliance on implementation details. Therefore, unless we specifically want to test an implementation detail, we should prefer `userEvent`._