### PR TITLE
fix: sm >> small

### DIFF
--- a/docs/data/joy/getting-started/templates/profile-dashboard/components/MyProfile.tsx
+++ b/docs/data/joy/getting-started/templates/profile-dashboard/components/MyProfile.tsx
@@ -50,7 +50,7 @@ export default function MyProfile() {
           <Breadcrumbs
             size="sm"
             aria-label="breadcrumbs"
-            separator={<ChevronRightRoundedIcon fontSize="sm" />}
+            separator={<ChevronRightRoundedIcon fontSize="small" />}
             sx={{ pl: 0 }}
           >
             <Link


### PR DESCRIPTION
Fixing this error: 
```
No overload matches this call.
  Overload 1 of 2, '(props: { component: ElementType<any, keyof IntrinsicElements>; } & SvgIconOwnProps & CommonProps & Omit<any, "color" | ... 10 more ... | "titleAccess">): Element | null', gave the following error.
    Type '"sm"' is not assignable to type 'OverridableStringUnion<"small" | "inherit" | "medium" | "large", SvgIconPropsSizeOverrides> | undefined'.
  Overload 2 of 2, '(props: DefaultComponentProps<SvgIconTypeMap<{}, "svg">>): Element | null', gave the following error.
    Type '"sm"' is not assignable to type 'OverridableStringUnion<"small" | "inherit" | "medium" | "large", SvgIconPropsSizeOverrides> | undefined'.ts(2769)
SvgIcon.d.ts(44, 3): The expected type comes from property 'fontSize' which is declared here on type 'IntrinsicAttributes & { component: ElementType<any, keyof IntrinsicElements>; } & SvgIconOwnProps & CommonProps & Omit<...>'
SvgIcon.d.ts(44, 3): The expected type comes from property 'fontSize' which is declared here on type 'IntrinsicAttributes & SvgIconOwnProps & CommonProps & Omit<Omit<SVGProps<SVGSVGElement>, "ref"> & { ...; }, "color" | ... 10 more ... | "titleAccess">'
(property) SvgIconOwnProps.fontSize?: OverridableStringUnion<"small" | "inherit" | "medium" | "large", SvgIconPropsSizeOverrides> | undefined
The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.

@default

'medium'
```