### PR TITLE
[material-ui][Modal] Replace `show` parameter name with `hide` in modal manager

### DIFF
--- a/packages/mui-material/src/Modal/ModalManager.ts
+++ b/packages/mui-material/src/Modal/ModalManager.ts
@@ -19,8 +19,8 @@ function isOverflowing(container: Element): boolean {
   return container.scrollHeight > container.clientHeight;
 }
 
-export function ariaHidden(element: Element, show: boolean): void {
-  if (show) {
+export function ariaHidden(element: Element, hide: boolean): void {
+  if (hide) {
     element.setAttribute('aria-hidden', 'true');
   } else {
     element.removeAttribute('aria-hidden');
@@ -61,7 +61,7 @@ function ariaHiddenSiblings(
   mountElement: Element,
   currentElement: Element,
   elementsToExclude: readonly Element[],
-  show: boolean,
+  hide: boolean,
 ): void {
   const blacklist = [mountElement, currentElement, ...elementsToExclude];
 
@@ -69,7 +69,7 @@ function ariaHiddenSiblings(
     const isNotExcludedElement = !blacklist.includes(element);
     const isNotForbiddenElement = !isAriaHiddenForbiddenOnElement(element);
     if (isNotExcludedElement && isNotForbiddenElement) {
-      ariaHidden(element, show);
+      ariaHidden(element, hide);
     }
   });
 }


### PR DESCRIPTION
While reviewing a PR I noticed the parameter name `show` is confusing because `aria-hidden` should be set to true when `hide` is true, hiding the element from the accessibility tree. This PR renames the parameter from `show` to `hide` for clarity.