### PR TITLE
[code-infra] Link to production app for bundle size

### DIFF
--- a/dangerFileContent.ts
+++ b/dangerFileContent.ts
@@ -141,7 +141,7 @@ async function reportBundleSize() {
   const comparison = await loadLastComparison(upstreamRef);
 
   const detailedComparisonQuery = `circleCIBuildNumber=${circleCIBuildNumber}&baseRef=${danger.github.pr.base.ref}&baseCommit=${comparison.previous}&prNumber=${danger.github.pr.number}`;
-  const detailedComparisonToolpadUrl = `https://tools-public.onrender.com/prod/pages/h71gdad?${detailedComparisonQuery}`;
+  const detailedComparisonToolpadUrl = `https://tools-public.mui.com/prod/pages/h71gdad?${detailedComparisonQuery}`;
   const detailedComparisonRoute = `/size-comparison?${detailedComparisonQuery}`;
   const detailedComparisonUrl = `https://mui-dashboard.netlify.app${detailedComparisonRoute}`;
 


### PR DESCRIPTION
Saw this in #44075. We should be able to change hosting without breaking all the link history (when checking old PRs).