### PR TITLE
[code-infra] Use vitest-compatible skip in `describeConformance`

### DIFF
--- a/packages-internal/test-utils/src/describeConformance.tsx
+++ b/packages-internal/test-utils/src/describeConformance.tsx
@@ -617,12 +617,14 @@ function testThemeDefaultProps(
   });
 
   describe('default props provider:', () => {
-    it('respect custom default props', async function test() {
+    it('respect custom default props', async function test(t = {}) {
       const testProp = 'data-id';
       const { muiName, render, DefaultPropsProvider } = getOptions();
 
       if (!DefaultPropsProvider) {
-        this.skip();
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        this?.skip?.() ?? t?.skip();
       }
 
       if (!muiName) {
@@ -634,6 +636,7 @@ function testThemeDefaultProps(
       }
 
       const { container } = await render(
+        // @ts-expect-error we skip it above.
         <DefaultPropsProvider
           value={{
             [muiName]: {


### PR DESCRIPTION
Use `this?.skip?.() ?? t?.skip();` so we can continue the vitest migration 😅 