### PR TITLE
[test] Point Istanbul to correct URL

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -142,7 +142,7 @@ Here is an [example](https://github.com/mui/material-ui/blob/814fb60bbd8e500517b
 
 `pnpm test:coverage:html`
 
-When running this command you should get under `coverage/index.html` a full coverage report in HTML format. This is created using [Istanbul](https://istanbul-js.org)'s HTML reporter and gives good data such as line, branch and function coverage.
+When running this command you should get under `coverage/index.html` a full coverage report in HTML format. This is created using [Istanbul](https://istanbul.js.org)'s HTML reporter and gives good data such as line, branch and function coverage.
 
 ### DOM API level
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

I was browisng through test ReadMe, found istanbul package url is wrong

previous url: https://istanbul-js.org (Site not found)
updated url: https://istanbul.js.org

Opened same PR in base-ui repo as well: https://github.com/mui/base-ui/pull/657