### PR TITLE
[system] Add empty interfaces to fix issue with typescript module augmentation 

### DIFF
--- a/packages/mui-system/src/createTheme/createTheme.d.ts
+++ b/packages/mui-system/src/createTheme/createTheme.d.ts
@@ -18,7 +18,7 @@ export interface Typography {}
 export interface Mixins {}
 export interface Shadows {}
 export interface Transitions {}
-export interface zIndex {}
+export interface ZIndex {}
 
 export interface ThemeOptions {
   shape?: ShapeOptions;
@@ -31,7 +31,7 @@ export interface ThemeOptions {
   transitions?: Transitions;
   components?: Record<string, any>;
   typography?: Typography;
-  zIndex?: zIndex;
+  zIndex?: ZIndex;
   unstable_sxConfig?: SxConfig;
 }
 

--- a/packages/mui-system/src/createTheme/createTheme.d.ts
+++ b/packages/mui-system/src/createTheme/createTheme.d.ts
@@ -45,7 +45,7 @@ export interface Theme extends CssContainerQueries {
   components?: Record<string, any>;
   mixins?: Mixins;
   typography?: Typography;
-  zIndex?: unknown;
+  zIndex?: Record<string, number>;
   applyStyles: ApplyStyles<'light' | 'dark'>;
   unstable_sxConfig: SxConfig;
   unstable_sx: (props: SxProps<Theme>) => CSSObject;

--- a/packages/mui-system/src/createTheme/createTheme.d.ts
+++ b/packages/mui-system/src/createTheme/createTheme.d.ts
@@ -14,17 +14,22 @@ export {
 
 export type Direction = 'ltr' | 'rtl';
 
+export interface Typography {}
+export interface Mixins {}
+export interface Shadows {}
+export interface Transitions {}
+
 export interface ThemeOptions {
   shape?: ShapeOptions;
   breakpoints?: BreakpointsOptions;
   direction?: Direction;
-  mixins?: unknown;
+  mixins?: Mixins;
   palette?: Record<string, any>;
-  shadows?: unknown;
+  shadows?: Shadows;
   spacing?: SpacingOptions;
-  transitions?: unknown;
+  transitions?: Transitions;
   components?: Record<string, any>;
-  typography?: unknown;
+  typography?: Typography;
   zIndex?: Record<string, number>;
   unstable_sxConfig?: SxConfig;
 }
@@ -34,12 +39,12 @@ export interface Theme extends CssContainerQueries {
   breakpoints: Breakpoints;
   direction: Direction;
   palette: Record<string, any> & { mode: 'light' | 'dark' };
-  shadows?: unknown;
+  shadows?: Shadows;
   spacing: Spacing;
-  transitions?: unknown;
+  transitions?: Transitions;
   components?: Record<string, any>;
-  mixins?: unknown;
-  typography?: unknown;
+  mixins?: Mixins;
+  typography?: Typography;
   zIndex?: unknown;
   applyStyles: ApplyStyles<'light' | 'dark'>;
   unstable_sxConfig: SxConfig;

--- a/packages/mui-system/src/createTheme/createTheme.d.ts
+++ b/packages/mui-system/src/createTheme/createTheme.d.ts
@@ -18,6 +18,7 @@ export interface Typography {}
 export interface Mixins {}
 export interface Shadows {}
 export interface Transitions {}
+export interface zIndex {}
 
 export interface ThemeOptions {
   shape?: ShapeOptions;
@@ -30,7 +31,7 @@ export interface ThemeOptions {
   transitions?: Transitions;
   components?: Record<string, any>;
   typography?: Typography;
-  zIndex?: Record<string, number>;
+  zIndex?: zIndex;
   unstable_sxConfig?: SxConfig;
 }
 
@@ -45,7 +46,7 @@ export interface Theme extends CssContainerQueries {
   components?: Record<string, any>;
   mixins?: Mixins;
   typography?: Typography;
-  zIndex?: Record<string, number>;
+  zIndex?: zIndex;
   applyStyles: ApplyStyles<'light' | 'dark'>;
   unstable_sxConfig: SxConfig;
   unstable_sx: (props: SxProps<Theme>) => CSSObject;

--- a/packages/mui-system/src/createTheme/createTheme.d.ts
+++ b/packages/mui-system/src/createTheme/createTheme.d.ts
@@ -46,7 +46,7 @@ export interface Theme extends CssContainerQueries {
   components?: Record<string, any>;
   mixins?: Mixins;
   typography?: Typography;
-  zIndex?: zIndex;
+  zIndex?: ZIndex;
   applyStyles: ApplyStyles<'light' | 'dark'>;
   unstable_sxConfig: SxConfig;
   unstable_sx: (props: SxProps<Theme>) => CSSObject;


### PR DESCRIPTION
fix for #43855 to allow typescript module augmentation

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
