### PR TITLE
[examples] Fix Pigment CSS Vite example

### DIFF
--- a/examples/material-ui-pigment-css-vite-ts/README.md
+++ b/examples/material-ui-pigment-css-vite-ts/README.md
@@ -7,7 +7,7 @@ Download the example [or clone the repo](https://github.com/mui/material-ui):
 <!-- #default-branch-switch -->
 
 ```bash
-curl https://codeload.github.com/mui/material-ui/tar.gz/next | tar -xz --strip=2 material-ui-next/examples/material-ui-pigment-css-vite-ts
+curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/material-ui-pigment-css-vite-ts
 cd material-ui-pigment-css-vite-ts
 ```
 


### PR DESCRIPTION
I wanted to try Pigment CSS with Vite and this is the error I got. 
<img width="957" alt="SCR-20241012-bajh" src="https://github.com/user-attachments/assets/cff0b530-e662-411e-83fc-3d9ebea0ec89">

This has been broken with [v6.0.0 release](https://github.com/mui/material-ui/releases/tag/v6.0.0), so 6-7 weeks ago. I imagine the Pigment CSS team is responsible for this example.

I'm surprised I'm the first one to work on this. Like, how comes not even community's members faced this? It would mean that nobody uses this example, but then Vite is super popular, so it would mean nobody wants to try Pigment CSS which also doesn't make sense. I'm missing something. Maybe it's that +99% of the people are migrating applications, so nobody can use this example right away, only people who want to create bug reproductions use it today (until it's stable).

---

Side notes:

- The example doesn't work with pnpm (it works with npm):

<img width="1377" alt="SCR-20241012-brja" src="https://github.com/user-attachments/assets/e401d183-ba47-4ba5-bdb0-2bbd61939140">

- I think I raised this in the past, I don't understand why `@mui/material-pigment-css` exists. I'm trying to think of a permutations that would explain it, but I can't connect the dots: 
  - If it's because we need to sync breaking changes, we can pin versions, or replicate them between repos before releases. If Pigment CSS makes a breaking change, it should be replicated to Material UI instantly, users should adapt to it now, not later.
  - If it's because a wrapper allows smoothing the experience, I think it comes with so many downsides that I think it's clearly not worth it, one of the learnings of @mui/styles. For example, it doesn't force us to build the right extension theme tools like anyone else who would want to use  Pigment CSS in their own product. 
  - If it's because of the layout components, this is @mui/system / @mui/layout concern, not Pigment CSS concern. It should be a private implementation details
  - etc?

  How about we remove this package?