### PR TITLE
[docs-infra] Open Codesandbox demo with fontsize=12

### DIFF
--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -28,7 +28,7 @@ function openSandbox({ files, codeVariant, initialFile }: any) {
   addHiddenInput(
     form,
     'query',
-    `module=${initialFile}${initialFile.match(/(\.tsx|\.ts|\.js)$/) ? '' : extension}`,
+    `module=${initialFile}${initialFile.match(/(\.tsx|\.ts|\.js)$/) ? '' : extension}&fontsize=12`,
   );
   document.body.appendChild(form);
   form.submit();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Why

The default font-size is too big

**Before**:

https://codesandbox.io/embed/gggjjd?module=/MarketingPage.tsx

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/2e8aab71-b6a3-49b2-8a41-83ede15b3479">

**After**:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/f868330a-bc15-4d90-a6c6-d379b05139d2">


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
