### PR TITLE
[core] Update Gold sponsoring backlinks

### DIFF
--- a/docs/data/material/discover-more/backers/backers.md
+++ b/docs/data/material/discover-more/backers/backers.md
@@ -156,7 +156,7 @@ Your organization logo will be placed in:
 - the [README.md](https://github.com/mui/material-ui#sponsors) (80k+ unique visitors/month)
 - the [Gold sponsor list](#gold-sponsors)
 
-\*we accept donations, but we won't show unethical ads.
+\*for backlink sponsors, your logo won't be visible.
 
 ### Silver
 


### PR DESCRIPTION
Keep the sponsoring docs in sync with: https://www.notion.so/mui-org/sales-Introduce-backlink-sponsor-plan-49e70924423e462aad099df16273c094.

https://opencollective.com/mui-org Gold plan description already reflects this.