### PR TITLE
[code-infra] Forbid calling `Error` without `new`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -16,7 +16,6 @@
 /packages/mui-icons-material/material-icons/
 /packages/mui-icons-material/src/*.js
 /packages/mui-icons-material/templateSvgIcon.js
-/packages/mui-utils/macros/__fixtures__/
 # Ignore fixtures
 /packages-internal/scripts/typescript-to-proptypes/test/*/*
 /test/bundling/fixtures/**/*.fixture.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -235,7 +235,7 @@ module.exports = /** @type {Config} */ ({
         selector: 'ExpressionStatement[expression.value="use client"] ~ ExportAllDeclaration',
       },
       {
-        message: 'Do not call Error without `new`. Use `new Error()` instead.',
+        message: 'Do not call `Error(...)` without `new`. Use `new Error(...)` instead.',
         selector: "CallExpression[callee.name='Error']",
       },
     ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,9 @@
+// @ts-check
+
+/**
+ * @typedef {import('eslint').Linter.Config} Config
+ */
+
 const path = require('path');
 
 const OneLevelImportMessage = [
@@ -39,7 +45,7 @@ const NO_RESTRICTED_IMPORTS_PATTERNS_DEEPLY_NESTED = [
   },
 ];
 
-module.exports = {
+module.exports = /** @type {Config} */ ({
   root: true, // So parent files don't get applied
   env: {
     es6: true,
@@ -227,6 +233,10 @@ module.exports = {
         message:
           "The 'use client' pragma can't be used with export * in the same module. This is not supported by Next.js.",
         selector: 'ExpressionStatement[expression.value="use client"] ~ ExportAllDeclaration',
+      },
+      {
+        message: 'Avoid calling Error without `new`. Use `new Error()` instead.',
+        selector: "CallExpression[callee.name='Error']",
       },
     ],
 
@@ -526,4 +536,4 @@ module.exports = {
       },
     },
   ],
-};
+});

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -235,7 +235,7 @@ module.exports = /** @type {Config} */ ({
         selector: 'ExpressionStatement[expression.value="use client"] ~ ExportAllDeclaration',
       },
       {
-        message: 'Avoid calling Error without `new`. Use `new Error()` instead.',
+        message: 'Do not call Error without `new`. Use `new Error()` instead.',
         selector: "CallExpression[callee.name='Error']",
       },
     ],

--- a/docs/src/modules/components/ApiPage/definitions/classes.ts
+++ b/docs/src/modules/components/ApiPage/definitions/classes.ts
@@ -60,14 +60,14 @@ export function getClassApiDefinitions(params: GetClassApiDefinitionsParams): Cl
 
     if (description.includes('{{conditions}}')) {
       if (!conditions) {
-        throw Error(errorMessage(componentName, classDefinition.className, 'conditions'));
+        throw new Error(errorMessage(componentName, classDefinition.className, 'conditions'));
       }
       description = description.replace(/{{conditions}}/, conditions);
     }
 
     if (description.includes('{{nodeName}}')) {
       if (!nodeName) {
-        throw Error(errorMessage(componentName, classDefinition.className, 'nodeName'));
+        throw new Error(errorMessage(componentName, classDefinition.className, 'nodeName'));
       }
       description = description.replace(/{{nodeName}}/, nodeName);
     }

--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -545,7 +545,7 @@ export function createRenderer(globalOptions: CreateRendererOptions = {}): Rende
 
   afterEach(() => {
     if (!clock.isReal()) {
-      const error = Error(
+      const error = new Error(
         "Can't cleanup before fake timers are restored.\n" +
           'Be sure to:\n' +
           '  1. Only use `clock` from `createRenderer`.\n' +


### PR DESCRIPTION
Noticed in https://github.com/mui/material-ui/pull/43904 that the error minification macro checks for this, but it would be better served by an eslint rule, so that more of our code base is covered.

Also removing an unused ignore line.