### PR TITLE
[code-infra] Fix flaky dashboard screenshot - take 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,7 @@ jobs:
           command: xvfb-run pnpm test:regressions
       - run:
           name: Build packages for fixtures
-          command: xvfb-run pnpm release:build
+          command: pnpm release:build
       - run:
           name: Run visual regression tests using Pigment CSS
           command: xvfb-run pnpm test:regressions-pigment-css

--- a/apps/pigment-css-vite-app/src/pages/fixtures/index.test.js
+++ b/apps/pigment-css-vite-app/src/pages/fixtures/index.test.js
@@ -50,6 +50,13 @@ async function main() {
   routes = routes.map((route) => route.replace(baseUrl, ''));
 
   async function renderFixture(index) {
+    await page.evaluate(() => {
+      // Playwright hides scrollbar when capturing a screenshot on an element or with fullPage: true.
+      // When the body has a scrollbar, this causes a brief layout shift. Disable the body overflow
+      // altogether to prevent this
+      window.document.body.style.overflow = 'hidden';
+    });
+
     // Use client-side routing which is much faster than full page navigation via page.goto().
     // Could become an issue with test isolation.
     // If tests are flaky due to global pollution switch to page.goto(route);

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -57,7 +57,7 @@ async function main() {
     await page.evaluate((_route) => {
       // Use client-side routing which is much faster than full page navigation via page.goto().
       window.muiFixture.navigate(`${_route}#no-dev`);
-  
+
       // Playwright hides scrollbar when capturing a screenshot on an element or with fullPage: true.
       // When the body has a scrollbar, this causes a brief layout shift. Disable the body overflow
       // altogether to prevent this

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -58,6 +58,14 @@ async function main() {
     await page.$eval(`#tests li:nth-of-type(${index + 1}) a`, (link) => {
       link.click();
     });
+
+    // Playwright hides scrollbar when capturing a screenshot on an element or with fullPage: true.
+    // When the body has a scrollbar, this causes a brief layout shift. Disable the body overflow
+    // altogether to prevent this
+    await page.evaluate(() => {
+      window.document.body.style.overflow = 'hidden';
+    });
+
     // Move cursor offscreen to not trigger unwanted hover effects.
     page.mouse.move(0, 0);
 

--- a/test/regressions/template.html
+++ b/test/regressions/template.html
@@ -7,15 +7,6 @@
     <style>
       body {
         background-color: white;
-        /* 
-        Hide scrollbars but keep scrollable. Playwright hides scrollbar when capturing a screenshot on an element
-        or with fullPage: true. When the body has a scrollbar, this causes a brief layout shift.
-        */
-        -ms-overflow-style: none; /* Internet Explorer 10+ */
-        scrollbar-width: none; /* Firefox */
-      }
-      body::-webkit-scrollbar {
-        display: none; /* Safari and Chrome */
       }
     </style>
   </head>


### PR DESCRIPTION
Still seeing flakyness after https://github.com/mui/material-ui/pull/43890. I could reproduce locally after switching the scrollbar visibility setting on my laptop. Just disabling overflow on the body seems to fix it reliably for any of the settings. There is now also a noticable difference in all screenshots of elements that overflow. Looks like this change is an improvement for those screenshots as well.

Doing the same for pigment regression tests.

Make sure to check out the [changed screenshots](https://app.argos-ci.com/mui/material-ui/builds/32503/111246087)
