### PR TITLE
[code-infra] Remove playwright docker (experiment)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -440,13 +440,13 @@ jobs:
           browsers: true
       - run:
           name: Run visual regression tests
-          command: xvfb-run pnpm test:regressions
+          command: pnpm test:regressions
       - run:
           name: Build packages for fixtures
-          command: xvfb-run pnpm release:build
+          command: pnpm release:build
       - run:
           name: Run visual regression tests using Pigment CSS
-          command: xvfb-run pnpm test:regressions-pigment-css
+          command: pnpm test:regressions-pigment-css
       - run:
           name: Upload screenshots to Argos CI
           command: pnpm test:argos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,13 +100,6 @@ commands:
           name: Install js dependencies
           command: pnpm install
 
-      - when:
-          condition: << parameters.browsers >>
-          steps:
-            - run:
-                name: Install playwright browsers
-                command: pnpm playwright install --with-deps
-
 jobs:
   checkout:
     <<: *default-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ commands:
                   corepack prepare pnpm@latest-8 --activate
             - run:
                 name: Prepare playwright hash
-                command: pnpm list --json --filter playwright > /tmp/playwright_info.json
+                command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
             - store_artifacts:
                 name: Debug playwright hash
                 path: /tmp/playwright_info.json
@@ -121,7 +121,7 @@ commands:
                 key: v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
                 paths:
                   # Keep path in sync with "PLAYWRIGHT_BROWSERS_PATH"
-                  # Can't use environment variables for `save_cache` paths (tested in https://app.circleci.com/pipelines/github/mui/material-ui/37813/workflows/5b1e207f-ac8b-44e7-9ba4-d0f9a01f5c55/jobs/223370)
+                  # Can't use environment variables for `save_cache` paths
                   - /tmp/pw-browsers
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ default-job: &default-job
     REACT_VERSION: << parameters.react-version >>
     TEST_GATE: << parameters.test-gate >>
     AWS_REGION_ARTIFACTS: eu-central-1
+    COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
   working_directory: /tmp/material-ui
   docker:
     - image: cimg/node:20.17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ default-job: &default-job
     COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
   working_directory: /tmp/material-ui
   docker:
-    - image: cimg/node:20.17
+    - image: cimg/node:20.17-browsers
 
 default-context: &default-context
   context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,9 +81,9 @@ commands:
             - run:
                 name: Prepare playwright hash
                 command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
-            - store_artifacts:
+            - run:
                 name: Debug playwright hash
-                path: /tmp/playwright_info.json
+                command: cat /tmp/playwright_info.json
             - restore_cache:
                 name: Restore playwright cache
                 keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,20 +68,9 @@ commands:
         description: 'Set to true if you intend to any browser (for example with playwright).'
 
     steps:
-      - when:
-          condition: << parameters.browsers >>
-          steps:
-            - run:
-                name: Install pnpm package manager
-                command: corepack enable
-      - when:
-          condition:
-            not: << parameters.browsers >>
-          steps:
-            - run:
-                name: Install pnpm package manager
-                # See https://stackoverflow.com/a/73411601
-                command: corepack enable --install-directory ~/bin
+      - run:
+          name: Install pnpm package manager
+          command: corepack enable
 
       - run:
           name: View install environment
@@ -100,6 +89,12 @@ commands:
           name: Install js dependencies
           command: pnpm install
 
+      - when:
+          condition: << parameters.browsers >>
+          steps:
+            - run:
+                name: Install playwright
+                command: pnpm exec playwright install --with-deps
 jobs:
   checkout:
     <<: *default-job
@@ -368,10 +363,6 @@ jobs:
   test_browser:
     <<: *default-job
     resource_class: 'medium+'
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
@@ -398,10 +389,6 @@ jobs:
           destination: artifact-file
   test_e2e:
     <<: *default-job
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
@@ -412,10 +399,6 @@ jobs:
   test_e2e_website:
     # NOTE: This workflow runs after successful docs deploy. See /test/e2e-website/README.md#ci
     <<: *default-job
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
@@ -427,10 +410,6 @@ jobs:
             PLAYWRIGHT_TEST_BASE_URL: << parameters.e2e-base-url >>
   test_profile:
     <<: *default-job
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
@@ -454,10 +433,6 @@ jobs:
           destination: react-profiler-report/karma
   test_regressions:
     <<: *default-job
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:
@@ -514,10 +489,6 @@ jobs:
   test_bundling_next-webpack4:
     <<: *default-job
     working_directory: /tmp/material-ui/test/bundling/fixtures/next-webpack4/
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -538,10 +509,6 @@ jobs:
   test_bundling_next-webpack5:
     <<: *default-job
     working_directory: /tmp/material-ui/test/bundling/fixtures/next-webpack5/
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -562,10 +529,6 @@ jobs:
   test_bundling_create-react-app:
     <<: *default-job
     working_directory: /tmp/material-ui/test/bundling/fixtures/create-react-app/
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -586,10 +549,6 @@ jobs:
   test_bundling_snowpack:
     <<: *default-job
     working_directory: /tmp/material-ui/test/bundling/fixtures/snowpack/
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -610,10 +569,6 @@ jobs:
   test_bundling_vite:
     <<: *default-job
     working_directory: /tmp/material-ui/test/bundling/fixtures/vite/
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -634,10 +589,6 @@ jobs:
   test_bundling_esbuild:
     <<: *default-job
     working_directory: /tmp/material-ui/test/bundling/fixtures/esbuild/
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -662,10 +613,6 @@ jobs:
   test_bundling_gatsby:
     <<: *default-job
     working_directory: /tmp/material-ui/test/bundling/fixtures/gatsby/
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout:
           path: /tmp/material-ui
