### PR TITLE
[ThemeProvider] Support setting default mode

### DIFF
--- a/docs/data/material/customization/dark-mode/dark-mode.md
+++ b/docs/data/material/customization/dark-mode/dark-mode.md
@@ -134,7 +134,7 @@ To instantly switch between color schemes with no transition, apply the `disable
 
 ## Setting the default mode
 
-When `colorSchemes` is provided, the default mode is `system`, which means the app will use the system preference when users first visit the site.
+When `colorSchemes` is provided, the default mode is `system`, which means the app uses the system preference when users first visit the site.
 
 To set a different default mode, pass the `defaultMode` prop to the ThemeProvider component:
 

--- a/docs/data/material/customization/dark-mode/dark-mode.md
+++ b/docs/data/material/customization/dark-mode/dark-mode.md
@@ -132,6 +132,20 @@ To instantly switch between color schemes with no transition, apply the `disable
 </ThemeProvider>
 ```
 
+## Setting the default mode
+
+When `colorSchemes` is provided, the default mode is `system`, which means the app will use the system preference when users first visit the site.
+
+To set a different default mode, pass the `defaultMode` prop to the ThemeProvider component:
+
+```js
+<ThemeProvider theme={theme} defaultMode="dark">
+```
+
+:::info
+The `defaultMode` value can be `'light'`, `'dark'`, or `'system'`.
+:::
+
 ## Styling in dark mode
 
 Use the `theme.applyStyles` utility to apply styles for a specific mode.

--- a/packages/mui-material/src/styles/ThemeProvider.test.tsx
+++ b/packages/mui-material/src/styles/ThemeProvider.test.tsx
@@ -96,7 +96,7 @@ describe('ThemeProvider', () => {
       expect(getByTestId('mode-switcher')).to.have.property('value', 'dark');
     });
 
-    it('should be dark by default', () => {
+    it('allows default mode to be changed', () => {
       const theme = createTheme({
         colorSchemes: { dark: true },
       });

--- a/packages/mui-material/src/styles/ThemeProvider.test.tsx
+++ b/packages/mui-material/src/styles/ThemeProvider.test.tsx
@@ -95,5 +95,18 @@ describe('ThemeProvider', () => {
 
       expect(getByTestId('mode-switcher')).to.have.property('value', 'dark');
     });
+
+    it('should be dark by default', () => {
+      const theme = createTheme({
+        colorSchemes: { dark: true },
+      });
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme} defaultMode="dark">
+          <ModeSwitcher />
+        </ThemeProvider>,
+      );
+
+      expect(getByTestId('mode-switcher')).to.have.property('value', 'dark');
+    });
   });
 });

--- a/packages/mui-material/src/styles/ThemeProvider.tsx
+++ b/packages/mui-material/src/styles/ThemeProvider.tsx
@@ -37,6 +37,12 @@ export interface ThemeProviderProps<Theme = DefaultTheme> extends ThemeProviderC
    */
   documentNode?: Document | null;
   /**
+   * The default mode when the storage is empty,
+   * require the theme to have `colorSchemes` with light and dark.
+   * @default 'system'
+   */
+  defaultMode?: 'light' | 'dark' | 'system';
+  /**
    * The window that attaches the 'storage' event listener
    * @default window
    */

--- a/packages/mui-material/src/styles/ThemeProvider.tsx
+++ b/packages/mui-material/src/styles/ThemeProvider.tsx
@@ -37,8 +37,8 @@ export interface ThemeProviderProps<Theme = DefaultTheme> extends ThemeProviderC
    */
   documentNode?: Document | null;
   /**
-   * The default mode when the storage is empty,
-   * require the theme to have `colorSchemes` with light and dark.
+   * The default mode when the local storage has no mode yet,
+   * requires the theme to have `colorSchemes` with light and dark.
    * @default 'system'
    */
   defaultMode?: 'light' | 'dark' | 'system';

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -55,6 +55,12 @@ export interface CreateCssVarsProviderResult<
           }
         >;
         /**
+         * The default mode when the storage is empty,
+         * require the theme to have `colorSchemes` with light and dark.
+         * @default 'system'
+         */
+        defaultMode?: 'light' | 'dark' | 'system';
+        /**
          * The document used to perform `disableTransitionOnChange` feature
          * @default document
          */

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -60,6 +60,7 @@ export default function createCssVarsProvider(options) {
       colorSchemeNode = typeof document === 'undefined' ? undefined : document.documentElement,
       disableNestedContext = false,
       disableStyleSheetGeneration = false,
+      defaultMode: initialMode = 'system',
     } = props;
     const hasMounted = React.useRef(false);
     const upperTheme = muiUseTheme();
@@ -92,7 +93,7 @@ export default function createCssVarsProvider(options) {
       typeof defaultColorScheme === 'string' ? defaultColorScheme : defaultColorScheme.dark;
     const defaultMode =
       colorSchemes[defaultLightColorScheme] && colorSchemes[defaultDarkColorScheme]
-        ? 'system'
+        ? initialMode
         : colorSchemes[restThemeProp.defaultColorScheme]?.palette?.mode ||
           restThemeProp.palette?.mode;
 
@@ -299,6 +300,11 @@ export default function createCssVarsProvider(options) {
      * localStorage key used to store `colorScheme`
      */
     colorSchemeStorageKey: PropTypes.string,
+    /**
+     * The default mode when the storage is empty,
+     * require the theme to have `colorSchemes` with light and dark.
+     */
+    defaultMode: PropTypes.string,
     /**
      * If `true`, the provider creates its own context and generate stylesheet as if it is a root `CssVarsProvider`.
      */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #43622

## Changes

The default mode can be controlled by a prop (see https://github.com/mui/material-ui/issues/43622 for use cases):

```js
<ThemeProvider defaultMode="dark | light | system">
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
