### PR TITLE
[docs][material-ui] Fix incorrect `slotProp` name in the `TextField` deprecation note.

### DIFF
--- a/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
+++ b/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
@@ -1539,13 +1539,13 @@ All of the TextField's slot props (`*Props`) props were deprecated in favor of e
 -  inputProps={CustomHtmlInputProps}
 -  SelectProps={CustomSelectProps}
 -  InputLabelProps={CustomInputLabelProps}
--  FormHelperTextProps={CustomFormHelperProps}
+-  FormHelperTextProps={CustomFormHelperTextProps}
 +  slotProps={{
 +    input: CustomInputProps
 +    htmlInput: CustomHtmlInputProps
 +    select: CustomSelectProps
 +    inputLabel: CustomInputLabelProps
-+    formHelper: CustomFormHelperProps
++    formHelperText: CustomFormHelperTextProps
 +  }}
  />
 ```


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The deprecation note about the `TextField` `FormHelperTextProps` is incorrect. It says to change to `slotProps.formHelper`, but it should be `slotProps.formHelperText` according to the [component documentation](https://mui.com/material-ui/api/text-field/#slots), [source code](https://github.com/mui/material-ui/blob/95fd6b5c97aca84f1f8b02bfeefddf4a55baea5c/packages/mui-material/src/TextField/TextField.js#L144-L151) and [codemod](https://github.com/mui/material-ui/blob/95fd6b5c97aca84f1f8b02bfeefddf4a55baea5c/packages/mui-codemod/src/deprecations/text-field-props/text-field-props.js#L40-L45).

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
