### PR TITLE
[docs] Fix Sign-in template form experience

### DIFF
--- a/docs/data/material/getting-started/templates/sign-in-side/SignInCard.js
+++ b/docs/data/material/getting-started/templates/sign-in-side/SignInCard.js
@@ -126,6 +126,7 @@ export default function SignInCard() {
             <FormLabel htmlFor="password">Password</FormLabel>
             <Link
               component="button"
+              type="button"
               onClick={handleClickOpen}
               variant="body2"
               sx={{ alignSelf: 'baseline' }}

--- a/docs/data/material/getting-started/templates/sign-in-side/SignInCard.tsx
+++ b/docs/data/material/getting-started/templates/sign-in-side/SignInCard.tsx
@@ -126,6 +126,7 @@ export default function SignInCard() {
             <FormLabel htmlFor="password">Password</FormLabel>
             <Link
               component="button"
+              type="button"
               onClick={handleClickOpen}
               variant="body2"
               sx={{ alignSelf: 'baseline' }}

--- a/docs/data/material/getting-started/templates/sign-in/SignIn.js
+++ b/docs/data/material/getting-started/templates/sign-in/SignIn.js
@@ -155,6 +155,7 @@ export default function SignIn(props) {
                 <FormLabel htmlFor="password">Password</FormLabel>
                 <Link
                   component="button"
+                  type="button"
                   onClick={handleClickOpen}
                   variant="body2"
                   sx={{ alignSelf: 'baseline' }}

--- a/docs/data/material/getting-started/templates/sign-in/SignIn.tsx
+++ b/docs/data/material/getting-started/templates/sign-in/SignIn.tsx
@@ -155,6 +155,7 @@ export default function SignIn(props: { disableCustomTheme?: boolean }) {
                 <FormLabel htmlFor="password">Password</FormLabel>
                 <Link
                   component="button"
+                  type="button"
                   onClick={handleClickOpen}
                   variant="body2"
                   sx={{ alignSelf: 'baseline' }}


### PR DESCRIPTION
The UX on https://mui.com/material-ui/getting-started/templates/sign-in/ is completely broken. Pressing <kbd>Enter</kbd> on the password field should submit the form, not trigger the forgot password flow.

https://github.com/user-attachments/assets/7604dcd0-a2f7-46d3-9c1d-17c8842a3d01

I'm going straight to a PR, feels too important. Related to #42609. It was working OK in https://v5.mui.com/material-ui/getting-started/templates/sign-in/.