### PR TITLE
[material-ui][Autocomplete] Use `ul` element for the listbox 

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -326,7 +326,7 @@ const AutocompleteNoOptions = styled('div', {
   })),
 );
 
-const AutocompleteListbox = styled('div', {
+const AutocompleteListbox = styled('ul', {
   name: 'MuiAutocomplete',
   slot: 'Listbox',
   overridesResolver: (props, styles) => styles.listbox,

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1069,6 +1069,7 @@ describe('<Autocomplete />', () => {
       expect(textbox).to.have.attribute('aria-expanded', 'true');
 
       const listbox = getByRole('listbox');
+      expect(listbox.tagName.toLowerCase()).to.equal('ul');
       expect(textbox).to.have.attribute('aria-controls', listbox.getAttribute('id'));
       expect(textbox, 'no option is focused when opened').not.to.have.attribute(
         'aria-activedescendant',


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/issues/44264

### Explanation

The `ul` element was lost in this PR: https://github.com/mui/material-ui/pull/43994. **Previously, it was provided via the `as` prop**:

https://github.com/mui/material-ui/blob/15ea548de803e4602894cae6304a497d7ddaf09c/packages/mui-material/src/Autocomplete/Autocomplete.js#L560-L561

https://github.com/mui/material-ui/blob/15ea548de803e4602894cae6304a497d7ddaf09c/packages/mui-material/src/Autocomplete/Autocomplete.js#L685

But after https://github.com/mui/material-ui/pull/43994 fix, we failed to maintain it:

https://github.com/mui/material-ui/blob/01c5f344628bc66e16f86284ee0fc7107002a5ca/packages/mui-material/src/Autocomplete/Autocomplete.js#L329

https://github.com/mui/material-ui/blob/01c5f344628bc66e16f86284ee0fc7107002a5ca/packages/mui-material/src/Autocomplete/Autocomplete.js#L559-L560

https://github.com/mui/material-ui/blob/01c5f344628bc66e16f86284ee0fc7107002a5ca/packages/mui-material/src/Autocomplete/Autocomplete.js#L686

### Solution

This PR brings it back by setting `AutocompleteListbox`'s element to `ul`, and adds a test for it.

**v5:** https://codesandbox.io/p/sandbox/pr-44422-v5-x2ff5z
**Before:** https://codesandbox.io/p/sandbox/pr-44422-before-l66t9p
**After:** https://codesandbox.io/p/sandbox/pr-44422-after-cx66k3


