### PR TITLE
[docs] Mark the Hidden component as deprecated in the sidenav

### DIFF
--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -110,7 +110,7 @@ const pages: MuiPage[] = [
           { pathname: '/material-ui/react-grid2', title: 'Grid v2' },
           { pathname: '/material-ui/react-stack' },
           { pathname: '/material-ui/react-image-list', title: 'Image List' },
-          { pathname: '/material-ui/react-hidden' },
+          { pathname: '/material-ui/react-hidden', deprecated: true },
         ],
       },
       {


### PR DESCRIPTION
The Grid component had a nice deprecated label in the navigation drawer, while Hidden didn't despite being deprecated, so added it :)

Preview: https://deploy-preview-44068--material-ui.netlify.app/material-ui/react-hidden/