### PR TITLE
[utils] Add documentation to `useForkRef`

### DIFF
--- a/packages/mui-utils/src/useForkRef/useForkRef.ts
+++ b/packages/mui-utils/src/useForkRef/useForkRef.ts
@@ -2,6 +2,25 @@
 import * as React from 'react';
 import setRef from '../setRef';
 
+/**
+ * Takes an array of refs and returns a new ref which will apply any modification to all of the refs.
+ *
+ * This is useful when you want have the ref used in multiple places.
+ *
+ * ```tsx
+ * const newRef = React.useRef<Instance>(null);
+ * const refFork = useForkRef(newRef, props.ref);
+ *
+ * return (
+ *   <LogicProvider ref={newRef}>
+ *    <Component ref={refFork} />
+ *   </LogicProvider>
+ * );
+ * ```
+ *
+ * @param {Array<React.Ref<Instance> | undefined>} refs the ref array.
+ * @returns {React.RefCallback<Instance> | null} the new ref callback.
+ */
 export default function useForkRef<Instance>(
   ...refs: Array<React.Ref<Instance> | undefined>
 ): React.RefCallback<Instance> | null {


### PR DESCRIPTION
Add documentation to explain what the `useForkRef` actually does and is useful for.