### PR TITLE
[material-ui][Dialog] Fix Keyboard scrolling doesn't work in fullscreen modal ( #42989 )

### DIFF
--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
@@ -181,7 +181,11 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
     };
 
     const focusScrollableElement = () => {
-      const scrollableElement = findScrollableElement(rootRef.current!);
+      if (!rootRef.current) {
+        return;
+      }
+
+      const scrollableElement = findScrollableElement(rootRef.current);
 
       if (scrollableElement) {
         scrollableElement.tabIndex = -1;
@@ -190,7 +194,6 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
         rootRef.current.focus();
       }
     };
-
     if (!rootRef.current.contains(doc.activeElement)) {
       if (!rootRef.current.hasAttribute('tabIndex')) {
         if (process.env.NODE_ENV !== 'production') {

--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
@@ -165,6 +165,32 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
 
     const doc = ownerDocument(rootRef.current);
 
+    const findScrollableElement = (element: HTMLElement): HTMLElement | null => {
+      if (element.scrollHeight > element.clientHeight) {
+        return element;
+      }
+
+      for (const child of Array.from(element.children) as HTMLElement[]) {
+        const scrollable = findScrollableElement(child);
+        if (scrollable) {
+          return scrollable;
+        }
+      }
+
+      return null;
+    };
+
+    const focusScrollableElement = () => {
+      const scrollableElement = findScrollableElement(rootRef.current!);
+
+      if (scrollableElement) {
+        scrollableElement.tabIndex = -1;
+        scrollableElement.focus();
+      } else {
+        rootRef.current.focus();
+      }
+    };
+
     if (!rootRef.current.contains(doc.activeElement)) {
       if (!rootRef.current.hasAttribute('tabIndex')) {
         if (process.env.NODE_ENV !== 'production') {
@@ -180,7 +206,7 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
       }
 
       if (activated.current) {
-        rootRef.current.focus();
+        focusScrollableElement();
       }
     }
 


### PR DESCRIPTION
Fixes #42989 

Summary 
- When in fullscreen mode, event.target.scrollHeight and event.target.clientHeight are equal, preventing any scrolling. 
To address this:

1. If rootRef.current is scrollable, we now focus on the existing rootRef.current.
2. If rootRef.current is not scrollable, we find and focus on the first scrollable child element.

This modification ensures proper focus and scrolling behavior in fullscreen scenarios.

AS-IS 

https://github.com/user-attachments/assets/8028295c-3b41-4965-b3fa-d343a2f9e264





TO-BE

https://github.com/user-attachments/assets/9cbf53fa-5e1a-421a-be81-e56fa820f6b5


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
