### PR TITLE
[code-infra] Widen eslint file patterns

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -257,10 +257,7 @@ module.exports = /** @type {Config} */ ({
     {
       files: [
         // matching the pattern of the test runner
-        '*.test.mjs',
-        '*.test.js',
-        '*.test.ts',
-        '*.test.tsx',
+        '*.test.?(c|m)[jt]s?(x)',
       ],
       extends: ['plugin:mocha/recommended'],
       rules: {
@@ -332,14 +329,14 @@ module.exports = /** @type {Config} */ ({
     },
     // Next.js entry points pages
     {
-      files: ['docs/pages/**/*{.tsx,.js}'],
+      files: ['docs/pages/**/*.?(c|m)[jt]s?(x)'],
       rules: {
         'react/prop-types': 'off',
       },
     },
     // demos
     {
-      files: ['docs/src/pages/**/*{.tsx,.js}', 'docs/data/**/*{.tsx,.js}'],
+      files: ['docs/src/pages/**/*.?(c|m)[jt]s?(x)', 'docs/data/**/*.?(c|m)[jt]s?(x)'],
       rules: {
         // This most often reports data that is defined after the component definition.
         // This is safe to do and helps readability of the demo code since the data is mostly irrelevant.
@@ -349,23 +346,14 @@ module.exports = /** @type {Config} */ ({
         'no-console': 'off',
       },
     },
-    // demos - proptype generation
     {
-      files: ['docs/data/base/components/modal/UseModal.js'],
-      rules: {
-        'consistent-return': 'off',
-        'func-names': 'off',
-        'no-else-return': 'off',
-        'prefer-template': 'off',
-      },
-    },
-    {
-      files: ['docs/data/**/*{.tsx,.js}'],
+      files: ['docs/data/**/*.?(c|m)[jt]s?(x)'],
       excludedFiles: [
-        'docs/data/joy/getting-started/templates/**/*.tsx',
-        'docs/data/**/css/*{.tsx,.js}',
-        'docs/data/**/system/*{.tsx,.js}',
-        'docs/data/**/tailwind/*{.tsx,.js}',
+        // filenames/match-exported sees filename as 'file-name.d'
+        // Plugin looks unmaintain, find alternative? (e.g. eslint-plugin-project-structure)
+        '*.d.ts',
+        'docs/data/joy/getting-started/templates/**/*',
+        'docs/data/**/{css,system,tailwind}/*',
       ],
       rules: {
         'filenames/match-exported': ['error'],
@@ -380,6 +368,13 @@ module.exports = /** @type {Config} */ ({
     {
       files: ['packages/*/src/**/*.tsx'],
       excludedFiles: '*.spec.tsx',
+      rules: {
+        'react/prop-types': 'off',
+      },
+    },
+    {
+      files: ['packages/*/src/**/*.?(c|m)[jt]s?(x)'],
+      excludedFiles: '*.spec.*',
       rules: {
         'no-restricted-imports': [
           'error',
@@ -406,11 +401,10 @@ module.exports = /** @type {Config} */ ({
             ],
           },
         ],
-        'react/prop-types': 'off',
       },
     },
     {
-      files: ['*.spec.tsx', '*.spec.ts'],
+      files: ['*.spec.*'],
       rules: {
         'no-alert': 'off',
         'no-console': 'off',
@@ -449,7 +443,7 @@ module.exports = /** @type {Config} */ ({
       },
     },
     {
-      files: ['docs/**/*{.ts,.tsx,.js}'],
+      files: ['docs/**/*.?(c|m)[jt]s?(x)'],
       rules: {
         'no-restricted-imports': [
           'error',
@@ -461,8 +455,8 @@ module.exports = /** @type {Config} */ ({
       },
     },
     {
-      files: ['packages/*/src/**/*{.ts,.tsx,.js}'],
-      excludedFiles: ['*.d.ts', '*.spec.ts', '*.spec.tsx'],
+      files: ['packages/*/src/**/*.?(c|m)[jt]s?(x)'],
+      excludedFiles: ['*.d.ts', '*.spec.*'],
       rules: {
         'no-restricted-imports': [
           'error',
@@ -477,8 +471,8 @@ module.exports = /** @type {Config} */ ({
       },
     },
     {
-      files: ['packages/*/src/**/*{.ts,.tsx,.js}'],
-      excludedFiles: ['*.d.ts', '*.spec.ts', '*.spec.tsx', 'packages/mui-joy/**/*{.ts,.tsx,.js}'],
+      files: ['packages/*/src/**/*.?(c|m)[jt]s?(x)'],
+      excludedFiles: ['*.d.ts', '*.spec.*', 'packages/mui-joy/**/*'],
       rules: {
         'material-ui/mui-name-matches-component-name': 'error',
       },

--- a/docs/data/base/components/modal/UseModal.js
+++ b/docs/data/base/components/modal/UseModal.js
@@ -1,6 +1,4 @@
-/* eslint-disable no-else-return */
-/* eslint-disable prefer-template */
-/* eslint-disable consistent-return, func-names */
+/* eslint-disable consistent-return, func-names, prefer-template, no-else-return */
 
 'use client';
 import * as React from 'react';

--- a/docs/data/base/components/modal/UseModal.js
+++ b/docs/data/base/components/modal/UseModal.js
@@ -1,3 +1,5 @@
+/* eslint-disable consistent-return, func-names */
+
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
@@ -140,12 +142,10 @@ Modal.propTypes = {
   container: PropTypes.oneOfType([
     function (props, propName) {
       if (props[propName] == null) {
-        return new Error("Prop '" + propName + "' is required but wasn't specified");
-      } else if (
-        typeof props[propName] !== 'object' ||
-        props[propName].nodeType !== 1
-      ) {
-        return new Error("Expected prop '" + propName + "' to be of type Element");
+        return new Error(`Prop '${propName}' is required but wasn't specified`);
+      }
+      if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
+        return new Error(`Expected prop '${propName}' to be of type Element`);
       }
     },
     PropTypes.func,

--- a/docs/data/base/components/modal/UseModal.js
+++ b/docs/data/base/components/modal/UseModal.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-else-return */
+/* eslint-disable prefer-template */
 /* eslint-disable consistent-return, func-names */
 
 'use client';
@@ -142,10 +144,12 @@ Modal.propTypes = {
   container: PropTypes.oneOfType([
     function (props, propName) {
       if (props[propName] == null) {
-        return new Error(`Prop '${propName}' is required but wasn't specified`);
-      }
-      if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
-        return new Error(`Expected prop '${propName}' to be of type Element`);
+        return new Error("Prop '" + propName + "' is required but wasn't specified");
+      } else if (
+        typeof props[propName] !== 'object' ||
+        props[propName].nodeType !== 1
+      ) {
+        return new Error("Expected prop '" + propName + "' to be of type Element");
       }
     },
     PropTypes.func,

--- a/docs/data/base/components/modal/UseModal.js
+++ b/docs/data/base/components/modal/UseModal.js
@@ -1,5 +1,3 @@
-/* eslint-disable consistent-return, func-names, prefer-template, no-else-return */
-
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
@@ -140,15 +138,14 @@ Modal.propTypes = {
   children: PropTypes.element.isRequired,
   closeAfterTransition: PropTypes.bool,
   container: PropTypes.oneOfType([
-    function (props, propName) {
+    (props, propName) => {
       if (props[propName] == null) {
-        return new Error("Prop '" + propName + "' is required but wasn't specified");
-      } else if (
-        typeof props[propName] !== 'object' ||
-        props[propName].nodeType !== 1
-      ) {
-        return new Error("Expected prop '" + propName + "' to be of type Element");
+        return new Error(`Prop '${propName}' is required but wasn't specified`);
       }
+      if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
+        return new Error(`Expected prop '${propName}' to be of type Element`);
+      }
+      return null;
     },
     PropTypes.func,
   ]),

--- a/packages-internal/scripts/typescript-to-proptypes/src/generatePropTypes.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/src/generatePropTypes.ts
@@ -186,16 +186,18 @@ export function generatePropTypes(
     }
 
     if (propType.type === 'DOMElementNode') {
-      return `function (props, propName) {
+      return `(props, propName) => {
 			if (props[propName] == null) {
 				return ${
           propType.optional
             ? 'null'
-            : `new Error("Prop '" + propName + "' is required but wasn't specified")`
+            : `new Error(\`Prop '\${propName}' is required but wasn't specified\`)`
         }
-			} else if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
-				return new Error("Expected prop '" + propName + "' to be of type Element")
 			}
+      if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
+				return new Error(\`Expected prop '\${propName}' to be of type Element\`)
+			}
+      return null;
 		}`;
     }
 

--- a/packages-internal/scripts/typescript-to-proptypes/test/generator/html-elements/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/generator/html-elements/output.js
@@ -1,30 +1,38 @@
 Foo.propTypes = {
-  bothTypes: function (props, propName) {
+  bothTypes: (props, propName) => {
     if (props[propName] == null) {
-      return new Error("Prop '" + propName + "' is required but wasn't specified");
-    } else if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
-      return new Error("Expected prop '" + propName + "' to be of type Element");
+      return new Error(`Prop '${propName}' is required but wasn't specified`);
     }
+    if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
+      return new Error(`Expected prop '${propName}' to be of type Element`);
+    }
+    return null;
   },
-  element: function (props, propName) {
+  element: (props, propName) => {
     if (props[propName] == null) {
-      return new Error("Prop '" + propName + "' is required but wasn't specified");
-    } else if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
-      return new Error("Expected prop '" + propName + "' to be of type Element");
+      return new Error(`Prop '${propName}' is required but wasn't specified`);
     }
+    if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
+      return new Error(`Expected prop '${propName}' to be of type Element`);
+    }
+    return null;
   },
-  htmlElement: function (props, propName) {
+  htmlElement: (props, propName) => {
     if (props[propName] == null) {
-      return new Error("Prop '" + propName + "' is required but wasn't specified");
-    } else if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
-      return new Error("Expected prop '" + propName + "' to be of type Element");
+      return new Error(`Prop '${propName}' is required but wasn't specified`);
     }
+    if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
+      return new Error(`Expected prop '${propName}' to be of type Element`);
+    }
+    return null;
   },
-  optional: function (props, propName) {
+  optional: (props, propName) => {
     if (props[propName] == null) {
       return null;
-    } else if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
-      return new Error("Expected prop '" + propName + "' to be of type Element");
     }
+    if (typeof props[propName] !== 'object' || props[propName].nodeType !== 1) {
+      return new Error(`Expected prop '${propName}' to be of type Element`);
+    }
+    return null;
   },
 };


### PR DESCRIPTION
Widen javascript/typescript rules to all possible extensions. Avoids situations like https://github.com/mui/material-ui/pull/44143#discussion_r1804939744

Question for @mui/docs-infra: what with `material-ui/no-hardcoded-labels`, it applies only to js files and in many ts files there are violations. Should we fix those cases? Or remove the rule altogether?