### PR TITLE
[system] Use @scope to make applyStyles work correctly

### DIFF
--- a/packages/mui-joy/src/styles/extendTheme.test.js
+++ b/packages/mui-joy/src/styles/extendTheme.test.js
@@ -301,7 +301,7 @@ describe('extendTheme', () => {
       );
 
       expect(darkStyles).to.deep.equal({
-        [`*:where([${attribute}="dark"]) &`]: {
+        [`@scope ([${attribute}="dark"])`]: {
           backgroundColor: 'rgba(0, 0, 0, 0)',
         },
       });

--- a/packages/mui-system/src/createTheme/applyStyles.test.ts
+++ b/packages/mui-system/src/createTheme/applyStyles.test.ts
@@ -26,7 +26,7 @@ describe('applyStyles', () => {
     };
     const styles = { background: '#e5e5e5' };
     expect(applyStyles.call(theme, 'light', styles)).to.deep.equal({
-      '*:where(.light) &': styles,
+      '@scope (.light)': styles,
     });
   });
 
@@ -40,7 +40,7 @@ describe('applyStyles', () => {
     };
     const styles = { background: '#e5e5e5' };
     expect(applyStyles.call(theme, 'light', styles)).to.deep.equal({
-      '*:where([data-color-scheme-light]) &': styles,
+      '@scope ([data-color-scheme-light])': styles,
     });
   });
 
@@ -54,7 +54,7 @@ describe('applyStyles', () => {
     };
     const styles = { background: '#e5e5e5' };
     expect(applyStyles.call(theme, 'light', styles)).to.deep.equal({
-      '*:where([data-color-scheme="light"]) &': styles,
+      '@scope ([data-color-scheme="light"])': styles,
     });
   });
 

--- a/packages/mui-system/src/createTheme/applyStyles.ts
+++ b/packages/mui-system/src/createTheme/applyStyles.ts
@@ -74,14 +74,14 @@ export default function applyStyles<K extends string>(key: K, styles: CSSObject)
     if (!theme.colorSchemes?.[key] || typeof theme.getColorSchemeSelector !== 'function') {
       return {};
     }
-    // If CssVarsProvider is used as a provider, returns '*:where({selector}) &'
+    // If CssVarsProvider is used as a provider, returns '@scope ({selector}) &'
     let selector = theme.getColorSchemeSelector(key);
     if (selector === '&') {
       return styles;
     }
     if (selector.includes('data-') || selector.includes('.')) {
       // '*' is required as a workaround for Emotion issue (https://github.com/emotion-js/emotion/issues/2836)
-      selector = `*:where(${selector.replace(/\s*&$/, '')}) &`;
+      selector = `@scope (${selector.replace(/\s*&$/, '')})`;
     }
     return {
       [selector]: styles,


### PR DESCRIPTION
I believe we can leverage `@scope` to resolve the specificity issues outlined in https://github.com/mui/material-ui/issues/43824.

Example with the patch

[mui-css-vars.zip](https://github.com/user-attachments/files/17255916/mui-css-vars.zip)

In light color scheme

https://github.com/user-attachments/assets/7e487143-c243-4405-90d8-07eb287b9786

In dark color scheme

https://github.com/user-attachments/assets/0d2c83bd-b95c-4e99-85e3-1720602b9e65


> [!WARNING]  
> I'm aware of drawback of `@scope` [support](https://caniuse.com/css-cascade-scope) though. At least it's more reliable than `where` selector.



