### PR TITLE
[material-ui][Drawer] Fix issue with main window being used instead of iframe's window

### DIFF
--- a/packages/mui-material/src/Modal/ModalManager.ts
+++ b/packages/mui-material/src/Modal/ModalManager.ts
@@ -100,7 +100,7 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
   if (!props.disableScrollLock) {
     if (isOverflowing(container)) {
       // Compute the size before applying overflow hidden to avoid any scroll jumps.
-      const scrollbarSize = getScrollbarSize(ownerDocument(container));
+      const scrollbarSize = getScrollbarSize(ownerDocument(container), ownerWindow(container));
 
       restoreStyle.push({
         value: container.style.paddingRight,

--- a/packages/mui-material/src/Modal/ModalManager.ts
+++ b/packages/mui-material/src/Modal/ModalManager.ts
@@ -100,7 +100,7 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
   if (!props.disableScrollLock) {
     if (isOverflowing(container)) {
       // Compute the size before applying overflow hidden to avoid any scroll jumps.
-      const scrollbarSize = getScrollbarSize(ownerDocument(container), ownerWindow(container));
+      const scrollbarSize = getScrollbarSize(ownerDocument(container));
 
       restoreStyle.push({
         value: container.style.paddingRight,

--- a/packages/mui-utils/src/getScrollbarSize/getScrollbarSize.ts
+++ b/packages/mui-utils/src/getScrollbarSize/getScrollbarSize.ts
@@ -1,7 +1,7 @@
 // A change of the browser zoom change the scrollbar size.
 // Credit https://github.com/twbs/bootstrap/blob/488fd8afc535ca3a6ad4dc581f5e89217b6a36ac/js/src/util/scrollbar.js#L14-L18
-export default function getScrollbarSize(doc: Document): number {
+export default function getScrollbarSize(doc: Document, win: Window = window): number {
   // https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth#usage_notes
   const documentWidth = doc.documentElement.clientWidth;
-  return Math.abs(window.innerWidth - documentWidth);
+  return Math.abs(win.innerWidth - documentWidth);
 }

--- a/packages/mui-utils/src/getScrollbarSize/getScrollbarSize.ts
+++ b/packages/mui-utils/src/getScrollbarSize/getScrollbarSize.ts
@@ -1,7 +1,7 @@
 // A change of the browser zoom change the scrollbar size.
 // Credit https://github.com/twbs/bootstrap/blob/488fd8afc535ca3a6ad4dc581f5e89217b6a36ac/js/src/util/scrollbar.js#L14-L18
-export default function getScrollbarSize(doc: Document, win: Window = window): number {
+export default function getScrollbarSize(doc: Document): number {
   // https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth#usage_notes
   const documentWidth = doc.documentElement.clientWidth;
-  return Math.abs(win.innerWidth - documentWidth);
+  return Math.abs((doc.defaultView || window).innerWidth - documentWidth);
 }

--- a/packages/mui-utils/src/getScrollbarSize/getScrollbarSize.ts
+++ b/packages/mui-utils/src/getScrollbarSize/getScrollbarSize.ts
@@ -3,5 +3,5 @@
 export default function getScrollbarSize(doc: Document): number {
   // https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth#usage_notes
   const documentWidth = doc.documentElement.clientWidth;
-  return Math.abs((doc.defaultView || window).innerWidth - documentWidth);
+  return Math.abs(doc.defaultView!.innerWidth - documentWidth);
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes #43244

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


[preview](https://deploy-preview-43818--material-ui.netlify.app/material-ui/react-drawer/#responsive-drawer)