### PR TITLE
[code-infra] Fix flaky dashboard screenshot

### DIFF
--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -7,15 +7,7 @@ async function main() {
   const screenshotDir = path.resolve(__dirname, './screenshots/chrome');
 
   const browser = await playwright.chromium.launch({
-    args: [
-      '--font-render-hinting=none',
-      // Playwright hides scrollbars when taking screenshots, this causes the width to slightly change
-      // for a brief moment. Some UI, such as responsive charts measure DOM elements in effects and
-      // update the UI based on the width. This causes a race condition where the screenshot is taken
-      // before the UI is updated. This makes the screenshot flaky. We can just always hide the scrollbar
-      // to prevent this.
-      '--hide-scrollbars',
-    ],
+    args: ['--font-render-hinting=none'],
     // otherwise the loaded google Roboto font isn't applied
     headless: false,
   });

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -7,7 +7,15 @@ async function main() {
   const screenshotDir = path.resolve(__dirname, './screenshots/chrome');
 
   const browser = await playwright.chromium.launch({
-    args: ['--font-render-hinting=none'],
+    args: [
+      '--font-render-hinting=none',
+      // Playwright hides scrollbars when taking screenshots, this causes the width to slightly change
+      // for a brief moment. Some UI, such as responsive charts measure DOM elements in effects and
+      // update the UI based on the width. This causes a race condition where the screenshot is taken
+      // before the UI is updated. This makes the screenshot flaky. We can just always hide the scrollbar
+      // to prevent this.
+      '--hide-scrollbars',
+    ],
     // otherwise the loaded google Roboto font isn't applied
     headless: false,
   });

--- a/test/regressions/template.html
+++ b/test/regressions/template.html
@@ -7,6 +7,15 @@
     <style>
       body {
         background-color: white;
+        /* 
+        Hide scrollbars but keep scrollable. Playwright hides scrollbar when capturing a screenshot on an element
+        or with fullPage: true. When the body has a scrollbar, this causes a brief layout shift.
+        */
+        -ms-overflow-style: none; /* Internet Explorer 10+ */
+        scrollbar-width: none; /* Firefox */
+      }
+      body::-webkit-scrollbar {
+        display: none; /* Safari and Chrome */
       }
     </style>
   </head>


### PR DESCRIPTION
Been debugging the flakyness of the dashboard screenshot. After throttling the playwright browser, it becomes apparent there is a horizontal layout shift while running the test:

https://github.com/user-attachments/assets/793e9a3e-4473-469a-9eff-5677fbdc0bd2

This shift doesn't happen when just visiting the page. Debugging further reveals that it is caused by the `page.screenshot` call. Apparently, playwright [hides scrollbars](https://github.com/microsoft/playwright/issues/30228) when taking the screenshot. It looks like there's a race condition between the responsive charts reacting to a width change and playwright capturing the page. This causes a flaky screenshot.

~It looks like we can remedy this by always hiding scrollbars, through the `--hide-scrollbars` flag.~
This causes every scrollbar to disappear

It looks like we can remedy this by always hiding the scrollbar on the `body`.


https://github.com/user-attachments/assets/ea90926e-8e89-42ce-b27b-174ef83bbd38

