### PR TITLE
[styled-engine-sc] Fix missing `@types/hoist-non-react-statics` causing `styled` returns any

### DIFF
--- a/packages/mui-styled-engine-sc/package.json
+++ b/packages/mui-styled-engine-sc/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
+    "@types/hoist-non-react-statics": "^3.3.5",
     "csstype": "^3.1.3",
     "hoist-non-react-statics": "^3.3.2",
     "prop-types": "^15.8.1"
@@ -45,7 +46,6 @@
   "devDependencies": {
     "@mui/internal-test-utils": "workspace:^",
     "@types/chai": "^4.3.20",
-    "@types/hoist-non-react-statics": "^3.3.5",
     "@types/react": "^18.3.12",
     "chai": "^4.5.0",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1940,6 +1940,9 @@ importers:
       '@babel/runtime':
         specifier: ^7.26.0
         version: 7.26.0
+      '@types/hoist-non-react-statics':
+        specifier: ^3.3.5
+        version: 3.3.5
       csstype:
         specifier: ^3.1.3
         version: 3.1.3
@@ -1956,9 +1959,6 @@ importers:
       '@types/chai':
         specifier: ^4.3.20
         version: 4.3.20
-      '@types/hoist-non-react-statics':
-        specifier: ^3.3.5
-        version: 3.3.5
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.12


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I moved `@types/hoist-non-react-statics` from devDependencies to dependencies.

The type definitions for `styled-engine-sc` depend on `hoist-non-react-statics`.

https://github.com/mui/material-ui/blob/47326108836da30c36b6b63bf6413f936a1e71fb/packages/mui-styled-engine-sc/src/index.d.ts#L3

The `@types/hoist-non-react-statics` is not included in the dependencies, if this type definition is not installed, `styled` would return any.

<img width="355" alt="styled_returns_any" src="https://github.com/user-attachments/assets/055bc177-9bd8-4443-9bcc-7a63a08779bd">

I tried this in [Material UI + CRA + styled-components (TypeScript)](https://github.com/mui/material-ui/tree/47326108836da30c36b6b63bf6413f936a1e71fb/examples/material-ui-cra-styled-components-ts) repository.

---

I re-created this PR because the CI is stuck.
https://github.com/mui/material-ui/pull/43730#issuecomment-2468464758