### PR TITLE
[docs-infra] Fix link in header regression

### DIFF
--- a/docs/pages/experiments/docs/headers.md
+++ b/docs/pages/experiments/docs/headers.md
@@ -14,6 +14,8 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
 
 It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English.
 
+## [Header with link](/)
+
 ## Header with Pro plan [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 ## Header with Premium plan [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'premium plan')

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -369,8 +369,8 @@ function createRender(context) {
         headingHtml.includes('<a ')
           ? [
               // Avoid breaking the anchor link button
-              `<h${level} id="${hash}"><a href="#${hash}" class="title-link-to-anchor">${headingHtml}</a>`,
-              `<a href="#${hash}" class="title-link-to-anchor"><span class="anchor-icon"><svg><use xlink:href="#anchor-link-icon" /></svg></span></a>`,
+              `<h${level} id="${hash}">${headingHtml}`,
+              `<a href="#${hash}" class="title-link-to-anchor" aria-labelledby="${hash}"><span class="anchor-icon"><svg><use xlink:href="#anchor-link-icon" /></svg></span></a>`,
             ].join('')
           : `<h${level} id="${hash}"><a href="#${hash}" class="title-link-to-anchor">${headingHtml}<span class="anchor-icon"><svg><use xlink:href="#anchor-link-icon" /></svg></span></a>`,
         `<button title="Post a comment" class="comment-link" data-feedback-hash="${hash}">`,


### PR DESCRIPTION
I'm not sure when this got broken, but it's definitely a regression. I saw this in https://mui.com/legal/ while trying to make a quick PR https://github.com/mui/mui-private/pull/605.

- wrong spacing:
<img width="211" alt="SCR-20240921-cltt" src="https://github.com/user-attachments/assets/5e816b86-abc8-4667-95be-998c797b1a54">

- wrong header label:
<img width="338" alt="SCR-20240921-clge" src="https://github.com/user-attachments/assets/26959a89-6d63-41fb-a212-a78fde33ab3f">

Preview: https://deploy-preview-43834--material-ui.netlify.app/experiments/docs/headers/