### PR TITLE
[icons] Reduce Material Icon page size

### DIFF
--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -128,19 +128,15 @@ const StyledSvgIcon = styled(SvgIcon)(({ theme }) => ({
   },
 }));
 
-const handleIconClick = (event) => {
-  const { iconName, iconTheme } = event.currentTarget.dataset;
-
-  if (Math.random() < 0.1) {
-    window.gtag('event', 'material-icons', {
-      eventAction: 'click',
-      eventLabel: iconName,
-    });
-    window.gtag('event', 'material-icons-theme', {
-      eventAction: 'click',
-      eventLabel: iconTheme,
-    });
-  }
+const handleIconClick = (icon) => () => {
+  window.gtag('event', 'material-icons', {
+    eventAction: 'click',
+    eventLabel: icon.name,
+  });
+  window.gtag('event', 'material-icons-theme', {
+    eventAction: 'click',
+    eventLabel: icon.theme,
+  });
 };
 
 function handleLabelClick(event) {
@@ -153,9 +149,7 @@ function Icon(props) {
   return (
     <StyledIcon
       key={icon.importName}
-      onClick={handleIconClick}
-      data-icon-theme={icon.theme}
-      data-icon-name={icon.name}
+      onClick={Math.random() < 0.1 ? handleIconClick(icon) : null}
     >
       <StyledSvgIcon
         component={icon.Component}


### PR DESCRIPTION
Before
<img width="638" alt="SCR-20240928-kzud" src="https://github.com/user-attachments/assets/bf3c39d5-cab4-4ee7-a896-73b1c13dd6e2">

After
<img width="637" alt="SCR-20240928-kzqp" src="https://github.com/user-attachments/assets/7854badc-19c7-4371-8ac5-8889a297a43e">

Not a big difference ~7% saving, but it helps, the page is big. This is flagged in https://app.ahrefs.com/site-audit/3992793/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2Csize%2CtimeToFirstByte%2CloadingTime%2Cdepth%2Ccompliant%2CincomingAllLinks%2Corigin&current=27-09-2024T024913&filterId=709f929d4b01712e0ab256af7bad8fea&issueId=c64da874-d0f4-11e7-8ed1-001e67ed4656&sorting=-pageRating. Since we compet for SEO for this page, it makes sense to me, it's a quick-win.

Preview https://deploy-preview-43911--material-ui.netlify.app/material-ui/material-icons/