### PR TITLE
[material-ui][pigment-css] Support project without enabling CSS variables

### DIFF
--- a/packages/mui-material/src/styles/createTheme.test.js
+++ b/packages/mui-material/src/styles/createTheme.test.js
@@ -561,4 +561,12 @@ describe('createTheme', () => {
       ],
     ).to.equal('5 7 10');
   });
+
+  it('should have `toRuntimeSource` for integrating with Pigment CSS', () => {
+    const theme = createTheme();
+    expect(typeof theme.toRuntimeSource).to.equal('function');
+
+    const themeCssVars = createTheme({ cssVariables: true });
+    expect(typeof themeCssVars.toRuntimeSource).to.equal('function');
+  });
 });

--- a/packages/mui-material/src/styles/createThemeNoVars.js
+++ b/packages/mui-material/src/styles/createThemeNoVars.js
@@ -10,6 +10,7 @@ import createTypography from './createTypography';
 import shadows from './shadows';
 import createTransitions from './createTransitions';
 import zIndex from './zIndex';
+import { stringifyTheme } from './stringifyTheme';
 
 function createThemeNoVars(options = {}, ...args) {
   const {
@@ -117,6 +118,7 @@ function createThemeNoVars(options = {}, ...args) {
       theme: this,
     });
   };
+  muiTheme.toRuntimeSource = stringifyTheme; // for Pigment CSS integration
 
   return muiTheme;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #43750

## Root cause

The `.toRuntimeSource` is required in the theme for some components that access runtime theme's transitions (e.g. Slide) but the property only exist when using CSS theme variables.

Pigment CSS should work with any theme, so the fix is to also add the property to the theme when CSS variables is not enabled.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
