### PR TITLE
next.config.js to next.config.mjs in nextjs-pages-router-ts example

### DIFF
--- a/examples/material-ui-nextjs-pages-router-ts/next.config.mjs
+++ b/examples/material-ui-nextjs-pages-router-ts/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;


### PR DESCRIPTION
In this PR, I've converted next.config.js to next.config.mjs. Also I've changed it to align with Next.js recommendations for ES module syntax.

#42568