### PR TITLE
[material-ui][Tabs] Fix type of TabPanel component

### DIFF
--- a/docs/pages/material-ui/api/tab-panel.json
+++ b/docs/pages/material-ui/api/tab-panel.json
@@ -1,6 +1,9 @@
 {
   "props": {
-    "value": { "type": { "name": "string" }, "required": true },
+    "value": {
+      "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" },
+      "required": true
+    },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "keepMounted": { "type": { "name": "bool" }, "default": "false" },

--- a/packages/mui-lab/src/TabPanel/TabPanel.d.ts
+++ b/packages/mui-lab/src/TabPanel/TabPanel.d.ts
@@ -21,7 +21,7 @@ export interface TabPanelProps extends StandardProps<React.HTMLAttributes<HTMLDi
    * The `value` of the corresponding `Tab`. Must use the index of the `Tab` when
    * no `value` was passed to `Tab`.
    */
-  value: string;
+  value: string | number;
   /**
    * Always keep the children in the DOM.
    * @default false

--- a/packages/mui-lab/src/TabPanel/TabPanel.js
+++ b/packages/mui-lab/src/TabPanel/TabPanel.js
@@ -93,7 +93,7 @@ TabPanel.propTypes /* remove-proptypes */ = {
    * The `value` of the corresponding `Tab`. Must use the index of the `Tab` when
    * no `value` was passed to `Tab`.
    */
-  value: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
 };
 
 export default TabPanel;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

change the value type of `TabPanel` component from `string` to `string | number`