### PR TITLE
[docs][Rating] Added info about workaround for testing

### DIFF
--- a/docs/data/material/components/rating/rating.md
+++ b/docs/data/material/components/rating/rating.md
@@ -12,6 +12,19 @@ githubSource: packages/mui-material/src/Rating
 <p class="description">Ratings provide insight regarding others' opinions and experiences, and can allow the user to submit a rating of their own.</p>
 
 {{"component": "@mui/docs/ComponentLinkHeader"}}
+:::warning
+
+Testing with `@testing-library/user-event`
+
+When using `@testing-library/user-event` for testing the `Rating` component, you may encounter an issue where `onChange` returns `NaN`. This happens because the mouse event simulations rely on `getBoundingClientRect`, which returns default values (zeros) in Jest.
+
+Workaround:
+
+1. Stub `getBoundingClientRect` to return meaningful values.
+2. Use `userEvent.setup({ skipHover: true })` to bypass hover events.
+
+For more details, see the [GitHub issue](https://github.com/mui/material-ui/issues/38828).
+:::
 
 ## Basic rating
 


### PR DESCRIPTION
Closes: [38828](https://github.com/mui/material-ui/issues/38828)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
