### PR TITLE
[code-infra] Remove custom playwright installation steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,13 +464,13 @@ jobs:
           browsers: true
       - run:
           name: Run visual regression tests
-          command: pnpm test:regressions
+          command: xvfb-run pnpm test:regressions
       - run:
           name: Build packages for fixtures
-          command: pnpm release:build
+          command: xvfb-run pnpm release:build
       - run:
           name: Run visual regression tests using Pigment CSS
-          command: pnpm test:regressions-pigment-css
+          command: xvfb-run pnpm test:regressions-pigment-css
       - run:
           name: Upload screenshots to Argos CI
           command: pnpm test:argos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,13 +100,6 @@ commands:
           name: Install js dependencies
           command: pnpm install
 
-      - when:
-          condition: << parameters.browsers >>
-          steps:
-            - run:
-                name: Install playwright browsers
-                command: pnpm playwright install --with-deps
-
 jobs:
   checkout:
     <<: *default-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ commands:
                   corepack prepare pnpm@latest-8 --activate
             - run:
                 name: Prepare playwright hash
-                command: pnpm list --json --filter playwright > /tmp/playwright_info.json
+                command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
             - store_artifacts:
                 name: Debug playwright hash
                 path: /tmp/playwright_info.json
@@ -121,7 +121,7 @@ commands:
                 key: v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
                 paths:
                   # Keep path in sync with "PLAYWRIGHT_BROWSERS_PATH"
-                  # Can't use environment variables for `save_cache` paths (tested in https://app.circleci.com/pipelines/github/mui/material-ui/37813/workflows/5b1e207f-ac8b-44e7-9ba4-d0f9a01f5c55/jobs/223370)
+                  # Can't use environment variables for `save_cache` paths
                   - /tmp/pw-browsers
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ default-job: &default-job
     REACT_VERSION: << parameters.react-version >>
     TEST_GATE: << parameters.test-gate >>
     AWS_REGION_ARTIFACTS: eu-central-1
+    COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
   working_directory: /tmp/material-ui
   docker:
     - image: cimg/node:20.17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,9 +81,9 @@ commands:
             - run:
                 name: Prepare playwright hash
                 command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
-            - store_artifacts:
+            - run:
                 name: Debug playwright hash
-                path: /tmp/playwright_info.json
+                command: cat /tmp/playwright_info.json
             - restore_cache:
                 name: Restore playwright cache
                 keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,13 +464,13 @@ jobs:
           browsers: true
       - run:
           name: Run visual regression tests
-          command: xvfb-run pnpm test:regressions
+          command: pnpm test:regressions
       - run:
           name: Build packages for fixtures
-          command: xvfb-run pnpm release:build
+          command: pnpm release:build
       - run:
           name: Run visual regression tests using Pigment CSS
-          command: xvfb-run pnpm test:regressions-pigment-css
+          command: pnpm test:regressions-pigment-css
       - run:
           name: Upload screenshots to Argos CI
           command: pnpm test:argos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,9 @@ commands:
                   corepack enable
                   corepack prepare pnpm@latest-8 --activate
             - run:
+                name: Debug playwright hash generation
+                command: pnpm list --recursive --no-color playwright
+            - run:
                 name: Prepare playwright hash
                 command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,6 @@ default-job: &default-job
       type: string
       default: << pipeline.parameters.e2e-base-url >>
   environment:
-    # Keep in sync with "Save playwright cache"
-    PLAYWRIGHT_BROWSERS_PATH: /tmp/pw-browsers
     # expose it globally otherwise we have to thread it from each job to the install command
     BROWSERSTACK_FORCE: << pipeline.parameters.browserstack-force >>
     REACT_VERSION: << parameters.react-version >>
@@ -80,8 +78,10 @@ commands:
           condition:
             not: << parameters.browsers >>
           steps:
-            # See https://stackoverflow.com/a/73411601
-            - run: corepack enable --install-directory ~/bin
+            - run:
+                name: Install pnpm package manager
+                # See https://stackoverflow.com/a/73411601
+                command: corepack enable --install-directory ~/bin
 
       - run:
           name: View install environment
