### PR TITLE
[icons][docs] Index search synchronously

### DIFF
--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -518,26 +518,20 @@ const searchIndex = new FlexSearchIndex({
   tokenize: 'full',
 });
 
-const nameCleanRegex = /(Outlined|TwoTone|Rounded|Sharp)$/;
-
 const allIconsMap = {};
 const allIcons = Object.keys(mui)
   .sort()
   .map((importName) => {
-    let theme;
-    if (importName.endsWith('Outlined')) {
-      theme = 'Outlined';
-    } else if (importName.endsWith('TwoTone')) {
-      theme = 'Two tone';
-    } else if (importName.endsWith('Rounded')) {
-      theme = 'Rounded';
-    } else if (importName.endsWith('Sharp')) {
-      theme = 'Sharp';
-    } else {
-      theme = 'Filled';
-    }
+    let theme = 'Filled';
+    let name = importName;
 
-    const name = importName.replace(nameCleanRegex, '');
+    for (const currentTheme of ['Outlined', 'Rounded', 'TwoTone', 'Sharp']) {
+      if (importName.endsWith(currentTheme)) {
+        theme = currentTheme === 'TwoTone' ? 'Two tone' : currentTheme;
+        name = importName.slice(0, -currentTheme.length);
+        break;
+      }
+    }
     let searchable = name;
     if (synonyms[searchable]) {
       searchable += ` ${synonyms[searchable]}`;

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -518,29 +518,31 @@ const searchIndex = new FlexSearchIndex({
   tokenize: 'full',
 });
 
+const nameCleanRegex = /(Outlined|TwoTone|Rounded|Sharp)$/;
+
 const allIconsMap = {};
 const allIcons = Object.keys(mui)
   .sort()
   .map((importName) => {
     let theme;
-    if (importName.includes('Outlined')) {
+    if (importName.endsWith('Outlined')) {
       theme = 'Outlined';
-    } else if (importName.includes('TwoTone')) {
+    } else if (importName.endsWith('TwoTone')) {
       theme = 'Two tone';
-    } else if (importName.includes('Rounded')) {
+    } else if (importName.endsWith('Rounded')) {
       theme = 'Rounded';
-    } else if (importName.includes('Sharp')) {
+    } else if (importName.endsWith('Sharp')) {
       theme = 'Sharp';
     } else {
       theme = 'Filled';
     }
 
-    const name = importName.replace(/(Outlined|TwoTone|Rounded|Sharp)$/, '');
+    const name = importName.replace(nameCleanRegex, '');
     let searchable = name;
     if (synonyms[searchable]) {
       searchable += ` ${synonyms[searchable]}`;
     }
-    searchIndex.addAsync(importName, searchable);
+    searchIndex.add(importName, searchable);
 
     const icon = {
       importName,


### PR DESCRIPTION
See the time it takes to see the input updated with the search term "a". I have used this as a way to measure Time To Interactive.

Before: 6.2s https://deploy-preview-44000--material-ui.netlify.app/material-ui/material-icons/?query=a
<img width="318" alt="SCR-20241006-cmxo" src="https://github.com/user-attachments/assets/b1966f08-1e81-41ac-a633-f7a9c51150b3">

After: 1.9s https://deploy-preview-44001--material-ui.netlify.app/material-ui/material-icons/?query=a
<img width="314" alt="SCR-20241006-clwt" src="https://github.com/user-attachments/assets/9611f1a5-9a95-4914-8035-a75d56c32b1c">

Help with #41126

With all the changes that we did, we are closer to the kind of performance that we had in https://v4.mui.com/components/material-icons/. We are not at v4 level yet (1.4s), but at least, it's not horrible like it was before (not sure where all the regressions on the icons page came from).