### PR TITLE
[docs] Fix Pigment CSS install

### DIFF
--- a/docs/data/material/experimental-api/pigment-css/pigment-css.md
+++ b/docs/data/material/experimental-api/pigment-css/pigment-css.md
@@ -48,8 +48,8 @@ npm install --save-dev @pigment-css/nextjs-plugin
 ```
 
 ```bash Vite
-npm install @pigment-css/react@next
-npm install --save-dev @pigment-css/vite-plugin@next
+npm install @pigment-css/react
+npm install --save-dev @pigment-css/vite-plugin
 ```
 
 </codeblock>


### PR DESCRIPTION
Same as https://github.com/mui/pigment-css/pull/292. There is no `next` tag on 

- https://www.npmjs.com/package/@pigment-css/react?activeTab=versions
- https://www.npmjs.com/package/@pigment-css/vite-plugin?activeTab=versions

so for sure it won't work.

---

A general rule of thumb I follow all the time:

1. Setup VS Code to have all the MUI org's codebase

<img width="266" alt="SCR-20241109-nvuc" src="https://github.com/user-attachments/assets/0abaf814-767a-4970-a614-c994092e6c4b">

2. Search the codebase for similar problems

I'm not super confident about those probabilities, but it feels like this: 90% of the time community contributor PR's authors don't do this. And 30% of the time we fix only part of the issue because if we did, we would have found more. So I now systematically do it, so I think it's a best practice for maintainers too.