### PR TITLE
use :not(:has(...)) to resolve subtree specificity issues when using CSS vars

### DIFF
--- a/packages/mui-system/src/createTheme/applyStyles.test.ts
+++ b/packages/mui-system/src/createTheme/applyStyles.test.ts
@@ -81,4 +81,47 @@ describe('applyStyles', () => {
     const styles = { background: '#e5e5e5' };
     expect(applyStyles.call(theme, 'light', styles)).to.deep.equal(styles);
   });
+
+  it('should exclude single other color scheme when defined', () => {
+    const theme = {
+      vars: {},
+      colorSchemes: { light: true, dark: true },
+      getColorSchemeSelector: (colorScheme: string) => {
+        return `.${colorScheme}`;
+      },
+    };
+    const styles = { background: '#e5e5e5' };
+    expect(applyStyles.call(theme, 'light', styles)).to.deep.equal({
+      '*:where(.light):not(:has(* .dark)) &': styles,
+    });
+  });
+
+  it('should exclude multiple other color schemes when defined', () => {
+    const theme = {
+      vars: {},
+      colorSchemes: { light: true, dark: true, contrast: true },
+      getColorSchemeSelector: (colorScheme: string) => {
+        return `.${colorScheme}`;
+      },
+    };
+    const styles = { background: '#e5e5e5' };
+    expect(applyStyles.call(theme, 'light', styles)).to.deep.equal({
+      '*:where(.light):not(:has(* .dark, * .contrast)) &': styles,
+    });
+  });
+
+  it('should exclude other themes when used with data selector', () => {
+    const theme = {
+      vars: {},
+      colorSchemes: { light: true, dark: true, contrast: true },
+      getColorSchemeSelector: (colorScheme: string) => {
+        return `[data-color-scheme-${colorScheme}]`;
+      },
+    };
+    const styles = { background: '#e5e5e5' };
+    expect(applyStyles.call(theme, 'light', styles)).to.deep.equal({
+      '*:where([data-color-scheme-light]):not(:has(* [data-color-scheme-dark], * [data-color-scheme-contrast])) &':
+        styles,
+    });
+  });
 });

--- a/packages/mui-system/src/createTheme/applyStyles.ts
+++ b/packages/mui-system/src/createTheme/applyStyles.ts
@@ -80,8 +80,19 @@ export default function applyStyles<K extends string>(key: K, styles: CSSObject)
       return styles;
     }
     if (selector.includes('data-') || selector.includes('.')) {
+      // Filter out child elements that might be forcing another theme
+      let excludeOtherThemesSelector = '';
+      const otherThemes = Object.keys(theme.colorSchemes).filter((n) => n !== key);
+      if (otherThemes.length > 0) {
+        const otherThemesSelector = otherThemes
+          // Optional chaining is to make TS happy, but it's actually not optional because of line 74
+          .map((s) => `* ${theme.getColorSchemeSelector?.(s).replace(/\s*&$/, '')}`)
+          .join(', ');
+
+        excludeOtherThemesSelector = `:not(:has(${otherThemesSelector}))`;
+      }
       // '*' is required as a workaround for Emotion issue (https://github.com/emotion-js/emotion/issues/2836)
-      selector = `*:where(${selector.replace(/\s*&$/, '')}) &`;
+      selector = `*:where(${selector.replace(/\s*&$/, '')})${excludeOtherThemesSelector} &`;
     }
     return {
       [selector]: styles,


### PR DESCRIPTION
I believe we can leverage `:not(:has(...))` to resolve the specificity issues outlined in https://github.com/mui/material-ui/issues/43824, as the selector should only match the parent that does not have a child element with a conflicting theme selector applied to it.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Resolves https://github.com/mui/material-ui/issues/43824

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Exampe

- https://github.com/rossipedia/mui-css-vars-with-patch
- https://stackblitz.com/~/github.com/rossipedia/mui-css-vars-with-patch