### PR TITLE
[code-infra] Align `next` dependency specifier across project

### DIFF
--- a/packages/mui-material-nextjs/package.json
+++ b/packages/mui-material-nextjs/package.json
@@ -43,7 +43,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/server": "^11.11.0",
     "@types/react": "^18.3.6",
-    "next": "14.2.14",
+    "next": "^14.2.14",
     "react": "^18.3.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1846,7 +1846,7 @@ importers:
         specifier: ^18.3.6
         version: 18.3.10
       next:
-        specifier: 14.2.14
+        specifier: ^14.2.14
         version: 14.2.14(@babel/core@7.25.2)(@opentelemetry/api@1.8.0)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1


### PR DESCRIPTION
Noticed this morning that we had two Next.js versions in node_module (has been fixed by renovatebot now). This was caused by having all but one specifier marked with `^` and a lockfile maintenance cycle updating all but this one.