@@ -763,10 +710,6 @@ jobs:
             DANGER_COMMAND: reportBundleSize
   test_benchmark:
     <<: *default-job
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.47.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
       - install_js:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,9 @@ commands:
                   corepack enable
                   corepack prepare pnpm@latest-8 --activate
             - run:
+                name: Debug playwright hash generation
+                command: pnpm list --recursive --no-color playwright
+            - run:
                 name: Prepare playwright hash
                 command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -440,13 +440,13 @@ jobs:
           browsers: true
       - run:
           name: Run visual regression tests
-          command: pnpm test:regressions
+          command: xvfb-run pnpm test:regressions
       - run:
           name: Build packages for fixtures
-          command: pnpm release:build
+          command: xvfb-run pnpm release:build
       - run:
           name: Run visual regression tests using Pigment CSS
-          command: pnpm test:regressions-pigment-css
+          command: xvfb-run pnpm test:regressions-pigment-css
       - run:
           name: Upload screenshots to Argos CI
           command: pnpm test:argos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,8 @@ commands:
     steps:
       - run:
           name: Install pnpm package manager
-          command: corepack enable
+          # See https://stackoverflow.com/a/73411601
+          command: corepack enable --install-directory ~/bin
 
       - run:
           name: View install environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,6 @@ default-job: &default-job
       type: string
       default: << pipeline.parameters.e2e-base-url >>
   environment:
-    # Keep in sync with "Save playwright cache"
-    PLAYWRIGHT_BROWSERS_PATH: /tmp/pw-browsers
     # expose it globally otherwise we have to thread it from each job to the install command
     BROWSERSTACK_FORCE: << pipeline.parameters.browserstack-force >>
     REACT_VERSION: << parameters.react-version >>
@@ -80,8 +78,10 @@ commands:
           condition:
             not: << parameters.browsers >>
           steps:
-            # See https://stackoverflow.com/a/73411601
-            - run: corepack enable --install-directory ~/bin
+            - run:
+                name: Install pnpm package manager
+                # See https://stackoverflow.com/a/73411601
+                command: corepack enable --install-directory ~/bin
 
       - run:
           name: View install environment
@@ -99,29 +99,13 @@ commands:
       - run:
           name: Install js dependencies
           command: pnpm install
+
       - when:
           condition: << parameters.browsers >>
           steps:
             - run:
-                name: Prepare playwright hash
-                command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
-            - run:
-                name: Debug playwright hash
-                command: cat /tmp/playwright_info.json
-            - restore_cache:
-                name: Restore playwright cache
-                keys:
-                  - v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
-            - run:
                 name: Install playwright browsers
                 command: pnpm playwright install --with-deps
-            - save_cache:
-                name: Save playwright cache
-                key: v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
-                paths:
-                  # Keep path in sync with "PLAYWRIGHT_BROWSERS_PATH"
-                  # Can't use environment variables for `save_cache` paths
-                  - /tmp/pw-browsers
 
 jobs:
   checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,22 +75,7 @@ commands:
           steps:
             - run:
                 name: Install pnpm package manager
-                command: |
-                  corepack enable
-                  corepack prepare pnpm@latest-8 --activate
-            - run:
-                name: Debug playwright hash generation
-                command: pnpm list --recursive --no-color playwright
-            - run:
-                name: Prepare playwright hash
-                command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
-            - run:
-                name: Debug playwright hash
-                command: cat /tmp/playwright_info.json
-            - restore_cache:
-                name: Restore playwright cache
-                keys:
-                  - v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
+                command: corepack enable
       - when:
           condition:
             not: << parameters.browsers >>
@@ -117,6 +102,16 @@ commands:
       - when:
           condition: << parameters.browsers >>
           steps:
+            - run:
+                name: Prepare playwright hash
+                command: pnpm list --recursive --no-color playwright > /tmp/playwright_info.json
+            - run:
+                name: Debug playwright hash
+                command: cat /tmp/playwright_info.json
+            - restore_cache:
+                name: Restore playwright cache
+                keys:
+                  - v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
             - run:
                 name: Install playwright browsers
                 command: pnpm playwright install --with-deps


### PR DESCRIPTION
Further simplify https://github.com/mui/material-ui/pull/43881 by removing the playwright docker image and installing the browsers directly:

- the setup step decreases from ~23s to ~0s
- the new playwright install step ranges from ~23s to ~41s

This is a decrease in terms of perfomance, but it could simplify our setup, and allow us to control the Node.js version across all jobs

--- 

Seems to have font problems