### PR TITLE
[Dialog] Add the aria-modal="true" by default

### DIFF
--- a/docs/pages/material-ui/api/dialog.json
+++ b/docs/pages/material-ui/api/dialog.json
@@ -7,7 +7,8 @@
       "type": {
         "name": "union",
         "description": "'false'<br>&#124;&nbsp;'true'<br>&#124;&nbsp;bool"
-      }
+      },
+      "default": "true"
     },
     "BackdropComponent": {
       "type": { "name": "elementType" },

--- a/docs/pages/material-ui/api/dialog.json
+++ b/docs/pages/material-ui/api/dialog.json
@@ -3,6 +3,12 @@
     "open": { "type": { "name": "bool" }, "required": true },
     "aria-describedby": { "type": { "name": "string" } },
     "aria-labelledby": { "type": { "name": "string" } },
+    "aria-modal": {
+      "type": {
+        "name": "union",
+        "description": "'false'<br>&#124;&nbsp;'true'<br>&#124;&nbsp;bool"
+      }
+    },
     "BackdropComponent": {
       "type": { "name": "elementType" },
       "default": "styled(Backdrop, {\n  name: 'MuiModal',\n  slot: 'Backdrop',\n  overridesResolver: (props, styles) => {\n    return styles.backdrop;\n  },\n})({\n  zIndex: -1,\n})",

--- a/docs/translations/api-docs/dialog/dialog.json
+++ b/docs/translations/api-docs/dialog/dialog.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "aria-describedby": { "description": "The id(s) of the element(s) that describe the dialog." },
     "aria-labelledby": { "description": "The id(s) of the element(s) that label the dialog." },
+    "aria-modal": { "description": "Indicates whether an element is modal when displayed." },
     "BackdropComponent": {
       "description": "A backdrop component. This prop enables custom backdrop rendering."
     },

--- a/docs/translations/api-docs/dialog/dialog.json
+++ b/docs/translations/api-docs/dialog/dialog.json
@@ -3,7 +3,9 @@
   "propDescriptions": {
     "aria-describedby": { "description": "The id(s) of the element(s) that describe the dialog." },
     "aria-labelledby": { "description": "The id(s) of the element(s) that label the dialog." },
-    "aria-modal": { "description": "Indicates whether an element is modal when displayed." },
+    "aria-modal": {
+      "description": "Informs assistive technologies that the element is modal. It&#39;s added on the element with role=&quot;dialog&quot;."
+    },
     "BackdropComponent": {
       "description": "A backdrop component. This prop enables custom backdrop rendering."
     },

--- a/packages/mui-material/src/Dialog/Dialog.d.ts
+++ b/packages/mui-material/src/Dialog/Dialog.d.ts
@@ -16,6 +16,12 @@ export interface DialogProps extends StandardProps<ModalProps, 'children'> {
    */
   'aria-labelledby'?: string;
   /**
+   * Informs assistive technologies that the element is modal.
+   * It's added on the element with role="dialog".
+   * @default true
+   */
+  'aria-modal'?: boolean | 'true' | 'false';
+  /**
    * Dialog children, usually the included sub-components.
    */
   children?: React.ReactNode;

--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -218,7 +218,7 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
   const {
     'aria-describedby': ariaDescribedby,
     'aria-labelledby': ariaLabelledbyProp,
-    'aria-modal': ariaModal,
+    'aria-modal': ariaModal = true,
     BackdropComponent,
     BackdropProps,
     children,
@@ -323,7 +323,7 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
             role="dialog"
             aria-describedby={ariaDescribedby}
             aria-labelledby={ariaLabelledby}
-            aria-modal={ariaModal ?? true}
+            aria-modal={ariaModal}
             {...PaperProps}
             className={clsx(classes.paper, PaperProps.className)}
             ownerState={ownerState}
@@ -350,7 +350,9 @@ Dialog.propTypes /* remove-proptypes */ = {
    */
   'aria-labelledby': PropTypes.string,
   /**
-   * Indicates whether an element is modal when displayed.
+   * Informs assistive technologies that the element is modal.
+   * It's added on the element with role="dialog".
+   * @default true
    */
   'aria-modal': PropTypes.oneOfType([PropTypes.oneOf(['false', 'true']), PropTypes.bool]),
   /**

--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -218,6 +218,7 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
   const {
     'aria-describedby': ariaDescribedby,
     'aria-labelledby': ariaLabelledbyProp,
+    'aria-modal': ariaModal,
     BackdropComponent,
     BackdropProps,
     children,
@@ -322,6 +323,7 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
             role="dialog"
             aria-describedby={ariaDescribedby}
             aria-labelledby={ariaLabelledby}
+            aria-modal={ariaModal ?? true}
             {...PaperProps}
             className={clsx(classes.paper, PaperProps.className)}
             ownerState={ownerState}
@@ -347,6 +349,10 @@ Dialog.propTypes /* remove-proptypes */ = {
    * The id(s) of the element(s) that label the dialog.
    */
   'aria-labelledby': PropTypes.string,
+  /**
+   * Indicates whether an element is modal when displayed.
+   */
+  'aria-modal': PropTypes.oneOfType([PropTypes.oneOf(['false', 'true']), PropTypes.bool]),
   /**
    * A backdrop component. This prop enables custom backdrop rendering.
    * @deprecated Use `slots.backdrop` instead. While this prop currently works, it will be removed in the next major version.

--- a/packages/mui-material/src/Dialog/Dialog.test.js
+++ b/packages/mui-material/src/Dialog/Dialog.test.js
@@ -376,6 +376,20 @@ describe('<Dialog />', () => {
       const label = document.getElementById(dialog.getAttribute('aria-labelledby'));
       expect(label).to.have.text('Choose either one');
     });
+
+    it('should add the aria-modal="true" by default', function test() {
+      const { getByRole } = render(<Dialog open />);
+
+      const dialog = getByRole('dialog');
+      expect(dialog).to.have.attr('aria-modal', 'true');
+    });
+
+    it('should render the custom aria-modal prop if provided', function test() {
+      const { getByRole } = render(<Dialog aria-modal="false" open />);
+
+      const dialog = getByRole('dialog');
+      expect(dialog).to.have.attr('aria-modal', 'false');
+    });
   });
 
   describe('prop: transitionDuration', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The Dialog component is implemented as a modal dialog, but it was missing the aria-modal="true". This PR adds it by default, but also adds the option for people to remove it if for some reason they need to override it. This makes the component compatible with SC 4.1.2