### PR TITLE
[code-infra] Optimize regression tests

### DIFF
--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -7,7 +7,7 @@ import JoyBox from '@mui/joy/Box';
 import { CssVarsProvider } from '@mui/joy/styles';
 
 function TestViewer(props) {
-  const { children } = props;
+  const { children, path } = props;
 
   // We're simulating `act(() => ReactDOM.render(children))`
   // In the end children passive effects should've been flushed.
@@ -82,6 +82,7 @@ function TestViewer(props) {
             <JoyBox
               aria-busy={!ready}
               data-testid="testcase"
+              data-testpath={path}
               sx={{ bgcolor: 'background.body', ...viewerBoxSx }}
             >
               {children}
@@ -91,6 +92,7 @@ function TestViewer(props) {
           <Box
             aria-busy={!ready}
             data-testid="testcase"
+            data-testpath={path}
             sx={{ bgcolor: 'background.default', ...viewerBoxSx }}
           >
             {children}
@@ -103,6 +105,7 @@ function TestViewer(props) {
 
 TestViewer.propTypes = {
   children: PropTypes.node.isRequired,
+  path: PropTypes.string.isRequired,
 };
 
 export default TestViewer;

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -31,7 +31,7 @@ async function main() {
 
   // Wait for all requests to finish.
   // This should load shared resources such as fonts.
-  await page.goto(`${baseUrl}#no-dev`, { waitUntil: 'networkidle0' });
+  await page.goto(`${baseUrl}#dev`, { waitUntil: 'networkidle0' });
   // If we still get flaky fonts after awaiting this try `document.fonts.ready`
   await page.waitForSelector('[data-webfontloader="active"]', { state: 'attached' });
 
@@ -50,18 +50,21 @@ async function main() {
   });
   routes = routes.map((route) => route.replace(baseUrl, ''));
 
-  async function renderFixture(index) {
+  /**
+   * @param {string} route
+   */
+  async function renderFixture(route) {
     // Use client-side routing which is much faster than full page navigation via page.goto().
-    // Could become an issue with test isolation.
-    // If tests are flaky due to global pollution switch to page.goto(route);
-    // puppeteers built-in click() times out
-    await page.$eval(`#tests li:nth-of-type(${index + 1}) a`, (link) => {
-      link.click();
-    });
-    // Move cursor offscreen to not trigger unwanted hover effects.
-    page.mouse.move(0, 0);
+    await page.evaluate((_route) => {
+      window.muiFixture.navigate(`${_route}#no-dev`);
+    }, route);
 
-    const testcase = await page.waitForSelector('[data-testid="testcase"]:not([aria-busy="true"])');
+    // Move cursor offscreen to not trigger unwanted hover effects.
+    await page.mouse.move(0, 0);
+
+    const testcase = await page.waitForSelector(
+      `[data-testid="testcase"][data-testpath="${route}"]:not([aria-busy="true"])`,
+    );
 
     return testcase;
   }
@@ -94,24 +97,21 @@ async function main() {
       await browser.close();
     });
 
-    routes.forEach((route, index) => {
+    routes.forEach((route) => {
       it(`creates screenshots of ${route}`, async function test() {
         // With the playwright inspector we might want to call `page.pause` which would lead to a timeout.
         if (process.env.PWDEBUG) {
           this.timeout(0);
         }
 
-        const testcase = await renderFixture(index);
+        const testcase = await renderFixture(route);
         await takeScreenshot({ testcase, route });
       });
     });
 
     describe('Rating', () => {
       it('should handle focus-visible correctly', async () => {
-        const index = routes.findIndex(
-          (route) => route === '/regression-Rating/FocusVisibleRating',
-        );
-        const testcase = await renderFixture(index);
+        const testcase = await renderFixture('/regression-Rating/FocusVisibleRating');
         await page.keyboard.press('Tab');
         await takeScreenshot({ testcase, route: '/regression-Rating/FocusVisibleRating2' });
         await page.keyboard.press('ArrowLeft');
@@ -119,10 +119,7 @@ async function main() {
       });
 
       it('should handle focus-visible with precise ratings correctly', async () => {
-        const index = routes.findIndex(
-          (route) => route === '/regression-Rating/PreciseFocusVisibleRating',
-        );
-        const testcase = await renderFixture(index);
+        const testcase = await renderFixture('/regression-Rating/PreciseFocusVisibleRating');
         await page.keyboard.press('Tab');
         await takeScreenshot({ testcase, route: '/regression-Rating/PreciseFocusVisibleRating2' });
         await page.keyboard.press('ArrowRight');


### PR DESCRIPTION
* Remove the need for 1300+ links to be rendered in the DOM while running regression tests
* Make it possible to scope a single test in running `test:regressions`. Just add `route = ['<path>']` at https://github.com/Janpot/material-ui/blob/632de3d7de97eadb3cc225aca5a3e3a4ba25fb10/test/regressions/index.test.js#L51
* Remove the links during running the tests (only render them once on initial render to determine which tests to run)

Results:
* On my local, about ~15s decrease in runtime (~11%)
* Gained possibility to scope one or more tests in the production run, very helpful for debugging https://github.com/mui/material-ui/pull/43890