### PR TITLE
[test] Fix flaky pigment-css screenshot

### DIFF
--- a/apps/pigment-css-vite-app/src/pages/material-ui/react-progress.tsx
+++ b/apps/pigment-css-vite-app/src/pages/material-ui/react-progress.tsx
@@ -8,7 +8,6 @@ import CircularUnderLoad from '../../../../../docs/data/material/components/prog
 import CircularWithValueLabel from '../../../../../docs/data/material/components/progress/CircularWithValueLabel.tsx';
 import CustomizedProgressBars from '../../../../../docs/data/material/components/progress/CustomizedProgressBars.tsx';
 import DelayingAppearance from '../../../../../docs/data/material/components/progress/DelayingAppearance.tsx';
-import LinearBuffer from '../../../../../docs/data/material/components/progress/LinearBuffer.tsx';
 import LinearColor from '../../../../../docs/data/material/components/progress/LinearColor.tsx';
 import LinearDeterminate from '../../../../../docs/data/material/components/progress/LinearDeterminate.tsx';
 import LinearIndeterminate from '../../../../../docs/data/material/components/progress/LinearIndeterminate.tsx';
@@ -64,12 +63,6 @@ export default function Progress() {
         <h2> Delaying Appearance</h2>
         <div className="demo-container">
           <DelayingAppearance />
-        </div>
-      </section>
-      <section>
-        <h2> Linear Buffer</h2>
-        <div className="demo-container">
-          <LinearBuffer />
         </div>
       </section>
       <section>


### PR DESCRIPTION
The CSS animations are disabled by playwright while taking the screenshot, but there is this one demo that animates the progressbar `value` property with Javascript. This sometimes results in flaky screenshots. Example: https://app.argos-ci.com/mui/material-ui/builds/32548/111399290

We could just remove this demo to solve the issue. 

Alternatives are:
* Mock `setTimeout`, but this seems to break too many other things
* Add a compile time flag in the demo to turn off animation
* Write a new test case specifically for the integration test
