### PR TITLE
[core] Reference commits in changelog when no PR

### DIFF
--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -162,7 +162,7 @@ async function main(argv) {
   const changes = commitsItems.map((commitsItem) => {
     let shortMessage = commitsItem.commit.message.split('\n')[0];
 
-    // If the commit message doesn't have an associated PR, add the commit reference.
+    // If the commit message doesn't have an associated PR, add the commit sha for reference.
     if (!prLinkRegEx.test(shortMessage)) {
       shortMessage += ` (${commitsItem.sha.substring(0, 7)})`;
     }

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -162,7 +162,7 @@ async function main(argv) {
   const changes = commitsItems.map((commitsItem) => {
     let shortMessage = commitsItem.commit.message.split('\n')[0];
 
-    // If the commit doesn't have an associated PR, add the commit reference.
+    // If the commit message doesn't have an associated PR, add the commit reference.
     if (!prLinkRegEx.test(shortMessage)) {
       shortMessage += ` (${commitsItem.sha.substring(0, 7)})`;
     }

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -162,7 +162,7 @@ async function main(argv) {
   const changes = commitsItems.map((commitsItem) => {
     let shortMessage = commitsItem.commit.message.split('\n')[0];
 
-    // In the commit doesn't have an associated PR, add the commit reference
+    // If the commit doesn't have an associated PR, add the commit reference.
     if (!prLinkRegEx.test(shortMessage)) {
       shortMessage += ` (${commitsItem.sha.substring(0, 7)})`;
     }


### PR DESCRIPTION
I occasionally, or quite frequently, push commits on the master branch of Material UI, Base UI, MUI X, Pigment CSS, etc. anytime I see a change that:

- a. Has no knowledge-sharing needs, not much room to delegate it, or at least it doesn't feel like the added latency in the PR review time. I don't want to overwhelm the PR review capacity of the team, when it feels like it would overload it.
- b. Is trivial, no much value is having a second pair of eyes.
- c. Is safe, no much value in running the CI against it.

(I get this balance wrong sometimes, I should likely be more moderate with this). In any case, there are use cases, I think ones that could be open to more team members.

Here is the value of this change, better DX for developers in the GitHub release page:

```diff
 - [code-infra] Link to production app for bundle size (#44076) @oliviertassinari
 - [core] Remove [website] from changelog (#44069) @oliviertassinari
-- [core] Apply #44052 to the latest release as well @oliviertassinari
-- [docs] Fix 404 link to Next.js @oliviertassinari
-- [examples] Avoid git diff when playing with examples @oliviertassinari
+- [core] Apply #44052 to the latest release as well (82a8253) @oliviertassinari
+- [docs] Fix 404 link to Next.js (a25a365) @oliviertassinari
+- [examples] Avoid git diff when playing with examples (bfe28ad) @oliviertassinari
 - [website] Fix outdated references to XGrid (#44046) @oliviertassinari
```