### PR TITLE
[code-infra] Fix playwright hash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ commands:
                   corepack prepare pnpm@latest-8 --activate
             - run:
                 name: Prepare playwright hash
-                command: pnpm list --json --filter playwright > /tmp/playwright_info.json
+                command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
             - store_artifacts:
                 name: Debug playwright hash
                 path: /tmp/playwright_info.json
@@ -121,7 +121,7 @@ commands:
                 key: v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
                 paths:
                   # Keep path in sync with "PLAYWRIGHT_BROWSERS_PATH"
-                  # Can't use environment variables for `save_cache` paths (tested in https://app.circleci.com/pipelines/github/mui/material-ui/37813/workflows/5b1e207f-ac8b-44e7-9ba4-d0f9a01f5c55/jobs/223370)
+                  # Can't use environment variables for `save_cache` paths
                   - /tmp/pw-browsers
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ default-job: &default-job
     REACT_VERSION: << parameters.react-version >>
     TEST_GATE: << parameters.test-gate >>
     AWS_REGION_ARTIFACTS: eu-central-1
+    COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
   working_directory: /tmp/material-ui
   docker:
     - image: cimg/node:20.17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,9 +81,9 @@ commands:
             - run:
                 name: Prepare playwright hash
                 command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
-            - store_artifacts:
+            - run:
                 name: Debug playwright hash
-                path: /tmp/playwright_info.json
+                command: cat /tmp/playwright_info.json
             - restore_cache:
                 name: Restore playwright cache
                 keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,9 @@ commands:
                   corepack enable
                   corepack prepare pnpm@latest-8 --activate
             - run:
+                name: Debug playwright hash generation
+                command: pnpm list --recursive --no-color playwright
+            - run:
                 name: Prepare playwright hash
                 command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,22 +75,7 @@ commands:
           steps:
             - run:
                 name: Install pnpm package manager
-                command: |
-                  corepack enable
-                  corepack prepare pnpm@latest-8 --activate
-            - run:
-                name: Debug playwright hash generation
-                command: pnpm list --recursive --no-color playwright
-            - run:
-                name: Prepare playwright hash
-                command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
-            - run:
-                name: Debug playwright hash
-                command: cat /tmp/playwright_info.json
-            - restore_cache:
-                name: Restore playwright cache
-                keys:
-                  - v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
+                command: corepack enable
       - when:
           condition:
             not: << parameters.browsers >>
@@ -117,6 +102,16 @@ commands:
       - when:
           condition: << parameters.browsers >>
           steps:
+            - run:
+                name: Prepare playwright hash
+                command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
+            - run:
+                name: Debug playwright hash
+                command: cat /tmp/playwright_info.json
+            - restore_cache:
+                name: Restore playwright cache
+                keys:
+                  - v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
             - run:
                 name: Install playwright browsers
                 command: pnpm playwright install --with-deps


### PR DESCRIPTION
The cache key calculation is executed before packages are installed, and this always results in an [empty file](https://app.circleci.com/pipelines/github/mui/material-ui/139672/workflows/ff832eda-3881-4af0-bf5d-a743c88ea518/jobs/752892/parallel-runs/0/steps/0-104).
The `--filter` parameter is for filtering workspace packages this command operates on, not to filter listed packages. This command always returns an empty string. The cache key never changes. Thus we're always both downloading an old cache and re-installing playwright browsers.

I'm moving the cache handling steps after the install step and I'm changing the command to filter on installed packages only. It's the positional argument in `pnpm list`. I'm also removing `--json` as it's unnecessary and adding `-r` because `playwright` is not installed at the top level. It's not the most ideal (*) output but probably closest to what we want that is doable with a simple `pnpm` command.

I noticed restoring the cache takes as exactly long as running `playwright install`.

Current situation:
![Screenshot 2024-09-25 at 11 23 05](https://github.com/user-attachments/assets/83e977ef-2a4e-4832-838e-0ae1f13aa471)


After the changes, we see the following numbers:
* Storing the cache takes about ~45s.
* Restoring the cache takes about ~22s
* Installing from cached takes about ~6s
* Installing from fresh takes about ~18s

In Circleci
* [cache miss](https://app.circleci.com/pipelines/github/mui/material-ui/139680/workflows/8bc7e396-1333-435e-a4b2-8845d5d92ac5/jobs/752939)

    ![Screenshot 2024-09-25 at 12 24 15](https://github.com/user-attachments/assets/d89ba67b-630e-4473-8c5e-c394b66816ab)

* [cache hit](https://app.circleci.com/pipelines/github/mui/material-ui/139682/workflows/746e47bf-95d5-4494-9b5e-9c32624cb8c7/jobs/752946)

    ![Screenshot 2024-09-25 at 12 24 04](https://github.com/user-attachments/assets/af8ce08b-f430-4b71-9529-31786b6cec8b)

In both cases this increases the CI time. I propose to remove the cache altogether. ~cc @mui/code-infra for your thoughts~ Superseded by https://github.com/mui/material-ui/pull/43881.

Also removing a dead CircleCi link

--- 

(*) technically this output will invalidate a bit more often than strictly necessary, but we can probably live with it, no need to add extra complexity.