### PR TITLE
[docs] Update Material Symbols plan to reflect Google development

### DIFF
--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -39,7 +39,7 @@ yarn add @mui/icons-material @mui/material @emotion/styled @emotion/react
 See the [Installation](/material-ui/getting-started/installation/) page for additional docs about how to make sure everything is set up correctly.
 
 :::info
-Google also offers [Material Symbols](https://fonts.google.com/icons?icon.set=Material+Symbols) as an alternative to Material Icons. `@mui/icons-material` only covers Icons, and there are no plans to support Symbols at this time.
+Google also offers [Material Symbols](https://fonts.google.com/icons?icon.set=Material+Symbols) as the successor of Material Icons. `@mui/icons-material` only covers Icons at this time, there are no support for Symbols yet.
 :::
 
 <hr/>

--- a/packages/mui-icons-material/README.md
+++ b/packages/mui-icons-material/README.md
@@ -2,7 +2,7 @@
 
 This package contains Google's [Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) converted to Material UI [SVG Icon](https://mui.com/material-ui/icons/#svgicon) components.
 
-> Google also offers [Material Symbols](https://fonts.google.com/icons?icon.set=Material+Symbols) as an alternative to Material Icons. `@mui/icons-material` only covers Icons, and there are no plans to support Symbols at this time.
+> Google also offers [Material Symbols](https://fonts.google.com/icons?icon.set=Material+Symbols) as the successor of Material Icons. `@mui/icons-material` only covers Icons at this time, there are no support for Symbols yet.
 
 ## Installation
 


### PR DESCRIPTION
I see two problems:

- Material Symbols is not an "alternative", it's the successor. Material Icons are deprecated: https://github.com/mui/material-ui/issues/32846#issuecomment-2296974762.
- As a user, I was confused reading "no plans", the thought I caught myself with: "How can there be no plans? Icons are outdated and have been stale for 2+ years. Surely, they plan to eventually support symbols."

It also looks like icons have no specific product owner: https://www.notion.so/mui-org/Icons-7ff27203df124147850ec3e26d04d517 so I imagine it's Material UI product owner defacto.