### PR TITLE
[typescript] `SystemCSSProperties` should not have `SystemStyleObject` as value

### DIFF
--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
@@ -51,7 +51,7 @@ export type SystemCssProperties<Theme extends object = {}> = {
   [K in keyof AllSystemCSSProperties]:
     | ResponsiveStyleValue<AllSystemCSSProperties[K]>
     | ((theme: Theme) => ResponsiveStyleValue<AllSystemCSSProperties[K]>)
-    | SystemStyleObject<Theme>;
+    | null;
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

It does not make sense for CSS Properties to have value as `SystemStyleObject` like this:

```js
{
  color: {
    '&.selector': {
      …
    }
  }
}
```

This might be a slightly typescript per improvement and it won't have any affect on the consumer side because the `sx` prop currently support nesting object with any keys (due to CSS selector)

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
