### PR TITLE
[docs] Fix visual bug on dashboard template

### DIFF
--- a/docs/data/material/getting-started/templates/dashboard/Dashboard.js
+++ b/docs/data/material/getting-started/templates/dashboard/Dashboard.js
@@ -46,7 +46,7 @@ export default function Dashboard(props) {
             sx={{
               alignItems: 'center',
               mx: 3,
-              pb: 10,
+              pb: 5,
               mt: { xs: 8, md: 0 },
             }}
           >

--- a/docs/data/material/getting-started/templates/dashboard/Dashboard.tsx
+++ b/docs/data/material/getting-started/templates/dashboard/Dashboard.tsx
@@ -49,7 +49,7 @@ export default function Dashboard(props: { disableCustomTheme?: boolean }) {
             sx={{
               alignItems: 'center',
               mx: 3,
-              pb: 10,
+              pb: 5,
               mt: { xs: 8, md: 0 },
             }}
           >


### PR DESCRIPTION
There is so much space for the footer in https://deploy-preview-43604--material-ui.netlify.app/material-ui/getting-started/templates/dashboard/, it's weird.

<img width="1292" alt="SCR-20240921-ozim" src="https://github.com/user-attachments/assets/2379c503-2328-4025-9bc0-557427b7c827">

Preview: https://deploy-preview-43836--material-ui.netlify.app/material-ui/getting-started/templates/dashboard/

An iteration on #41469.