### PR TITLE
[docs] Bring back `*Component` and `*Props` codemods and deprecation messages

### DIFF
--- a/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
+++ b/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
@@ -283,52 +283,29 @@ npx @mui/codemod@latest deprecations/autocomplete-props <path>
 
 ### \*Component props
 
-All of the Autocomplete's slot (`*Component`) props were deprecated in favor of equivalent `slots` entries:
+All of the Autocomplete's slot (`*Component`) props were deprecated in favor of equivalent `slots` and `slotProps` entries:
 
 ```diff
  <Autocomplete
--    ListboxComponent={CustomListboxComponent}
 -    PaperComponent={CustomPaperComponent}
 -    PopperComponent={CustomPopperComponent}
+-    ListboxComponent={CustomListboxComponent}
 +    slots={{
-+        listbox: CustomListboxComponent,
 +        paper: CustomPaperComponent,
 +        popper: CustomPopperComponent,
 +    }}
- />
-```
-
-### \*Props props
-
-All of the Autocomplete's slot props (`*Props`) props were deprecated in favor of equivalent `slotProps` entries:
-
-```diff
- <Autocomplete
--    ChipProps={CustomChipProps}
--    ListboxProps={CustomListboxProps}
 +    slotProps={{
-+        chip: CustomChipProps,
-+        listbox: CustomListboxProps,
++        listbox: {
++            component: CustomListboxComponent,
++        },
 +    }}
  />
 ```
 
-### \*Component props
-
-All of the Autocomplete's slot (`*Component`) props were deprecated in favor of equivalent `slots` entries:
-
-```diff
- <Autocomplete
--    ListboxComponent={CustomListboxComponent}
--    PaperComponent={CustomPaperComponent}
--    PopperComponent={CustomPopperComponent}
-+    slots={{
-+        listbox: CustomListboxComponent,
-+        paper: CustomPaperComponent,
-+        popper: CustomPopperComponent,
-+    }}
- />
-```
+:::warning
+The listbox slot is a special case because `ListboxComponent` was implemented differently from the other `*Component` props, behaving similar to the `component` and `as` props.
+The `slots.listbox` entry exists and you can use it to replace the component entirely, but if you want to keep `ListboxComponent`'s behavior which maintains the original listbox styles, you should use the `slotProps.listbox.component` entry.
+:::
 
 ### \*Props props
 

--- a/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
+++ b/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
@@ -87,6 +87,36 @@ You can also manually update your theme as shown in the snippet below:
 
 This reduces the API surface and lets you define variants in other slots of the component.
 
+## Accordion
+
+Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#accordion-props) below to migrate the code as described in the following sections:
+
+```bash
+npx @mui/codemod@latest deprecations/accordion-props <path>
+```
+
+### TransitionComponent
+
+The Accordion's `TransitionComponent` prop was deprecated in favor of `slots.transition`:
+
+```diff
+ <Accordion
+-  TransitionComponent={CustomTransition}
++  slots={{ transition: CustomTransition }}
+ />
+```
+
+### TransitionProps
+
+The Accordion's `TransitionProps` prop was deprecated in favor of `slotProps.transition`:
+
+```diff
+ <Accordion
+-  TransitionProps={{ unmountOnExit: true }}
++  slotProps={{ transition: { unmountOnExit: true } }}
+ />
+```
+
 ## AccordionSummary
 
 Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#accordion-summary-classes) below to migrate the code as described in the following sections:
@@ -251,6 +281,70 @@ Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-code
 npx @mui/codemod@latest deprecations/autocomplete-props <path>
 ```
 
+### \*Component props
+
+All of the Autocomplete's slot (`*Component`) props were deprecated in favor of equivalent `slots` entries:
+
+```diff
+ <Autocomplete
+-    ListboxComponent={CustomListboxComponent}
+-    PaperComponent={CustomPaperComponent}
+-    PopperComponent={CustomPopperComponent}
++    slots={{
++        listbox: CustomListboxComponent,
++        paper: CustomPaperComponent,
++        popper: CustomPopperComponent,
++    }}
+ />
+```
+
+### \*Props props
+
+All of the Autocomplete's slot props (`*Props`) props were deprecated in favor of equivalent `slotProps` entries:
+
+```diff
+ <Autocomplete
+-    ChipProps={CustomChipProps}
+-    ListboxProps={CustomListboxProps}
++    slotProps={{
++        chip: CustomChipProps,
++        listbox: CustomListboxProps,
++    }}
+ />
+```
+
+### \*Component props
+
+All of the Autocomplete's slot (`*Component`) props were deprecated in favor of equivalent `slots` entries:
+
+```diff
+ <Autocomplete
+-    ListboxComponent={CustomListboxComponent}
+-    PaperComponent={CustomPaperComponent}
+-    PopperComponent={CustomPopperComponent}
++    slots={{
++        listbox: CustomListboxComponent,
++        paper: CustomPaperComponent,
++        popper: CustomPopperComponent,
++    }}
+ />
+```
+
+### \*Props props
+
+All of the Autocomplete's slot props (`*Props`) props were deprecated in favor of equivalent `slotProps` entries:
+
+```diff
+ <Autocomplete
+-    ChipProps={CustomChipProps}
+-    ListboxProps={CustomListboxProps}
++    slotProps={{
++        chip: CustomChipProps,
++        listbox: CustomListboxProps,
++    }}
+ />
+```
+
 ### componentsProps
 
 The Autocomplete's `componentsProps` prop was deprecated in favor of `slotProps`:
@@ -269,6 +363,32 @@ The Autocomplete's `componentsProps` prop was deprecated in favor of `slotProps`
 +    popupIndicator: { width: 16 },
    }}
  />
+```
+
+## Avatar
+
+Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#avatar-props) below to migrate the code as described in the following sections:
+
+```bash
+npx @mui/codemod@latest deprecations/avatar-props <path>
+```
+
+### imgProps
+
+The Avatar's `imgProps` prop was deprecated in favor of `slotProps.img`:
+
+```diff
+ <Avatar
+-  imgProps={{
+-    onError: () => {},
+-    onLoad: () => {},
++  slotProps={{
++    img: {
++      onError: () => {},
++      onLoad: () => {},
++    }
+   }}
+ />;
 ```
 
 ## AvatarGroup
@@ -357,6 +477,16 @@ The Backdrop's `componentsProps` prop was deprecated in favor of `slotProps`:
 -  componentsProps={{ root: { testid: 'test-id' } }}
 +  slotProps={{ root: { testid: 'test-id' } }}
  />
+```
+
+### TransitionComponent
+
+The Backdrop's `TransitionComponent` prop was deprecated in favor of `slots.transition`:
+
+```diff
+ <Slider
+-  TransitionComponent={CustomTransition}
++  slots={{ transition: CustomTransition }}
 ```
 
 ## Badge
@@ -1625,6 +1755,28 @@ The StepLabel's `componentsProps` prop was deprecated in favor of `slotProps`:
  />
 ```
 
