### PR TITLE
Update ResponsiveDrawer.js

### DIFF
--- a/docs/data/material/components/drawers/ResponsiveDrawer.js
+++ b/docs/data/material/components/drawers/ResponsiveDrawer.js
@@ -17,26 +17,27 @@ import MenuIcon from '@mui/icons-material/Menu';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 
+//import close Icon
+import CloseIcon from '@mui/icons-material/Close';
+
+// import useTheme and useMediaquery
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { useTheme } from "@mui/material/styles";
+
 const drawerWidth = 240;
 
 function ResponsiveDrawer(props) {
   const { window } = props;
-  const [mobileOpen, setMobileOpen] = React.useState(false);
   const [isClosing, setIsClosing] = React.useState(false);
 
-  const handleDrawerClose = () => {
-    setIsClosing(true);
-    setMobileOpen(false);
-  };
+  const [isClosing, setIsClosing] = React.useState(false);
 
-  const handleDrawerTransitionEnd = () => {
-    setIsClosing(false);
-  };
+  //used to make the drawer responsive
+  const theme = useTheme();
+  const isSmUp = useMediaQuery(theme.breakpoints.up("sm"));
 
   const handleDrawerToggle = () => {
-    if (!isClosing) {
-      setMobileOpen(!mobileOpen);
-    }
+      setIsClosing(!isClosing);
   };
 
   const drawer = (
@@ -107,27 +108,15 @@ function ResponsiveDrawer(props) {
         {/* The implementation can be swapped with js to avoid SEO duplication of links. */}
         <Drawer
           container={container}
-          variant="temporary"
-          open={mobileOpen}
-          onTransitionEnd={handleDrawerTransitionEnd}
+          variant={isSmUp ? "permanent" : "temporary"}
+          open={isClosing}
           onClose={handleDrawerClose}
           ModalProps={{
             keepMounted: true, // Better open performance on mobile.
           }}
           sx={{
-            display: { xs: 'block', sm: 'none' },
             '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
           }}
-        >
-          {drawer}
-        </Drawer>
-        <Drawer
-          variant="permanent"
-          sx={{
-            display: { xs: 'none', sm: 'block' },
-            '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
-          }}
-          open
         >
           {drawer}
         </Drawer>


### PR DESCRIPTION
In this proposed change I use useMediaQuery and useTheme hooks to make the Drawer component responsive. I am using the Drawer component once instead of how it used twice in docs. I change the variant of the Drawer according to the screen width using the useMediaQuery and useTheme hooks. Just trying to implement it with the DRY principal. One drawer for both mobile and Desktop shown according to Device. If Desktop then the Drawer is permanent and if the Device is a mobile Device then the SAME Drawer is Temporary.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
