### PR TITLE
[Grid2] Remove required `item` prop for `size` prop

### DIFF
--- a/packages/mui-material/src/Grid2/Grid2.tsx
+++ b/packages/mui-material/src/Grid2/Grid2.tsx
@@ -270,7 +270,6 @@ if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react/forbid-foreign-prop-types
     ...Component.propTypes,
     direction: requireProp('container'),
-    size: requireProp('item'),
     spacing: requireProp('container'),
     wrap: requireProp('container'),
   };


### PR DESCRIPTION
Noticed warnings when running the docs

```
Warning: Failed prop type: The prop `size` of `Grid2` can only be used together with the `item` prop.
```

