### PR TITLE
[material-ui][Avatar] Fix AvatarGroup spacing

### DIFF
--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.js
@@ -130,10 +130,6 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {
     ownerState,
     additionalProps: {
       variant,
-      style: {
-        '--AvatarGroup-spacing': marginValue ? `${marginValue}px` : undefined,
-        ...other.style,
-      },
     },
   });
 
@@ -142,6 +138,10 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {
       as={component}
       ownerState={ownerState}
       className={clsx(classes.root, className)}
+      style={{
+        '--AvatarGroup-spacing': marginValue ? `${marginValue}px` : undefined,
+        ...other.style,
+      }}
       ref={ref}
       {...other}
     >

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.js
@@ -138,12 +138,12 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {
       as={component}
       ownerState={ownerState}
       className={clsx(classes.root, className)}
+      ref={ref}
+      {...other}
       style={{
         '--AvatarGroup-spacing': marginValue ? `${marginValue}px` : undefined,
         ...other.style,
       }}
-      ref={ref}
-      {...other}
     >
       {extraAvatars ? <SurplusSlot {...surplusProps}>{extraAvatarsElement}</SurplusSlot> : null}
       {children


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/44172

How to test
1. Go to https://deploy-preview-44208--material-ui.netlify.app/material-ui/react-avatar/#grouped
2. Change add the `spacing="small"` prop to the `AvatarGroup` component in the demo.
3. The spacing between all avatars now changes accordingly.