### PR TITLE
[docs-infra] Fix ad in RTL

### DIFF
--- a/packages/mui-docs/src/Ad/ad.styles.ts
+++ b/packages/mui-docs/src/Ad/ad.styles.ts
@@ -7,9 +7,11 @@ export const adBodyImageStyles = (theme: Theme) => ({
     border: '1px dashed',
     borderColor: theme.palette.divider,
     borderRadius: theme.shape.borderRadius,
-    padding: '8px 8px 8px calc(8px + 130px)',
+    padding: 8,
+    paddingLeft: 8 + 130,
     [theme.breakpoints.up('sm')]: {
-      padding: '12px 12px 12px calc(12px + 130px)',
+      padding: 12,
+      paddingLeft: 12 + 130,
     },
   },
   imgWrapper: {


### PR DESCRIPTION
It's a regression, it was working fine in v4: https://v4.mui.com/getting-started/installation/. It's a quick win, to get us closer to peak execution. RTL docs needs to look correct to have credibility with RTL. I noticed this in https://github.com/mui/mui-x/pull/15072.
Regressions like https://github.com/mui/material-ui/issues/41239 are red flags for RTL users (I have seen a few more problems with icons and spacing).

Before: https://mui.com/material-ui/react-button/
<img width="851" alt="SCR-20241108-bygo" src="https://github.com/user-attachments/assets/13e23c54-4991-4504-a0ae-94825b1fbc67">

After:
<img width="831" alt="SCR-20241108-bzjd" src="https://github.com/user-attachments/assets/470cf2c1-a4d5-41aa-a332-cbb5d0faf92e">
