### PR TITLE
[utils] skip deep clone React element

### DIFF
--- a/packages/mui-utils/src/deepmerge/deepmerge.test.ts
+++ b/packages/mui-utils/src/deepmerge/deepmerge.test.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { expect } from 'chai';
 import { runInNewContext } from 'vm';
 import deepmerge from './deepmerge';
@@ -121,5 +122,13 @@ describe('deepmerge', () => {
 
     expect(result).to.deep.equal({ foo: { baz: 'new test' } });
     expect(foo).to.deep.equal({ foo: { baz: 'test' } });
+  });
+
+  it('should not deep clone React element', () => {
+    const element = React.createElement('div', {}, React.createElement('span'));
+    const element2 = React.createElement('a');
+    const result = deepmerge({ element }, { element: element2 });
+
+    expect(result.element).to.equal(element2);
   });
 });

--- a/packages/mui-utils/src/deepmerge/deepmerge.ts
+++ b/packages/mui-utils/src/deepmerge/deepmerge.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 // https://github.com/sindresorhus/is-plain-obj/blob/main/index.js
 export function isPlainObject(item: unknown): item is Record<keyof any, unknown> {
   if (typeof item !== 'object' || item === null) {
@@ -41,7 +43,9 @@ export default function deepmerge<T>(
 
   if (isPlainObject(target) && isPlainObject(source)) {
     Object.keys(source).forEach((key) => {
-      if (
+      if (React.isValidElement(source[key])) {
+        (output as Record<keyof any, unknown>)[key] = source[key];
+      } else if (
         isPlainObject(source[key]) &&
         // Avoid prototype pollution
         Object.prototype.hasOwnProperty.call(target, key) &&

--- a/packages/mui-utils/src/deepmerge/deepmerge.ts
+++ b/packages/mui-utils/src/deepmerge/deepmerge.ts
@@ -21,7 +21,7 @@ export interface DeepmergeOptions {
 }
 
 function deepClone<T>(source: T): T | Record<keyof any, unknown> {
-  if (!isPlainObject(source)) {
+  if (React.isValidElement(source) || !isPlainObject(source)) {
     return source;
   }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #44278

## Root cause

Next.js 15 with Turbopack has a different signature for React element which cause the `@mui/utils/deepmerge` to recursively deepclone React element. More details on https://github.com/mui/material-ui/issues/44278

## Fix

I think it does not make sense anyway for the deepmerge function to deepClone React elements.

So I added a check to deepmerge directly to avoid deepClone React elements.

Tested with https://github.com/nphmuller/mui-next-15_0_2_issue, this PR fixes the issue.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