+### StepIconComponent
+
+The StepLabel's `StepIconComponent` prop was deprecated in favor of `slots.stepIcon`:
+
+```diff
+ <StepLabel
+-  StepIconComponent={StepIconComponent}
++  slots={{ stepIcon: StepIconComponent }}
+ />
+```
+
+### StepIconProps
+
+The StepLabel's `StepIconProps` prop was deprecated in favor of `slotProps.stepIcon`:
+
+```diff
+ <StepLabel
+-  StepIconProps={StepIconProps}
++  slotProps={{ stepIcon: StepIconProps }}
+ />
+```
+
 ## StepConnector
 
 Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#step-connector-classes) below to migrate the code as described in the following sections:
@@ -1663,4 +1815,33 @@ Here's how to migrate:
      },
    },
  },
+```
+
+## SpeedDial
+
+Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#speed-dial-props) below to migrate the code as described in the following sections:
+
+```bash
+npx @mui/codemod@next deprecations/speed-dial-props <path>
+```
+
+### TransitionComponent
+
+The SpeedDial's `TransitionComponent` prop was deprecated in favor of `slots.transition`:
+
+```diff
+ <SpeedDial
+-  TransitionComponent={CustomTransition}
++  slots={{ transition: CustomTransition }}
+```
+
+### TransitionProps
+
+The SpeedDial's `TransitionProps` prop was deprecated in favor of `slotProps.transition`:
+
+```diff
+ <SpeedDial
+-  TransitionProps={{ unmountOnExit: true }}
++  slotProps={{ transition: { unmountOnExit: true } }}
+ />
 ```

--- a/docs/pages/material-ui/api/accordion.json
+++ b/docs/pages/material-ui/api/accordion.json
@@ -35,8 +35,16 @@
       },
       "additionalInfo": { "sx": true }
     },
-    "TransitionComponent": { "type": { "name": "elementType" } },
-    "TransitionProps": { "type": { "name": "object" } }
+    "TransitionComponent": {
+      "type": { "name": "elementType" },
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slots.transition</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+    },
+    "TransitionProps": {
+      "type": { "name": "object" },
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slotProps.transition</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+    }
   },
   "name": "Accordion",
   "imports": [

--- a/docs/pages/material-ui/api/autocomplete.json
+++ b/docs/pages/material-ui/api/autocomplete.json
@@ -16,7 +16,11 @@
       },
       "default": "false"
     },
-    "ChipProps": { "type": { "name": "object" } },
+    "ChipProps": {
+      "type": { "name": "object" },
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slotProps.chip</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+    },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "clearIcon": { "type": { "name": "node" }, "default": "<ClearIcon fontSize=\"small\" />" },
     "clearOnBlur": { "type": { "name": "bool" }, "default": "!props.freeSolo" },
@@ -93,8 +97,17 @@
       }
     },
     "limitTags": { "type": { "name": "custom", "description": "integer" }, "default": "-1" },
-    "ListboxComponent": { "type": { "name": "elementType" }, "default": "'ul'" },
-    "ListboxProps": { "type": { "name": "object" } },
+    "ListboxComponent": {
+      "type": { "name": "elementType" },
+      "default": "'ul'",
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slots.listbox</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+    },
+    "ListboxProps": {
+      "type": { "name": "object" },
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slotProps.listbox</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+    },
     "loading": { "type": { "name": "bool" }, "default": "false" },
     "loadingText": { "type": { "name": "node" }, "default": "'Loading…'" },
     "multiple": { "type": { "name": "bool" }, "default": "false" },
@@ -137,8 +150,18 @@
     "open": { "type": { "name": "bool" } },
     "openOnFocus": { "type": { "name": "bool" }, "default": "false" },
     "openText": { "type": { "name": "string" }, "default": "'Open'" },
-    "PaperComponent": { "type": { "name": "elementType" }, "default": "Paper" },
-    "PopperComponent": { "type": { "name": "elementType" }, "default": "Popper" },
+    "PaperComponent": {
+      "type": { "name": "elementType" },
+      "default": "Paper",
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slots.paper</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+    },
+    "PopperComponent": {
+      "type": { "name": "elementType" },
+      "default": "Popper",
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slots.popper</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+    },
     "popupIcon": { "type": { "name": "node" }, "default": "<ArrowDropDownIcon />" },
     "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "renderGroup": {

--- a/docs/pages/material-ui/api/autocomplete.json
+++ b/docs/pages/material-ui/api/autocomplete.json
@@ -101,7 +101,7 @@
       "type": { "name": "elementType" },
       "default": "'ul'",
       "deprecated": true,
-      "deprecationInfo": "Use <code>slots.listbox</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+      "deprecationInfo": "Use <code>slotProps.listbox.component</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
     },
     "ListboxProps": {
       "type": { "name": "object" },

--- a/docs/pages/material-ui/api/avatar.json
+++ b/docs/pages/material-ui/api/avatar.json
@@ -4,7 +4,11 @@
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "component": { "type": { "name": "elementType" } },
-    "imgProps": { "type": { "name": "object" } },
+    "imgProps": {
+      "type": { "name": "object" },
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slotProps.img</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+    },
     "sizes": { "type": { "name": "string" } },
     "slotProps": {
       "type": { "name": "shape", "description": "{ img?: func<br>&#124;&nbsp;object }" },

--- a/docs/pages/material-ui/api/backdrop.json
+++ b/docs/pages/material-ui/api/backdrop.json
@@ -38,7 +38,12 @@
       },
       "additionalInfo": { "sx": true }
     },
-    "TransitionComponent": { "type": { "name": "elementType" }, "default": "Fade" },
+    "TransitionComponent": {
+      "type": { "name": "elementType" },
+      "default": "Fade",
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slots.transition</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+    },
     "transitionDuration": {
       "type": {
         "name": "union",

--- a/docs/pages/material-ui/api/speed-dial.json
+++ b/docs/pages/material-ui/api/speed-dial.json
@@ -44,7 +44,12 @@
       },
       "additionalInfo": { "sx": true }
     },
-    "TransitionComponent": { "type": { "name": "elementType" }, "default": "Zoom" },
+    "TransitionComponent": {
+      "type": { "name": "elementType" },
+      "default": "Zoom\n* @deprecated Use `slots.transition` instead. This prop will be removed in v7. [How to migrate](/material-ui/migration/migrating-from-deprecated-apis/)",
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slots.transition</code> instead. This prop will be removed in v7. <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">How to migrate</a>"
+    },
     "transitionDuration": {
       "type": {
         "name": "union",
@@ -52,7 +57,11 @@
       },
       "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     },
-    "TransitionProps": { "type": { "name": "object" } }
+    "TransitionProps": {
+      "type": { "name": "object" },
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slotProps.transition</code> instead. This prop will be removed in v7. <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">How to migrate</a>"
+    }
   },
   "name": "SpeedDial",
   "imports": [

--- a/docs/pages/material-ui/api/step-label.json
+++ b/docs/pages/material-ui/api/step-label.json
@@ -22,8 +22,16 @@
       "type": { "name": "shape", "description": "{ label?: elementType, stepIcon?: elementType }" },
       "default": "{}"
     },
-    "StepIconComponent": { "type": { "name": "elementType" } },
-    "StepIconProps": { "type": { "name": "object" } },
+    "StepIconComponent": {
+      "type": { "name": "elementType" },
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slots.stepIcon</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+    },
+    "StepIconProps": {
+      "type": { "name": "object" },
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slotProps.stepIcon</code> instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+    },
     "sx": {
       "type": {
         "name": "union",

--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -275,12 +275,14 @@ npx @mui/codemod@latest deprecations/alert-props <path>
 -  }}
 +  slots={{
 +    paper: CustomPaper,
-+    popper: CustomPopper,
-+    listbox: CustomListbox,
++    popper: CustomPopper
 +  }}
 +  slotProps={{
 +    chip: { height: 10 },
-+    listbox: { height: 12 },
++    listbox: {
++        component: CustomListbox,
++        ...{ height: 12 },
++    },
 +    clearIndicator: { width: 10 },
 +    paper: { width: 12 },
 +    popper: { width: 14 },
@@ -306,11 +308,13 @@ npx @mui/codemod@latest deprecations/alert-props <path>
 +    slots: {
 +      paper: CustomPaper,
 +      popper: CustomPopper,
-+      listbox: CustomListbox,
 +    },
 +    slotProps: {
 +      chip: { height: 10 },
-+      listbox: { height: 12 },
++      listbox: {
++        component: CustomListbox,
++        ...{ height: 12 },
++      },
 +      clearIndicator: { width: 10 },
 +      paper: { width: 12 },
 +      popper: { width: 14 },

--- a/packages/mui-codemod/src/deprecations/all/deprecations-all.js
+++ b/packages/mui-codemod/src/deprecations/all/deprecations-all.js
@@ -1,7 +1,9 @@
 import transformAccordionClasses from '../accordion-summary-classes';
+import transformAccordionProps from '../accordion-props';
 import transformAlertClasses from '../alert-classes';
 import transformAvatarGroupProps from '../avatar-group-props';
 import transformAutocompleteProps from '../autocomplete-props';
+import transformAvatarProps from '../avatar-props';
 import transformBackdropProps from '../backdrop-props';
 import transformButtonClasses from '../button-classes';
 import transformButtonGroupClasses from '../button-group-classes';
@@ -16,6 +18,7 @@ import transformInputProps from '../input-props';
 import transformModalProps from '../modal-props';
 import transformOutlinedInputProps from '../outlined-input-props';
 import transformPaginationItemClasses from '../pagination-item-classes';
+import transformSpeedDialProps from '../speed-dial-props';
 import transformTableSortLabelClasses from '../table-sort-label-classes';
 import transformStepConnectorClasses from '../step-connector-classes';
 import transformStepLabelProps from '../step-label-props';
@@ -29,9 +32,11 @@ import transformToggleButtonGroupClasses from '../toggle-button-group-classes';
  */
 export default function deprecationsAll(file, api, options) {
   file.source = transformAccordionClasses(file, api, options);
+  file.source = transformAccordionProps(file, api, options);
   file.source = transformAlertClasses(file, api, options);
   file.source = transformAvatarGroupProps(file, api, options);
   file.source = transformAutocompleteProps(file, api, options);
+  file.source = transformAvatarProps(file, api, options);
   file.source = transformBackdropProps(file, api, options);
   file.source = transformButtonClasses(file, api, options);
   file.source = transformButtonGroupClasses(file, api, options);
@@ -46,6 +51,7 @@ export default function deprecationsAll(file, api, options) {
   file.source = transformModalProps(file, api, options);
   file.source = transformOutlinedInputProps(file, api, options);
   file.source = transformPaginationItemClasses(file, api, options);
+  file.source = transformSpeedDialProps(file, api, options);
   file.source = transformStepConnectorClasses(file, api, options);
   file.source = transformStepLabelProps(file, api, options);
   file.source = transformTableSortLabelClasses(file, api, options);

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/autocomplete-props.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/autocomplete-props.js
@@ -1,3 +1,5 @@
+import movePropIntoSlots from '../utils/movePropIntoSlots';
+import movePropIntoSlotProps from '../utils/movePropIntoSlotProps';
 import replaceComponentsWithSlots from '../utils/replaceComponentsWithSlots';
 
 /**
@@ -8,6 +10,41 @@ export default function transformer(file, api, options) {
   const j = api.jscodeshift;
   const root = j(file.source);
   const printOptions = options.printOptions;
+
+  movePropIntoSlots(j, {
+    root,
+    componentName: 'Autocomplete',
+    propName: 'PaperComponent',
+    slotName: 'paper',
+  });
+
+  movePropIntoSlots(j, {
+    root,
+    componentName: 'Autocomplete',
+    propName: 'PopperComponent',
+    slotName: 'popper',
+  });
+
+  movePropIntoSlots(j, {
+    root,
+    componentName: 'Autocomplete',
+    propName: 'ListboxComponent',
+    slotName: 'listbox',
+  });
+
+  movePropIntoSlotProps(j, {
+    root,
+    componentName: 'Autocomplete',
+    propName: 'ListboxProps',
+    slotName: 'listbox',
+  });
+
+  movePropIntoSlotProps(j, {
+    root,
+    componentName: 'Autocomplete',
+    propName: 'ChipProps',
+    slotName: 'chip',
+  });
 
   replaceComponentsWithSlots(j, { root, componentName: 'Autocomplete' });
 

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/autocomplete-props.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/autocomplete-props.js
@@ -99,47 +99,62 @@ export default function transformer(file, api, options) {
   });
 
   // Move ListboxComponent default prop into slotProps.listbox.component
-  const defaultPropsPathCollection = findComponentDefaultProps(j, { root, componentName: 'Autocomplete' });
-
-  defaultPropsPathCollection.find(j.ObjectProperty, { key: { name: 'ListboxComponent' } }).forEach((path) => {
-    const removedValue = path.value.value;
-    const defaultProps = path.parent.value;
-
-    let hasSlotProps = false;
-    defaultProps.properties.forEach((property) => {
-      if (property.key?.name === 'slotProps') {
-        hasSlotProps = true;
-        const slotIndex = property.value.properties.findIndex(
-          (prop) => prop?.key?.name === 'listbox',
-        );
-        if (slotIndex === -1) {
-          property.value.properties.push(j.objectProperty(j.identifier('listbox'), j.objectExpression([j.objectProperty(j.identifier('component'), removedValue)])));
-        } else {
-          const slotPropsSlotValue = property.value.properties.splice(slotIndex, 1)[0].value;
-          property.value.properties.push(
-            j.objectProperty(
-              j.identifier('listbox'),
-              j.objectExpression([
-                j.objectProperty(j.identifier('component'), removedValue),
-                j.spreadElement(slotPropsSlotValue),
-              ]),
-            ),
-          );
-        }
-      }
-    });
-
-    if (!hasSlotProps) {
-      defaultProps.properties.push(
-        j.objectProperty(
-          j.identifier('slotProps'),
-          j.objectExpression([j.objectProperty(j.identifier('listbox'), j.objectExpression([j.objectProperty(j.identifier('component'), removedValue)]))]),
-        ),
-      );
-    }
-
-    path.prune();
+  const defaultPropsPathCollection = findComponentDefaultProps(j, {
+    root,
+    componentName: 'Autocomplete',
   });
+
+  defaultPropsPathCollection
+    .find(j.ObjectProperty, { key: { name: 'ListboxComponent' } })
+    .forEach((path) => {
+      const removedValue = path.value.value;
+      const defaultProps = path.parent.value;
+
+      let hasSlotProps = false;
+      defaultProps.properties.forEach((property) => {
+        if (property.key?.name === 'slotProps') {
+          hasSlotProps = true;
+          const slotIndex = property.value.properties.findIndex(
+            (prop) => prop?.key?.name === 'listbox',
+          );
+          if (slotIndex === -1) {
+            property.value.properties.push(
+              j.objectProperty(
+                j.identifier('listbox'),
+                j.objectExpression([j.objectProperty(j.identifier('component'), removedValue)]),
+              ),
+            );
+          } else {
+            const slotPropsSlotValue = property.value.properties.splice(slotIndex, 1)[0].value;
+            property.value.properties.push(
+              j.objectProperty(
+                j.identifier('listbox'),
+                j.objectExpression([
+                  j.objectProperty(j.identifier('component'), removedValue),
+                  j.spreadElement(slotPropsSlotValue),
+                ]),
+              ),
+            );
+          }
+        }
+      });
+
+      if (!hasSlotProps) {
+        defaultProps.properties.push(
+          j.objectProperty(
+            j.identifier('slotProps'),
+            j.objectExpression([
+              j.objectProperty(
+                j.identifier('listbox'),
+                j.objectExpression([j.objectProperty(j.identifier('component'), removedValue)]),
+              ),
+            ]),
+          ),
+        );
+      }
+
+      path.prune();
+    });
 
   return root.toSource(printOptions);
 }

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/autocomplete-props.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/autocomplete-props.js
@@ -1,6 +1,10 @@
 import movePropIntoSlots from '../utils/movePropIntoSlots';
 import movePropIntoSlotProps from '../utils/movePropIntoSlotProps';
 import replaceComponentsWithSlots from '../utils/replaceComponentsWithSlots';
+import findComponentJSX from '../../util/findComponentJSX';
+import findComponentDefaultProps from '../../util/findComponentDefaultProps';
+import assignObject from '../../util/assignObject';
+import appendAttribute from '../../util/appendAttribute';
 
 /**
  * @param {import('jscodeshift').FileInfo} file
@@ -25,13 +29,6 @@ export default function transformer(file, api, options) {
     slotName: 'popper',
   });
 
-  movePropIntoSlots(j, {
-    root,
-    componentName: 'Autocomplete',
-    propName: 'ListboxComponent',
-    slotName: 'listbox',
-  });
-
   movePropIntoSlotProps(j, {
     root,
     componentName: 'Autocomplete',
@@ -47,6 +44,102 @@ export default function transformer(file, api, options) {
   });
 
   replaceComponentsWithSlots(j, { root, componentName: 'Autocomplete' });
+
+  // Move ListboxComponent JSX prop into slotProps.listbox.component
+  findComponentJSX(j, { root, componentName: 'Autocomplete' }, (elementPath) => {
+    const element = elementPath.node;
+    const propIndex = element.openingElement.attributes.findIndex(
+      (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'ListboxComponent',
+    );
+
+    if (propIndex !== -1) {
+      const removedValue = element.openingElement.attributes.splice(propIndex, 1)[0].value
+        .expression;
+      let hasSlotProps = false;
+      element.openingElement.attributes.forEach((attr) => {
+        if (attr.name?.name === 'slotProps') {
+          hasSlotProps = true;
+          const slots = attr.value.expression;
+          const slotIndex = slots.properties.findIndex((prop) => prop?.key?.name === 'listbox');
+          if (slotIndex === -1) {
+            assignObject(j, {
+              target: attr,
+              key: 'listbox',
+              expression: j.objectExpression([
+                j.objectProperty(j.identifier('component'), removedValue),
+              ]),
+            });
+          } else {
+            const slotPropsSlotValue = slots.properties.splice(slotIndex, 1)[0].value;
+            assignObject(j, {
+              target: attr,
+              key: 'listbox',
+              expression: j.objectExpression([
+                j.objectProperty(j.identifier('component'), removedValue),
+                j.spreadElement(slotPropsSlotValue),
+              ]),
+            });
+          }
+        }
+      });
+
+      if (!hasSlotProps) {
+        appendAttribute(j, {
+          target: element,
+          attributeName: 'slotProps',
+          expression: j.objectExpression([
+            j.objectProperty(
+              j.identifier('listbox'),
+              j.objectExpression([j.objectProperty(j.identifier('component'), removedValue)]),
+            ),
+          ]),
+        });
+      }
+    }
+  });
+
+  // Move ListboxComponent default prop into slotProps.listbox.component
+  const defaultPropsPathCollection = findComponentDefaultProps(j, { root, componentName: 'Autocomplete' });
+
+  defaultPropsPathCollection.find(j.ObjectProperty, { key: { name: 'ListboxComponent' } }).forEach((path) => {
+    const removedValue = path.value.value;
+    const defaultProps = path.parent.value;
+
+    let hasSlotProps = false;
+    defaultProps.properties.forEach((property) => {
+      if (property.key?.name === 'slotProps') {
+        hasSlotProps = true;
+        const slotIndex = property.value.properties.findIndex(
+          (prop) => prop?.key?.name === 'listbox',
+        );
+        if (slotIndex === -1) {
+          property.value.properties.push(j.objectProperty(j.identifier('listbox'), j.objectExpression([j.objectProperty(j.identifier('component'), removedValue)])));
+        } else {
+          const slotPropsSlotValue = property.value.properties.splice(slotIndex, 1)[0].value;
+          property.value.properties.push(
+            j.objectProperty(
+              j.identifier('listbox'),
+              j.objectExpression([
+                j.objectProperty(j.identifier('component'), removedValue),
+                j.spreadElement(slotPropsSlotValue),
+              ]),
+            ),
+          );
+        }
+      }
+    });
+
+    if (!hasSlotProps) {
+      defaultProps.properties.push(
+        j.objectProperty(
+          j.identifier('slotProps'),
+          j.objectExpression([j.objectProperty(j.identifier('listbox'), j.objectExpression([j.objectProperty(j.identifier('component'), removedValue)]))]),
+        ),
+      );
+    }
+
+    path.prune();
+  });
 
   return root.toSource(printOptions);
 }

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/actual.js
@@ -2,6 +2,11 @@ import Autocomplete from '@mui/material/Autocomplete';
 import {Autocomplete as MyAutocomplete} from '@mui/material';
 
 <Autocomplete
+  ChipProps={{ height: 10 }}
+  PaperComponent={CustomPaper}
+  PopperComponent={CustomPopper}
+  ListboxComponent={CustomListbox}
+  ListboxProps={{ height: 12 }}
   componentsProps={{
     clearIndicator: { width: 10 },
     paper: { width: 12 },
@@ -11,6 +16,11 @@ import {Autocomplete as MyAutocomplete} from '@mui/material';
 />;
 
 <Autocomplete
+  ChipProps={{ height: 10 }}
+  PaperComponent={CustomPaper}
+  PopperComponent={CustomPopper}
+  ListboxComponent={CustomListbox}
+  ListboxProps={{ height: 12 }}
   slotProps={{
     popupIndicator: { width: 20 }
   }}
@@ -23,6 +33,11 @@ import {Autocomplete as MyAutocomplete} from '@mui/material';
 />;
 
 <MyAutocomplete
+  ChipProps={{ height: 10 }}
+  PaperComponent={CustomPaper}
+  PopperComponent={CustomPopper}
+  ListboxComponent={CustomListbox}
+  ListboxProps={{ height: 12 }}
   componentsProps={{
     clearIndicator: { width: 10 },
     paper: { width: 12 },
@@ -32,10 +47,9 @@ import {Autocomplete as MyAutocomplete} from '@mui/material';
 />;
 
 <CustomAutocomplete
-  componentsProps={{
-    clearIndicator: { width: 10 },
-    paper: { width: 12 },
-    popper: { width: 14 },
-    popupIndicator: { width: 16 },
-  }}
+  ChipProps={{ height: 10 }}
+  PaperComponent={CustomPaper}
+  PopperComponent={CustomPopper}
+  ListboxComponent={CustomListbox}
+  ListboxProps={{ height: 12 }}
 />

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/actual.js
@@ -47,6 +47,15 @@ import {Autocomplete as MyAutocomplete} from '@mui/material';
 />;
 
 <CustomAutocomplete
+  componentsProps={{
+    clearIndicator: { width: 10 },
+    paper: { width: 12 },
+    popper: { width: 14 },
+    popupIndicator: { width: 16 },
+  }}
+/>;
+
+<CustomAutocomplete
   ChipProps={{ height: 10 }}
   PaperComponent={CustomPaper}
   PopperComponent={CustomPopper}

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/expected.js
@@ -2,16 +2,24 @@ import Autocomplete from '@mui/material/Autocomplete';
 import {Autocomplete as MyAutocomplete} from '@mui/material';
 
 <Autocomplete
+  slots={{
+    paper: CustomPaper,
+    popper: CustomPopper,
+    listbox: CustomListbox
+  }}
   slotProps={{
+    listbox: { height: 12 },
+    chip: { height: 10 },
     clearIndicator: { width: 10 },
     paper: { width: 12 },
     popper: { width: 14 },
-    popupIndicator: { width: 16 },
-  }}
-/>;
+    popupIndicator: { width: 16 }
+  }} />;
 
 <Autocomplete
   slotProps={{
+    listbox: { height: 12 },
+    chip: { height: 10 },
     clearIndicator: { width: 10 },
     paper: { width: 12 },
     popper: { width: 14 },
@@ -20,22 +28,32 @@ import {Autocomplete as MyAutocomplete} from '@mui/material';
       ...{ width: 16 },
       ...{ width: 20 }
     }
+  }}
+  slots={{
+    paper: CustomPaper,
+    popper: CustomPopper,
+    listbox: CustomListbox
   }} />;
 
 <MyAutocomplete
+  slots={{
+    paper: CustomPaper,
+    popper: CustomPopper,
+    listbox: CustomListbox
+  }}
   slotProps={{
+    listbox: { height: 12 },
+    chip: { height: 10 },
     clearIndicator: { width: 10 },
     paper: { width: 12 },
     popper: { width: 14 },
-    popupIndicator: { width: 16 },
-  }}
-/>;
+    popupIndicator: { width: 16 }
+  }} />;
 
 <CustomAutocomplete
-  componentsProps={{
-    clearIndicator: { width: 10 },
-    paper: { width: 12 },
-    popper: { width: 14 },
-    popupIndicator: { width: 16 },
-  }}
+  ChipProps={{ height: 10 }}
+  PaperComponent={CustomPaper}
+  PopperComponent={CustomPopper}
+  ListboxComponent={CustomListbox}
+  ListboxProps={{ height: 12 }}
 />

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/expected.js
@@ -4,21 +4,23 @@ import {Autocomplete as MyAutocomplete} from '@mui/material';
 <Autocomplete
   slots={{
     paper: CustomPaper,
-    popper: CustomPopper,
-    listbox: CustomListbox
+    popper: CustomPopper
   }}
   slotProps={{
-    listbox: { height: 12 },
     chip: { height: 10 },
     clearIndicator: { width: 10 },
     paper: { width: 12 },
     popper: { width: 14 },
-    popupIndicator: { width: 16 }
+    popupIndicator: { width: 16 },
+
+    listbox: {
+      component: CustomListbox,
+      ...{ height: 12 }
+    }
   }} />;
 
 <Autocomplete
   slotProps={{
-    listbox: { height: 12 },
     chip: { height: 10 },
     clearIndicator: { width: 10 },
     paper: { width: 12 },
@@ -27,27 +29,34 @@ import {Autocomplete as MyAutocomplete} from '@mui/material';
     popupIndicator: {
       ...{ width: 16 },
       ...{ width: 20 }
+    },
+
+    listbox: {
+      component: CustomListbox,
+      ...{ height: 12 }
     }
   }}
   slots={{
     paper: CustomPaper,
-    popper: CustomPopper,
-    listbox: CustomListbox
+    popper: CustomPopper
   }} />;
 
 <MyAutocomplete
   slots={{
     paper: CustomPaper,
-    popper: CustomPopper,
-    listbox: CustomListbox
+    popper: CustomPopper
   }}
   slotProps={{
-    listbox: { height: 12 },
     chip: { height: 10 },
     clearIndicator: { width: 10 },
     paper: { width: 12 },
     popper: { width: 14 },
-    popupIndicator: { width: 16 }
+    popupIndicator: { width: 16 },
+
+    listbox: {
+      component: CustomListbox,
+      ...{ height: 12 }
+    }
   }} />;
 
 <CustomAutocomplete

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/expected.js
@@ -60,6 +60,15 @@ import {Autocomplete as MyAutocomplete} from '@mui/material';
   }} />;
 
 <CustomAutocomplete
+  componentsProps={{
+    clearIndicator: { width: 10 },
+    paper: { width: 12 },
+    popper: { width: 14 },
+    popupIndicator: { width: 16 },
+  }}
+/>;
+
+<CustomAutocomplete
   ChipProps={{ height: 10 }}
   PaperComponent={CustomPaper}
   PopperComponent={CustomPopper}

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/theme.actual.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/theme.actual.js
@@ -1,6 +1,11 @@
 fn({
   MuiAutocomplete: {
     defaultProps: {
+      ChipProps: { height: 10 },
+      PaperComponent: CustomPaper,
+      PopperComponent: CustomPopper,
+      ListboxComponent: CustomListbox,
+      ListboxProps: { height: 12 },
       componentsProps: {
         clearIndicator: { width: 10 },
         paper: { width: 12 },
@@ -14,6 +19,11 @@ fn({
 fn({
   MuiAutocomplete: {
     defaultProps: {
+      ChipProps: { height: 10 },
+      PaperComponent: CustomPaper,
+      PopperComponent: CustomPopper,
+      ListboxComponent: CustomListbox,
+      ListboxProps: { height: 12 },
       slotProps: {
         popupIndicator: { width: 20 }
       },

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/theme.expected.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/theme.expected.js
@@ -1,11 +1,19 @@
 fn({
   MuiAutocomplete: {
     defaultProps: {
+      slots: {
+        paper: CustomPaper,
+        popper: CustomPopper,
+        listbox: CustomListbox
+      },
+
       slotProps: {
         clearIndicator: { width: 10 },
         paper: { width: 12 },
         popper: { width: 14 },
-        popupIndicator: { width: 16 }
+        popupIndicator: { width: 16 },
+        listbox: { height: 12 },
+        chip: { height: 10 }
       }
     },
   },
@@ -22,7 +30,16 @@ fn({
         popupIndicator: {
           ...{ width: 16 },
           ...{ width: 20 }
-        }
+        },
+
+        listbox: { height: 12 },
+        chip: { height: 10 }
+      },
+
+      slots: {
+        paper: CustomPaper,
+        popper: CustomPopper,
+        listbox: CustomListbox
       }
     },
   },

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/theme.expected.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/theme.expected.js
@@ -3,8 +3,7 @@ fn({
     defaultProps: {
       slots: {
         paper: CustomPaper,
-        popper: CustomPopper,
-        listbox: CustomListbox
+        popper: CustomPopper
       },
 
       slotProps: {
@@ -12,8 +11,12 @@ fn({
         paper: { width: 12 },
         popper: { width: 14 },
         popupIndicator: { width: 16 },
-        listbox: { height: 12 },
-        chip: { height: 10 }
+        chip: { height: 10 },
+
+        listbox: {
+          component: CustomListbox,
+          ...{ height: 12 }
+        }
       }
     },
   },
@@ -32,14 +35,17 @@ fn({
           ...{ width: 20 }
         },
 
-        listbox: { height: 12 },
-        chip: { height: 10 }
+        chip: { height: 10 },
+
+        listbox: {
+          component: CustomListbox,
+          ...{ height: 12 }
+        }
       },
 
       slots: {
         paper: CustomPaper,
-        popper: CustomPopper,
-        listbox: CustomListbox
+        popper: CustomPopper
       }
     },
   },

--- a/packages/mui-codemod/src/deprecations/backdrop-props/backdrop-props.js
+++ b/packages/mui-codemod/src/deprecations/backdrop-props/backdrop-props.js
@@ -1,3 +1,4 @@
+import movePropIntoSlots from '../utils/movePropIntoSlots';
 import replaceComponentsWithSlots from '../utils/replaceComponentsWithSlots';
 
 /**
@@ -10,6 +11,13 @@ export default function transformer(file, api, options) {
   const printOptions = options.printOptions;
 
   replaceComponentsWithSlots(j, { root, componentName: 'Backdrop' });
+
+  movePropIntoSlots(j, {
+    root,
+    componentName: 'Backdrop',
+    propName: 'TransitionComponent',
+    slotName: 'transition',
+  });
 
   return root.toSource(printOptions);
 }

--- a/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/actual.js
@@ -1,6 +1,31 @@
 import Backdrop from '@mui/material/Backdrop';
 import { Backdrop as MyBackdrop } from '@mui/material';
 
+<Backdrop TransitionComponent={CustomTransition} />;
+<MyBackdrop TransitionComponent={CustomTransition} />;
+<Backdrop
+  TransitionComponent={CustomTransition}
+  slots={{
+    root: 'div',
+  }}
+/>;
+<MyBackdrop
+  TransitionComponent={CustomTransition}
+  slots={{
+    ...outerSlots,
+  }}
+/>;
+<Backdrop
+  TransitionComponent={ComponentTransition}
+  slots={{
+    root: 'div',
+    transition: SlotTransition,
+  }}
+/>;
+
+// should skip non MUI components
+<NonMuiBackdrop TransitionComponent={CustomTransition} />;
+
 <Backdrop components={{ Root: ComponentsRoot }} componentsProps={{ root: componentsRootProps }} />;
 <MyBackdrop components={{ Root: ComponentsRoot }} slotProps={{ root: slotsRootProps }} />;
 <Backdrop slots={{ root: SlotsRoot }} componentsProps={{ root: componentsRootProps }} />;

--- a/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/expected.js
@@ -2,6 +2,31 @@ import Backdrop from '@mui/material/Backdrop';
 import { Backdrop as MyBackdrop } from '@mui/material';
 
 <Backdrop slots={{
+  transition: CustomTransition
+}} />;
+<MyBackdrop slots={{
+  transition: CustomTransition
+}} />;
+<Backdrop
+  slots={{
+    root: 'div',
+    transition: CustomTransition
+  }} />;
+<MyBackdrop
+  slots={{
+    ...outerSlots,
+    transition: CustomTransition
+  }} />;
+<Backdrop
+  slots={{
+    root: 'div',
+    transition: SlotTransition,
+  }} />;
+
+// should skip non MUI components
+<NonMuiBackdrop TransitionComponent={CustomTransition} />;
+
+<Backdrop slots={{
   root: ComponentsRoot
 }} slotProps={{ root: componentsRootProps }} />;
 <MyBackdrop slotProps={{ root: slotsRootProps }} slots={{

--- a/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/theme.actual.js
+++ b/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/theme.actual.js
@@ -1,6 +1,37 @@
 fn({
   MuiBackdrop: {
     defaultProps: {
+      TransitionComponent: CustomTransition,
+    },
+  },
+});
+
+fn({
+  MuiBackdrop: {
+    defaultProps: {
+      TransitionComponent: CustomTransition,
+      slots: {
+        root: 'div',
+      },
+    },
+  },
+});
+
+fn({
+  MuiBackdrop: {
+    defaultProps: {
+      TransitionComponent: ComponentTransition,
+      slots: {
+        root: 'div',
+        transition: SlotTransition
+      },
+    },
+  },
+});
+
+fn({
+  MuiBackdrop: {
+    defaultProps: {
       components: { Root: ComponentsRoot },
       componentsProps: { root: componentsRootProps },
     },

--- a/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/theme.expected.js
+++ b/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/theme.expected.js
@@ -2,6 +2,38 @@ fn({
   MuiBackdrop: {
     defaultProps: {
       slots: {
+        transition: CustomTransition
+      }
+    },
+  },
+});
+
+fn({
+  MuiBackdrop: {
+    defaultProps: {
+      slots: {
+        root: 'div',
+        transition: CustomTransition
+      }
+    },
+  },
+});
+
+fn({
+  MuiBackdrop: {
+    defaultProps: {
+      slots: {
+        root: 'div',
+        transition: SlotTransition
+      }
+    },
+  },
+});
+
+fn({
+  MuiBackdrop: {
+    defaultProps: {
+      slots: {
         root: ComponentsRoot
       },
 

--- a/packages/mui-codemod/src/deprecations/step-label-props/step-label-props.js
+++ b/packages/mui-codemod/src/deprecations/step-label-props/step-label-props.js
@@ -1,4 +1,6 @@
 import replaceComponentsWithSlots from '../utils/replaceComponentsWithSlots';
+import movePropIntoSlots from '../utils/movePropIntoSlots';
+import movePropIntoSlotProps from '../utils/movePropIntoSlotProps';
 
 /**
  * @param {import('jscodeshift').FileInfo} file
@@ -10,6 +12,20 @@ export default function transformer(file, api, options) {
   const printOptions = options.printOptions;
 
   replaceComponentsWithSlots(j, { root, componentName: 'StepLabel' });
+
+  movePropIntoSlots(j, {
+    root,
+    componentName: 'StepLabel',
+    propName: 'StepIconComponent',
+    slotName: 'stepIcon',
+  });
+
+  movePropIntoSlotProps(j, {
+    root,
+    componentName: 'StepLabel',
+    propName: 'StepIconProps',
+    slotName: 'stepIcon',
+  });
 
   return root.toSource(printOptions);
 }

--- a/packages/mui-codemod/src/deprecations/step-label-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/step-label-props/test-cases/actual.js
@@ -6,3 +6,15 @@ import StepLabel from '@mui/material/StepLabel';
   slotProps={{ label: slotLabelProps }}
   componentsProps={{ label: componentsLabelProps }}
 />;
+<StepLabel componentsProps={{ label: componentsLabelProps }} StepIconProps={StepIconProps} />;
+<StepLabel
+  slots={{ label: SlotsLabel }}
+  slotProps={{ label: slotLabelProps }}
+  componentsProps={{ label: componentsLabelProps }}
+  StepIconComponent={StepIconComponent}
+  StepIconProps={StepIconProps}
+/>;
+<StepLabel
+  StepIconComponent={StepIconComponent}
+  StepIconProps={StepIconProps}
+/>;

--- a/packages/mui-codemod/src/deprecations/step-label-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/step-label-props/test-cases/expected.js
@@ -7,3 +7,29 @@ import StepLabel from '@mui/material/StepLabel';
     ...componentsLabelProps,
     ...slotLabelProps
   } }} />;
+<StepLabel
+  slotProps={{
+    label: componentsLabelProps,
+    stepIcon: StepIconProps
+  }} />;
+<StepLabel
+  slots={{
+    label: SlotsLabel,
+    stepIcon: StepIconComponent
+  }}
+  slotProps={{
+    label: {
+      ...componentsLabelProps,
+      ...slotLabelProps
+    },
+
+    stepIcon: StepIconProps
+  }} />;
+<StepLabel
+  slots={{
+    stepIcon: StepIconComponent
+  }}
+  slotProps={{
+    stepIcon: StepIconProps
+  }}
+/>;

--- a/packages/mui-codemod/src/deprecations/step-label-props/test-cases/theme.actual.js
+++ b/packages/mui-codemod/src/deprecations/step-label-props/test-cases/theme.actual.js
@@ -14,3 +14,23 @@ fn({
     },
   },
 });
+
+fn({
+  MuiStepLabel: {
+    defaultProps: {
+      StepIconComponent: StepIconComponent,
+      StepIconProps: StepIconProps,
+    },
+  },
+});
+
+fn({
+  MuiStepLabel: {
+    defaultProps: {
+      componentsProps: { label: componentsLabelProps },
+      slotProps: { label: slotLabelProps },
+      StepIconComponent: StepIconComponent,
+      StepIconProps: StepIconProps,
+    },
+  },
+});

--- a/packages/mui-codemod/src/deprecations/step-label-props/test-cases/theme.expected.js
+++ b/packages/mui-codemod/src/deprecations/step-label-props/test-cases/theme.expected.js
@@ -20,3 +20,36 @@ fn({
     },
   },
 });
+
+fn({
+  MuiStepLabel: {
+    defaultProps: {
+      slots: {
+        stepIcon: StepIconComponent
+      },
+
+      slotProps: {
+        stepIcon: StepIconProps
+      }
+    },
+  },
+});
+
+fn({
+  MuiStepLabel: {
+    defaultProps: {
+      slotProps: {
+        label: {
+          ...componentsLabelProps,
+          ...slotLabelProps
+        },
+
+        stepIcon: StepIconProps
+      },
+
+      slots: {
+        stepIcon: StepIconComponent
+      }
+    },
+  },
+});

--- a/packages/mui-material/src/Accordion/Accordion.d.ts
+++ b/packages/mui-material/src/Accordion/Accordion.d.ts
@@ -90,6 +90,7 @@ export type AccordionTypeMap<
       /**
        * The component used for the transition.
        * [Follow this guide](https://mui.com/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
+       * @deprecated Use `slots.transition` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
        */
       TransitionComponent?: React.JSXElementConstructor<
         TransitionProps & { children?: React.ReactElement<unknown, any> }
@@ -97,6 +98,7 @@ export type AccordionTypeMap<
       /**
        * Props applied to the transition element.
        * By default, the element is based on this [`Transition`](https://reactcommunity.org/react-transition-group/transition/) component.
+       * @deprecated Use `slotProps.transition` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
        */
       TransitionProps?: TransitionProps;
     } & AccordionSlotsAndSlotProps;

--- a/packages/mui-material/src/Accordion/Accordion.js
+++ b/packages/mui-material/src/Accordion/Accordion.js
@@ -322,11 +322,13 @@ Accordion.propTypes /* remove-proptypes */ = {
   /**
    * The component used for the transition.
    * [Follow this guide](https://mui.com/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
+   * @deprecated Use `slots.transition` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   TransitionComponent: PropTypes.elementType,
   /**
    * Props applied to the transition element.
    * By default, the element is based on this [`Transition`](https://reactcommunity.org/react-transition-group/transition/) component.
+   * @deprecated Use `slotProps.transition` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   TransitionProps: PropTypes.object,
 };

--- a/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
@@ -167,6 +167,7 @@ export interface AutocompleteProps<
     AutocompleteSlotsAndSlotProps<Value, Multiple, DisableClearable, FreeSolo, ChipComponent> {
   /**
    * Props applied to the [`Chip`](https://mui.com/material-ui/api/chip/) element.
+   * @deprecated Use `slotProps.chip` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   ChipProps?: ChipProps<ChipComponent>;
   /**
@@ -233,10 +234,12 @@ export interface AutocompleteProps<
   /**
    * The component used to render the listbox.
    * @default 'ul'
+   * @deprecated Use `slots.listbox` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   ListboxComponent?: React.JSXElementConstructor<React.HTMLAttributes<HTMLElement>>;
   /**
    * Props applied to the Listbox element.
+   * @deprecated Use `slotProps.listbox` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   ListboxProps?: ReturnType<ReturnType<typeof useAutocomplete>['getListboxProps']> & {
     sx?: SxProps<Theme>;
@@ -281,11 +284,13 @@ export interface AutocompleteProps<
   /**
    * The component used to render the body of the popup.
    * @default Paper
+   * @deprecated Use `slots.paper` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   PaperComponent?: React.JSXElementConstructor<React.HTMLAttributes<HTMLElement>>;
   /**
    * The component used to position the popup.
    * @default Popper
+   * @deprecated Use `slots.popper` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   PopperComponent?: React.JSXElementConstructor<PopperProps>;
   /**

--- a/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
@@ -234,7 +234,7 @@ export interface AutocompleteProps<
   /**
    * The component used to render the listbox.
    * @default 'ul'
-   * @deprecated Use `slots.listbox` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
+   * @deprecated Use `slotProps.listbox.component` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   ListboxComponent?: React.JSXElementConstructor<React.HTMLAttributes<HTMLElement>>;
   /**

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -828,6 +828,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   blurOnSelect: PropTypes.oneOfType([PropTypes.oneOf(['mouse', 'touch']), PropTypes.bool]),
   /**
    * Props applied to the [`Chip`](https://mui.com/material-ui/api/chip/) element.
+   * @deprecated Use `slotProps.chip` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   ChipProps: PropTypes.object,
   /**
@@ -1035,10 +1036,12 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   /**
    * The component used to render the listbox.
    * @default 'ul'
+   * @deprecated Use `slots.listbox` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   ListboxComponent: PropTypes.elementType,
   /**
    * Props applied to the Listbox element.
+   * @deprecated Use `slotProps.listbox` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   ListboxProps: PropTypes.object,
   /**
@@ -1133,11 +1136,13 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   /**
    * The component used to render the body of the popup.
    * @default Paper
+   * @deprecated Use `slots.paper` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   PaperComponent: PropTypes.elementType,
   /**
    * The component used to position the popup.
    * @default Popper
+   * @deprecated Use `slots.popper` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   PopperComponent: PropTypes.elementType,
   /**

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -1036,7 +1036,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   /**
    * The component used to render the listbox.
    * @default 'ul'
-   * @deprecated Use `slots.listbox` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
+   * @deprecated Use `slotProps.listbox.component` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   ListboxComponent: PropTypes.elementType,
   /**

--- a/packages/mui-material/src/Avatar/Avatar.d.ts
+++ b/packages/mui-material/src/Avatar/Avatar.d.ts
@@ -46,6 +46,7 @@ export interface AvatarOwnProps {
   /**
    * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attributes) applied to the `img` element if the component is used to display an image.
    * It can be used to listen for the loading error event.
+   * @deprecated Use `slotProps.img` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   imgProps?: React.ImgHTMLAttributes<HTMLImageElement> & {
     sx?: SxProps<Theme>;

--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -246,6 +246,7 @@ Avatar.propTypes /* remove-proptypes */ = {
   /**
    * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attributes) applied to the `img` element if the component is used to display an image.
    * It can be used to listen for the loading error event.
+   * @deprecated Use `slotProps.img` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   imgProps: PropTypes.object,
   /**

--- a/packages/mui-material/src/Backdrop/Backdrop.d.ts
+++ b/packages/mui-material/src/Backdrop/Backdrop.d.ts
@@ -97,6 +97,7 @@ export interface BackdropOwnProps
    * The component used for the transition.
    * [Follow this guide](https://mui.com/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Fade
+   * @deprecated Use `slots.transition` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   TransitionComponent?: React.JSXElementConstructor<
     TransitionProps & {

--- a/packages/mui-material/src/Backdrop/Backdrop.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.js
@@ -193,6 +193,7 @@ Backdrop.propTypes /* remove-proptypes */ = {
    * The component used for the transition.
    * [Follow this guide](https://mui.com/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Fade
+   * @deprecated Use `slots.transition` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   TransitionComponent: PropTypes.elementType,
   /**

--- a/packages/mui-material/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.d.ts
@@ -97,6 +97,7 @@ export interface SpeedDialProps
    * The component used for the transition.
    * [Follow this guide](https://mui.com/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Zoom
+   * * @deprecated Use `slots.transition` instead. This prop will be removed in v7. [How to migrate](/material-ui/migration/migrating-from-deprecated-apis/)
    */
   TransitionComponent?: React.JSXElementConstructor<TransitionProps>;
   /**
@@ -111,6 +112,7 @@ export interface SpeedDialProps
   /**
    * Props applied to the transition element.
    * By default, the element is based on this [`Transition`](https://reactcommunity.org/react-transition-group/transition/) component.
+   * @deprecated Use `slotProps.transition` instead. This prop will be removed in v7. [How to migrate](/material-ui/migration/migrating-from-deprecated-apis/)
    */
   TransitionProps?: TransitionProps;
 }

--- a/packages/mui-material/src/SpeedDial/SpeedDial.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.js
@@ -555,6 +555,7 @@ SpeedDial.propTypes /* remove-proptypes */ = {
    * The component used for the transition.
    * [Follow this guide](https://mui.com/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Zoom
+   * * @deprecated Use `slots.transition` instead. This prop will be removed in v7. [How to migrate](/material-ui/migration/migrating-from-deprecated-apis/)
    */
   TransitionComponent: PropTypes.elementType,
   /**
@@ -576,6 +577,7 @@ SpeedDial.propTypes /* remove-proptypes */ = {
   /**
    * Props applied to the transition element.
    * By default, the element is based on this [`Transition`](https://reactcommunity.org/react-transition-group/transition/) component.
+   * @deprecated Use `slotProps.transition` instead. This prop will be removed in v7. [How to migrate](/material-ui/migration/migrating-from-deprecated-apis/)
    */
   TransitionProps: PropTypes.object,
 };

--- a/packages/mui-material/src/StepLabel/StepLabel.d.ts
+++ b/packages/mui-material/src/StepLabel/StepLabel.d.ts
@@ -66,10 +66,12 @@ export interface StepLabelProps
   optional?: React.ReactNode;
   /**
    * The component to render in place of the [`StepIcon`](https://mui.com/material-ui/api/step-icon/).
+   * @deprecated Use `slots.stepIcon` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   StepIconComponent?: React.ElementType<StepIconProps>;
   /**
    * Props applied to the [`StepIcon`](https://mui.com/material-ui/api/step-icon/) element.
+   * @deprecated Use `slotProps.stepIcon` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   StepIconProps?: Partial<StepIconProps>;
   /**

--- a/packages/mui-material/src/StepLabel/StepLabel.js
+++ b/packages/mui-material/src/StepLabel/StepLabel.js
@@ -273,10 +273,12 @@ StepLabel.propTypes /* remove-proptypes */ = {
   }),
   /**
    * The component to render in place of the [`StepIcon`](https://mui.com/material-ui/api/step-icon/).
+   * @deprecated Use `slots.stepIcon` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   StepIconComponent: PropTypes.elementType,
   /**
    * Props applied to the [`StepIcon`](https://mui.com/material-ui/api/step-icon/) element.
+   * @deprecated Use `slotProps.stepIcon` instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   StepIconProps: PropTypes.object,
   /**


### PR DESCRIPTION
In #42466, we reverted these codemods and deprecation messages as we weren't sure of the direction of the slot pattern. Now that we're continuing this effort, we're bringing the deprecation messages back.

This PR also modifies `Autocomplete`'s `ListboxComponent` deprecation and codemods to point to `slotProps.listbox.component` instead of `slots.listbox`, which is the correct migration path.
