### PR TITLE
[core] Remove unnecessary `performance.now()`

### DIFF
--- a/packages/mui-base/src/utils/useTextNavigation.ts
+++ b/packages/mui-base/src/utils/useTextNavigation.ts
@@ -28,7 +28,7 @@ export function useTextNavigation(
       if (event.key.length === 1 && event.key !== ' ') {
         const textCriteria = textCriteriaRef.current;
         const lowerKey = event.key.toLowerCase();
-        const currentTime = performance.now();
+        const currentTime = Date.now();
         if (
           textCriteria.searchString.length > 0 &&
           textCriteria.lastTime &&

--- a/packages/mui-material/src/MenuList/MenuList.js
+++ b/packages/mui-material/src/MenuList/MenuList.js
@@ -179,7 +179,7 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
     } else if (key.length === 1) {
       const criteria = textCriteriaRef.current;
       const lowerKey = key.toLowerCase();
-      const currTime = performance.now();
+      const currTime = Date.now();
       if (criteria.keys.length > 0) {
         // Reset
         if (currTime - criteria.lastTime > 500) {

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -456,19 +456,19 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
 
     if (swipeInstance.current.lastTranslate === null) {
       swipeInstance.current.lastTranslate = translate;
-      swipeInstance.current.lastTime = performance.now() + 1;
+      swipeInstance.current.lastTime = Date.now() + 1;
     }
 
     const velocity =
       ((translate - swipeInstance.current.lastTranslate) /
-        (performance.now() - swipeInstance.current.lastTime)) *
+        (Date.now() - swipeInstance.current.lastTime)) *
       1e3;
 
     // Low Pass filter.
     swipeInstance.current.velocity = swipeInstance.current.velocity * 0.4 + velocity * 0.6;
 
     swipeInstance.current.lastTranslate = translate;
-    swipeInstance.current.lastTime = performance.now();
+    swipeInstance.current.lastTime = Date.now();
 
     // We are swiping, let's prevent the scroll event on iOS.
     if (nativeEvent.cancelable) {


### PR DESCRIPTION
This broke `vitest` tests as `performance.now()` is not mocked by default. We can perfectly mock `performance.now`, but the precision is completely unnecessary in these instances. And not that it's going to be noticable, but `performance.now()` is about 4 times slower than `date.now()`. May as well use `Date.now()`.