### PR TITLE
[core] Fix eslint-plugin-react-compiler issues in usePagination tests

### DIFF
--- a/packages/mui-material/src/usePagination/usePagination.test.js
+++ b/packages/mui-material/src/usePagination/usePagination.test.js
@@ -8,7 +8,7 @@ describe('usePagination', () => {
   const serialize = (items) => items.map((item) => (item.type === 'page' ? item.page : item.type));
 
   const renderHook = (useHook) => {
-    const result = { current: null };
+    const result = React.createRef();
     function TestCase() {
       const hookResult = useHook();
       React.useEffect(() => {

--- a/packages/mui-material/src/usePagination/usePagination.test.js
+++ b/packages/mui-material/src/usePagination/usePagination.test.js
@@ -8,9 +8,12 @@ describe('usePagination', () => {
   const serialize = (items) => items.map((item) => (item.type === 'page' ? item.page : item.type));
 
   const renderHook = (useHook) => {
-    const result = {};
+    const result = { current: null };
     function TestCase() {
-      result.current = useHook();
+      const hookResult = useHook();
+      React.useEffect(() => {
+        result.current = hookResult;
+      }, [hookResult]);
       return null;
     }
     render(<TestCase />);


### PR DESCRIPTION
Fixed eslint issue with usePagination.test.js file by using React.useEffect hook to update hook after execution, error: Writing to a variable defined outside a component or hook is not allowed. Consider using an effecteslint(react-compiler/react-compiler).

Ran the test file and had 16 tests passed, so should work :) 

Fix for the  packages/mui-material/src/usePagination/usePagination.test.js file which the box was unchecked from issue #42564 , where issue #43117 still contained the eslint error.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
