### PR TITLE
[test] Fix Escape event firing event

### DIFF
--- a/packages/eslint-plugin-material-ui/src/rules/disallow-active-elements-as-key-event-target.test.js
+++ b/packages/eslint-plugin-material-ui/src/rules/disallow-active-elements-as-key-event-target.test.js
@@ -8,7 +8,7 @@ const ruleTester = new eslint.RuleTester({
 ruleTester.run('disallow-active-element-as-key-event-target', rule, {
   valid: [
     "import { fireEvent } from '@mui/internal-test-utils';\nfireEvent.keyDown(getByRole('button'), { key: ' ' })",
-    "import { fireEvent } from '@mui/internal-test-utils';\nfireEvent.keyDown(document.body, { key: 'Esc' })",
+    "import { fireEvent } from '@mui/internal-test-utils';\nfireEvent.keyDown(document.body, { key: 'Escape' })",
     "import { fireEvent } from '@mui/internal-test-utils';\nfireEvent.keyUp(document.body, { key: 'Tab' })",
   ],
   invalid: [

--- a/packages/mui-material/src/Dialog/Dialog.test.js
+++ b/packages/mui-material/src/Dialog/Dialog.test.js
@@ -88,7 +88,7 @@ describe('<Dialog />', () => {
 
     // keyDown not targetted at anything specific
     // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target
-    fireEvent.keyDown(document.activeElement, { key: 'Esc' });
+    fireEvent.keyDown(document.activeElement, { key: 'Escape' });
     expect(onClose.calledOnce).to.equal(true);
 
     clock.tick(100);
@@ -107,10 +107,10 @@ describe('<Dialog />', () => {
 
     // Actual Behavior when "あ" (Japanese) is entered and press the Esc for IME cancellation.
     fireEvent.change(textbox, { target: { value: 'あ' } });
-    fireEvent.keyDown(textbox, { key: 'Esc', keyCode: 229 });
+    fireEvent.keyDown(textbox, { key: 'Escape', keyCode: 229 });
     expect(onClose.callCount).to.equal(0);
 
-    fireEvent.keyDown(textbox, { key: 'Esc' });
+    fireEvent.keyDown(textbox, { key: 'Escape' });
     expect(onClose.callCount).to.equal(1);
   });
 
@@ -143,7 +143,7 @@ describe('<Dialog />', () => {
       dialog.click();
       // keyDown is not targetted at anything specific.
       // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target
-      fireEvent.keyDown(document.activeElement, { key: 'Esc' });
+      fireEvent.keyDown(document.activeElement, { key: 'Escape' });
     });
 
     expect(onClose.callCount).to.equal(0);


### PR DESCRIPTION
`Esc` is legacy, e.g. https://github.com/facebook/react/blob/99c056abb0dac0e1a15b2c85b620b72c625e065b/packages/react-dom-bindings/src/events/SyntheticEvent.js#L313