### PR TITLE
[material-ui][Autocomplete] Fix results outside limit count are shown…

### DIFF
--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -32,7 +32,7 @@ export function createFilterOptions(config = {}) {
     if (ignoreAccents) {
       input = stripDiacritics(input);
     }
-
+    options = typeof limit === 'number' ? options.slice(0, limit) : options;
     const filteredOptions = !input
       ? options
       : options.filter((option) => {
@@ -47,7 +47,7 @@ export function createFilterOptions(config = {}) {
           return matchFrom === 'start' ? candidate.startsWith(input) : candidate.includes(input);
         });
 
-    return typeof limit === 'number' ? filteredOptions.slice(0, limit) : filteredOptions;
+    return filteredOptions;
   };
 }
 

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
@@ -124,6 +124,35 @@ describe('useAutocomplete', () => {
           options[1],
         ]);
       });
+
+      it('filters only from the limited set of options', () => {
+        const filterOptions = createFilterOptions({ limit: 2 });
+
+        const getOptionLabel = (option) => option.name;
+        const options = [
+          {
+            id: '1234',
+            name: 'a1',
+          },
+          {
+            id: '5678',
+            name: 'a2',
+          },
+          {
+            id: '9abc',
+            name: 'a3',
+          },
+          {
+            id: '9abc',
+            name: 'a4',
+          },
+        ];
+        // can only search from the first two options
+        expect(filterOptions(options, { inputValue: 'a1', getOptionLabel })).to.deep.equal([
+          options[0],
+        ]);
+        expect(filterOptions(options, { inputValue: 'a3', getOptionLabel })).to.deep.equal([]);
+      });
     });
 
     describe('option: matchFrom', () => {


### PR DESCRIPTION
Closes  #42384

Summary
- Background: Users can filter out results outside the limit count of options when the limit is provided to the createFilterOptions
- Solution: slice the option by `limit` before filter through input value.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
