### PR TITLE
[docs-infra] Enforce punctuation on descriptions

### DIFF
--- a/docs/data/material/integrations/nextjs/nextjs.md
+++ b/docs/data/material/integrations/nextjs/nextjs.md
@@ -1,6 +1,6 @@
 # Next.js integration
 
-<p class="description">Learn how to use Material UI with Next.js</p>
+<p class="description">Learn how to use Material UI with Next.js.</p>
 
 ## App Router
 

--- a/packages/markdown/prepareMarkdown.js
+++ b/packages/markdown/prepareMarkdown.js
@@ -102,6 +102,12 @@ function prepareMarkdown(config) {
         );
       }
 
+      if (description.slice(-1) !== '.' && description.slice(-1) !== '!') {
+        throw new Error(
+          `docs-infra: The description "${description}" should end with a "." or "!", those are sentences.`,
+        );
+      }
+
       const contents = getContents(markdown);
 
       if (headers.unstyled) {

--- a/packages/markdown/prepareMarkdown.test.js
+++ b/packages/markdown/prepareMarkdown.test.js
@@ -13,7 +13,7 @@ describe('prepareMarkdown', () => {
     const markdown = `
 # Support
 
-<p class="description">Foo</p>
+<p class="description">Foo.</p>
 
 ## Community help (free)
 ### GitHub <img src="/static/images/logos/github.svg" width="24" height="24" alt="GitHub logo" loading="lazy" />
@@ -64,7 +64,7 @@ describe('prepareMarkdown', () => {
     const markdown = `
 # Theming
 
-<p class="description">Foo</p>
+<p class="description">Foo.</p>
 
 ## API
 ### responsiveFontSizes(theme, options) => theme
@@ -105,7 +105,7 @@ describe('prepareMarkdown', () => {
     const markdownEn = `
 # Localization
 
-<p class="description">Foo</p>
+<p class="description">Foo.</p>
 
 ## Locales
 ### Example
@@ -115,7 +115,7 @@ describe('prepareMarkdown', () => {
     const markdownPt = `
 # Localização
 
-<p class="description">Foo</p>
+<p class="description">Foo.</p>
 
 ## Idiomas
 ### Exemplo
@@ -125,7 +125,7 @@ describe('prepareMarkdown', () => {
     const markdownZh = `
 # 所在位置
 
-<p class="description">Foo</p>
+<p class="description">Foo.</p>
 
 ## 语言环境
 ### 例
@@ -211,7 +211,7 @@ describe('prepareMarkdown', () => {
     const markdownEn = `
 # Localization
 
-<p class="description">Foo</p>
+<p class="description">Foo.</p>
 
 ## Locales
 ### Example
@@ -221,7 +221,7 @@ describe('prepareMarkdown', () => {
     const markdownPt = `
 # Localização
 
-<p class="description">Foo</p>
+<p class="description">Foo.</p>
 
 ## Idiomas
 ### Exemplo
@@ -292,7 +292,7 @@ describe('prepareMarkdown', () => {
     const markdown = `
 # Localization
 
-<p class="description">Foo</p>
+<p class="description">Foo.</p>
 
 [bar](/bar/)
 [foo](/foo)
@@ -314,7 +314,7 @@ See https://ahrefs.com/blog/trailing-slash/ for more details.
     const markdown = `
 # Localization
 
-<p class="description">Foo</p>
+<p class="description">Foo.</p>
 
 [bar](/bar/)
 [foo](foo/)
@@ -334,7 +334,7 @@ See https://ahrefs.com/blog/trailing-slash/ for more details.
     const markdown = `
 # Foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 
-<p class="description">Foo</p>
+<p class="description">Foo.</p>
 
 `;
 
@@ -354,7 +354,7 @@ https://developers.google.com/search/docs/advanced/appearance/title-link
     const markdown = `
 # Foo
 
-<p class="description">Fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo</p>
+<p class="description">Foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.</p>
 
 `;
 
@@ -364,7 +364,7 @@ https://developers.google.com/search/docs/advanced/appearance/title-link
         translations: [{ filename: 'index.md', markdown, userLanguage: 'en' }],
       });
     }).to
-      .throw(`docs-infra: The description "Fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo" is too long (188 characters).
+      .throw(`docs-infra: The description "Foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo." is too long (188 characters).
 It needs to have fewer than 170 characters—ideally less than 160. For more details, see:
 https://ahrefs.com/blog/meta-description/#4-be-concise
 `);
@@ -374,7 +374,7 @@ https://ahrefs.com/blog/meta-description/#4-be-concise
     const markdown = `
 # Foo
 
-<p class="description">Fo</p>
+<p class="description">Fo.</p>
 
 \`\`\`sh
 npm install @mui/material
@@ -401,7 +401,7 @@ Use "bash" instead.
     const markdown = `
 # Localization
 
-<p class="description">Foo</p>
+<p class="description">Foo.</p>
 
 [foo](/foo/)
 [bar](/bar//#foo)


### PR DESCRIPTION
I noticed this in: https://github.com/mui/toolpad/pull/4344/files#r1826369440.

I didn't look at how this can be replicated on the next docs-infra structure, but at least, in the meantime, we will make sure it's done right, less migration effort. I opened https://github.com/mui/toolpad/pull/4351 and https://github.com/mui/mui-x/pull/15229 to make it easier for those repositories to upgrade docs-infra with this PR in.