### PR TITLE
[utils] Bring back getReactNodeRef

### DIFF
--- a/packages/mui-utils/src/getReactNodeRef/getReactNodeRef.ts
+++ b/packages/mui-utils/src/getReactNodeRef/getReactNodeRef.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import getReactElementRef from '../getReactElementRef';
+
+/**
+ * Returns the ref of a React element handling differences between React 19 and older versions.
+ * It will throw runtime error if the element is not a valid React element.
+ *
+ * @param element React.ReactElement
+ * @returns React.Ref<any> | null
+ *
+ * @deprecated Use getReactElementRef instead
+ */
+
+export default function getReactNodeRef(element: React.ReactElement): React.Ref<any> | null {
+  return getReactElementRef(element);
+}

--- a/packages/mui-utils/src/getReactNodeRef/getReactNodeRef.ts
+++ b/packages/mui-utils/src/getReactNodeRef/getReactNodeRef.ts
@@ -6,6 +6,8 @@ import * as React from 'react';
  *
  * @param element React.ReactNode
  * @returns React.Ref<any> | null
+ *
+ * @deprecated Use getReactElementRef instead
  */
 export default function getReactNodeRef(element: React.ReactNode): React.Ref<any> | null {
   if (!element || !React.isValidElement(element)) {

--- a/packages/mui-utils/src/getReactNodeRef/getReactNodeRef.ts
+++ b/packages/mui-utils/src/getReactNodeRef/getReactNodeRef.ts
@@ -1,16 +1,22 @@
 import * as React from 'react';
-import getReactElementRef from '../getReactElementRef';
 
 /**
- * Returns the ref of a React element handling differences between React 19 and older versions.
- * It will throw runtime error if the element is not a valid React element.
+ * Returns the ref of a React node handling differences between React 19 and older versions.
+ * It will return null if the node is not a valid React element.
  *
- * @param element React.ReactElement
+ * @param element React.ReactNode
  * @returns React.Ref<any> | null
- *
- * @deprecated Use getReactElementRef instead
  */
+export default function getReactNodeRef(element: React.ReactNode): React.Ref<any> | null {
+  if (!element || !React.isValidElement(element)) {
+    return null;
+  }
 
-export default function getReactNodeRef(element: React.ReactElement): React.Ref<any> | null {
-  return getReactElementRef(element);
+  // 'ref' is passed as prop in React 19, whereas 'ref' is directly attached to children in older versions
+  return (element.props as any).propertyIsEnumerable('ref')
+    ? (element.props as any).ref
+    : // @ts-expect-error element.ref is not included in the ReactElement type
+      // We cannot check for it, but isValidElement is true at this point
+      // https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/70189
+      element.ref;
 }

--- a/packages/mui-utils/src/getReactNodeRef/index.ts
+++ b/packages/mui-utils/src/getReactNodeRef/index.ts
@@ -1,0 +1,1 @@
+export { default } from './getReactNodeRef';

--- a/packages/mui-utils/src/index.ts
+++ b/packages/mui-utils/src/index.ts
@@ -45,5 +45,6 @@ export { default as unstable_useSlotProps } from './useSlotProps';
 export type { UseSlotPropsParameters, UseSlotPropsResult } from './useSlotProps';
 export { default as unstable_resolveComponentProps } from './resolveComponentProps';
 export { default as unstable_extractEventHandlers } from './extractEventHandlers';
+export { default as unstable_getReactNodeRef } from './getReactNodeRef';
 export { default as unstable_getReactElementRef } from './getReactElementRef';
 export * from './types';


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/44096

`getReactNodeRef` was modified and renamed to `getReactElementRef` in https://github.com/mui/material-ui/pull/43022 which caused issues described in https://github.com/mui/material-ui/issues/44096


