### PR TITLE
[lab][Timeline] Fix types for React 19

### DIFF
--- a/packages/mui-lab/src/Timeline/Timeline.tsx
+++ b/packages/mui-lab/src/Timeline/Timeline.tsx
@@ -21,8 +21,8 @@ const useUtilityClasses = (ownerState: OwnerState) => {
   return composeClasses(slots, getTimelineUtilityClass, classes);
 };
 
-const TimelineRoot = styled('ul' as const, {
-  name: 'MuiTimeline' as const,
+const TimelineRoot = styled('ul', {
+  name: 'MuiTimeline',
   slot: 'Root',
   overridesResolver: (props, styles) => {
     const { ownerState } = props;

--- a/packages/mui-lab/src/Timeline/Timeline.types.ts
+++ b/packages/mui-lab/src/Timeline/Timeline.types.ts
@@ -4,7 +4,7 @@ import { Theme } from '@mui/material/styles';
 import { SxProps } from '@mui/system';
 import { TimelineClasses } from './timelineClasses';
 
-export interface TimelineProps extends StandardProps<React.HTMLAttributes<HTMLUListElement>> {
+export interface TimelineProps extends StandardProps<React.ComponentProps<'ul'>> {
   /**
    * The position where the TimelineContent should appear relative to the time axis.
    * @default 'right'


### PR DESCRIPTION
Extracted from https://github.com/mui/material-ui/pull/42824 to fix the following TS error in the `Timeline` component when using React 19 types:

<img width="888" alt="image" src="https://github.com/user-attachments/assets/8136e2af-b7c7-417c-b598-90e2b9ab53ac">