@@ -99,29 +99,13 @@ commands:
       - run:
           name: Install js dependencies
           command: pnpm install
+
       - when:
           condition: << parameters.browsers >>
           steps:
             - run:
-                name: Prepare playwright hash
-                command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
-            - run:
-                name: Debug playwright hash
-                command: cat /tmp/playwright_info.json
-            - restore_cache:
-                name: Restore playwright cache
-                keys:
-                  - v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
-            - run:
                 name: Install playwright browsers
                 command: pnpm playwright install --with-deps
-            - save_cache:
-                name: Save playwright cache
-                key: v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
-                paths:
-                  # Keep path in sync with "PLAYWRIGHT_BROWSERS_PATH"
-                  # Can't use environment variables for `save_cache` paths
-                  - /tmp/pw-browsers
 
 jobs:
   checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,8 +370,6 @@ jobs:
     resource_class: 'medium+'
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
@@ -400,8 +398,6 @@ jobs:
     <<: *default-job
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
@@ -414,8 +410,6 @@ jobs:
     <<: *default-job
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
@@ -429,8 +423,6 @@ jobs:
     <<: *default-job
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
@@ -456,8 +448,6 @@ jobs:
     <<: *default-job
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
@@ -516,8 +506,6 @@ jobs:
     working_directory: /tmp/material-ui/test/bundling/fixtures/next-webpack4/
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -540,8 +528,6 @@ jobs:
     working_directory: /tmp/material-ui/test/bundling/fixtures/next-webpack5/
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -564,8 +550,6 @@ jobs:
     working_directory: /tmp/material-ui/test/bundling/fixtures/create-react-app/
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -588,8 +572,6 @@ jobs:
     working_directory: /tmp/material-ui/test/bundling/fixtures/snowpack/
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -612,8 +594,6 @@ jobs:
     working_directory: /tmp/material-ui/test/bundling/fixtures/vite/
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -636,8 +616,6 @@ jobs:
     working_directory: /tmp/material-ui/test/bundling/fixtures/esbuild/
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -664,8 +642,6 @@ jobs:
     working_directory: /tmp/material-ui/test/bundling/fixtures/gatsby/
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -765,8 +741,6 @@ jobs:
     <<: *default-job
     docker:
       - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,22 +75,7 @@ commands:
           steps:
             - run:
                 name: Install pnpm package manager
-                command: |
-                  corepack enable
-                  corepack prepare pnpm@latest-8 --activate
-            - run:
-                name: Debug playwright hash generation
-                command: pnpm list --recursive --no-color playwright
-            - run:
-                name: Prepare playwright hash
-                command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
-            - run:
-                name: Debug playwright hash
-                command: cat /tmp/playwright_info.json
-            - restore_cache:
-                name: Restore playwright cache
-                keys:
-                  - v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
+                command: corepack enable
       - when:
           condition:
             not: << parameters.browsers >>
@@ -117,6 +102,16 @@ commands:
       - when:
           condition: << parameters.browsers >>
           steps:
+            - run:
+                name: Prepare playwright hash
+                command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
+            - run:
+                name: Debug playwright hash
+                command: cat /tmp/playwright_info.json
+            - restore_cache:
+                name: Restore playwright cache
+                keys:
+                  - v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
             - run:
                 name: Install playwright browsers
                 command: pnpm playwright install --with-deps


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/pull/43880

The caching currently is not working and fixing it decreases performance even more.
In fact it's not even necessary to install those browsers as we use the `mcr.microsoft.com/playwright:v1.47.1-focal` image which comes with the correct ones preinstalled, just have to remove the custom install location so playwright can find them instead of the ones we install after.

We were basically:
* downloading stale browsers from cache
* re-installing latest browsers in a custom location
* on an image that already has the right browsers installed in the default location

This should reduce runtime of jobs that use a browser with ~40s

Also slightly cleaning up the corepack steps

---

To investigate next: is it possible to use the regular node image but with a playwright install step, and what would be the performance impact vs. using `mcr.microsoft.com/playwright:v1.47.1-focal`?  See https://github.com/mui/material-ui/pull/43883