### PR TITLE
[Lab][Masonry] Fix hidden first item causing layout to collapseFix masonry hidden item

### DIFF
--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -220,15 +220,21 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
       }
 
       const masonry = masonryRef.current;
-      const masonryFirstChild = masonryRef.current.firstChild;
+      // Find the first visible child
+      const masonryFirstVisibleChild = Array.from(masonry.childNodes).find((child) => {
+        const childStyle = window.getComputedStyle(child);
+        return childStyle.display !== 'none' && childStyle.visibility !== 'hidden';
+      });
+      if (!masonryFirstVisibleChild) {
+        return;
+      }
       const parentWidth = masonry.clientWidth;
-      const firstChildWidth = masonryFirstChild.clientWidth;
+      const firstChildWidth = masonryFirstVisibleChild.clientWidth;
 
       if (parentWidth === 0 || firstChildWidth === 0) {
         return;
       }
-
-      const firstChildComputedStyle = window.getComputedStyle(masonryFirstChild);
+      const firstChildComputedStyle = window.getComputedStyle(masonryFirstVisibleChild);
       const firstChildMarginLeft = parseToNumber(firstChildComputedStyle.marginLeft);
       const firstChildMarginRight = parseToNumber(firstChildComputedStyle.marginRight);
 
@@ -243,6 +249,8 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
         if (child.nodeType !== Node.ELEMENT_NODE || child.dataset.class === 'line-break' || skip) {
           return;
         }
+        // Get the visibility of the child element to check if it has appeared in the window
+        const childVisibility = child.style.visibility;
         const childComputedStyle = window.getComputedStyle(child);
         const childMarginTop = parseToNumber(childComputedStyle.marginTop);
         const childMarginBottom = parseToNumber(childComputedStyle.marginBottom);
@@ -250,7 +258,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
         const childHeight = parseToNumber(childComputedStyle.height)
           ? Math.ceil(parseToNumber(childComputedStyle.height)) + childMarginTop + childMarginBottom
           : 0;
-        if (childHeight === 0) {
+        if (childHeight === 0 && childVisibility === 'hidden') {
           skip = true;
           return;
         }


### PR DESCRIPTION
Closes #42611

## Description

This pull request addresses a bug in the Masonry layout component where hiding the first item causes all remaining items to collapse into a single column. The expected behavior is that the remaining items should continue to distribute evenly across the columns, maintaining the Masonry layout's intended structure and visual consistency.

## Why the Bug Was Occurring

The Masonry component relies on the first child element to calculate the width and margins needed for layout calculations. When the first child is hidden (e.g., with `display: none` or `visibility: hidden`), the component still attempts to use it for these calculations. This results in zero values for width and margins, causing the layout algorithm to miscalculate the number of columns and forcing all items into a single column.

## How the Changes Fix It

The fix involves updating the layout calculation logic to identify and use the first *visible* child instead of always using the first child node. By finding the first child that is not hidden, we ensure that the layout calculations use valid measurements.

Changes made:

- Modified the `handleResize` function in the Masonry component to:

  - Iterate over `masonry.childNodes` to find the first child where `display` is not `none` and `visibility` is not `hidden`.
  - Use this first visible child for calculating the parent width, child width, and margins.

This change ensures that even if the first item is hidden, the Masonry layout correctly distributes the remaining items across the specified number of columns.

## Example Demonstrating the Fix

### Steps to Reproduce and Verify the Fix

1. **Set Up a Masonry Layout**

   Create a Masonry layout with several items:

   ```jsx
   import * as React from 'react';
   import Masonry from '@mui/lab/Masonry';
   import Box from '@mui/material/Box';

   const heights = [150, 30, 90, 70, 110, 150, 130, 80];

   export default function MasonryExample() {
     const [hideFirstItem, setHideFirstItem] = React.useState(true);

     return (
       <Box sx={{ width: 500, minHeight: 400 }}>
         <button onClick={() => setHideFirstItem(!hideFirstItem)}>
           Toggle First Item Visibility
         </button>
         <Masonry columns={3} spacing={2}>
           {heights.map((height, index) => (
             <Box
               key={index}
               sx={{
                 display: index === 0 && hideFirstItem ? 'none' : 'block',
                 height,
                 bgcolor: 'primary.main',
               }}
             >
               Item {index + 1}
             </Box>
           ))}
         </Masonry>
       </Box>
     );
   }
   ```

2. **Hide the First Item**

   By default, the first item is hidden (`hideFirstItem` is `true`).

3. **Observe the Layout**

   - **Before the Fix:** The remaining items collapse into a single column when the first item is hidden.
   - **After the Fix:** The remaining items are evenly distributed across the specified number of columns.

4. **Toggle the First Item's Visibility**

   - Click the "Toggle First Item Visibility" button to show or hide the first item.
   - Observe that the Masonry layout updates correctly, maintaining consistent item distribution regardless of the first item's visibility.

You can view a live example of the fixed behavior here: [Masonry Hidden First Item Fix Example](https://codesandbox.io/s/masonry-hidden-first-item-fix-example)

## Changes

- **Modified `handleResize` Function**

  - Updated the logic to find the first visible child for accurate layout calculations.
  - Ensured that only necessary changes are included to fix the specific issue.

## Related Issues

- Addresses issue #42611.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).