### PR TITLE
[code-infra] Fix testing library resolution with custom react

### DIFF
--- a/scripts/useReactVersion.mjs
+++ b/scripts/useReactVersion.mjs
@@ -89,8 +89,7 @@ async function main(version) {
           `Version ${majorVersion} does not have version defined for the ${packageName}`,
         );
       }
-      packageJson.devDependencies[packageName] =
-        additionalVersionsMappings[majorVersion][packageName];
+      packageJson.resolutions[packageName] = additionalVersionsMappings[majorVersion][packageName];
     });
   }
 


### PR DESCRIPTION
Currently it only updates the top-level dependency but there's a nested one in `@mui/internal-test-utils`. Makes the unit tests run (but not pass) for react 17.

Won't allocate more time to fixing these tests for now, but we may as well get this fix in.