### PR TITLE
[FormControlLabel][docs] Don't use unintuitive label position on chec…

### DIFF
--- a/docs/data/material/components/checkboxes/FormControlLabelPosition.js
+++ b/docs/data/material/components/checkboxes/FormControlLabelPosition.js
@@ -11,18 +11,6 @@ export default function FormControlLabelPosition() {
       <FormLabel component="legend">Label placement</FormLabel>
       <FormGroup aria-label="position" row>
         <FormControlLabel
-          value="top"
-          control={<Checkbox />}
-          label="Top"
-          labelPlacement="top"
-        />
-        <FormControlLabel
-          value="start"
-          control={<Checkbox />}
-          label="Start"
-          labelPlacement="start"
-        />
-        <FormControlLabel
           value="bottom"
           control={<Checkbox />}
           label="Bottom"

--- a/docs/data/material/components/checkboxes/FormControlLabelPosition.tsx
+++ b/docs/data/material/components/checkboxes/FormControlLabelPosition.tsx
@@ -11,18 +11,6 @@ export default function FormControlLabelPosition() {
       <FormLabel component="legend">Label placement</FormLabel>
       <FormGroup aria-label="position" row>
         <FormControlLabel
-          value="top"
-          control={<Checkbox />}
-          label="Top"
-          labelPlacement="top"
-        />
-        <FormControlLabel
-          value="start"
-          control={<Checkbox />}
-          label="Start"
-          labelPlacement="start"
-        />
-        <FormControlLabel
           value="bottom"
           control={<Checkbox />}
           label="Bottom"

--- a/docs/data/material/components/radio-buttons/FormControlLabelPlacement.js
+++ b/docs/data/material/components/radio-buttons/FormControlLabelPlacement.js
@@ -16,18 +16,6 @@ export default function FormControlLabelPlacement() {
         defaultValue="top"
       >
         <FormControlLabel
-          value="top"
-          control={<Radio />}
-          label="Top"
-          labelPlacement="top"
-        />
-        <FormControlLabel
-          value="start"
-          control={<Radio />}
-          label="Start"
-          labelPlacement="start"
-        />
-        <FormControlLabel
           value="bottom"
           control={<Radio />}
           label="Bottom"

--- a/docs/data/material/components/radio-buttons/FormControlLabelPlacement.tsx
+++ b/docs/data/material/components/radio-buttons/FormControlLabelPlacement.tsx
@@ -16,18 +16,6 @@ export default function FormControlLabelPlacement() {
         defaultValue="top"
       >
         <FormControlLabel
-          value="top"
-          control={<Radio />}
-          label="Top"
-          labelPlacement="top"
-        />
-        <FormControlLabel
-          value="start"
-          control={<Radio />}
-          label="Start"
-          labelPlacement="start"
-        />
-        <FormControlLabel
           value="bottom"
           control={<Radio />}
           label="Bottom"

--- a/docs/data/material/components/switches/FormControlLabelPosition.js
+++ b/docs/data/material/components/switches/FormControlLabelPosition.js
@@ -11,18 +11,6 @@ export default function FormControlLabelPosition() {
       <FormLabel component="legend">Label placement</FormLabel>
       <FormGroup aria-label="position" row>
         <FormControlLabel
-          value="top"
-          control={<Switch color="primary" />}
-          label="Top"
-          labelPlacement="top"
-        />
-        <FormControlLabel
-          value="start"
-          control={<Switch color="primary" />}
-          label="Start"
-          labelPlacement="start"
-        />
-        <FormControlLabel
           value="bottom"
           control={<Switch color="primary" />}
           label="Bottom"

--- a/docs/data/material/components/switches/FormControlLabelPosition.tsx
+++ b/docs/data/material/components/switches/FormControlLabelPosition.tsx
@@ -11,18 +11,6 @@ export default function FormControlLabelPosition() {
       <FormLabel component="legend">Label placement</FormLabel>
       <FormGroup aria-label="position" row>
         <FormControlLabel
-          value="top"
-          control={<Switch color="primary" />}
-          label="Top"
-          labelPlacement="top"
-        />
-        <FormControlLabel
-          value="start"
-          control={<Switch color="primary" />}
-          label="Start"
-          labelPlacement="start"
-        />
-        <FormControlLabel
           value="bottom"
           control={<Switch color="primary" />}
           label="Bottom"


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/44107.

Based on [SC 3.3.2](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html) the bottom and end position are the only one that should be allowed for checkboxes and radios. Having the top or left placement is unintuitive, and we should not give the developers instructions on using them.

Considering the FormControlLabel is a generic component, there is no easy way to restrict the values, but the least we can do is not teach people how to create nonaccessible UIs. 