### PR TITLE
[docs] Replace 'Experimental APIs - Toolpad' with 'Toolpad (Beta)'

### DIFF
--- a/docs/data/material/components/snackbars/snackbars.md
+++ b/docs/data/material/components/snackbars/snackbars.md
@@ -141,7 +141,7 @@ The Snackbar component is composed of a root `<div>` that houses interior elemen
 </div>
 ```
 
-## Experimental APIs - Toolpad
+## Toolpad (Beta)
 
 ### useNotifications
 


### PR DESCRIPTION
One title was missed in https://github.com/mui/material-ui/pull/43796