### PR TITLE
[test] Sync React.version parse logic with codebase

### DIFF
--- a/packages-internal/test-utils/src/reactMajor.ts
+++ b/packages-internal/test-utils/src/reactMajor.ts
@@ -1,3 +1,3 @@
 import * as React from 'react';
 
-export default Number(React.version.split('.')[0]);
+export default parseInt(React.version, 10);


### PR DESCRIPTION
Match the rest of the codebase https://github.com/search?q=org%3Amui%20React.version&type=code. Seen in https://github.com/mui/material-ui/pull/43022#discussion_r1766689082.