### PR TITLE
[code-infra] Decrease verbosity and allow ignoring act warnings

### DIFF
--- a/packages-internal/test-utils/src/setupVitest.ts
+++ b/packages-internal/test-utils/src/setupVitest.ts
@@ -21,9 +21,19 @@ testingLibrary.configure({
 
 failOnConsole({
   silenceMessage: (message) => {
-    if (process.env.NODE_ENV === 'production' || process.env.IGNORE_ACT_WARNINGS === 'true') {
+    if (process.env.NODE_ENV === 'production') {
       // TODO: mock scheduler
       if (message.includes('act(...) is not supported in production builds of React')) {
+        return true;
+      }
+    }
+
+    if (process.env.IGNORE_ACT_WARNINGS === 'true') {
+      if (
+        message.includes(
+          'When testing, code that causes React state updates should be wrapped into act(...)',
+        )
+      ) {
         return true;
       }
     }

--- a/packages-internal/test-utils/src/setupVitest.ts
+++ b/packages-internal/test-utils/src/setupVitest.ts
@@ -9,9 +9,6 @@ import './initMatchers';
 // from assistive technology
 const defaultHidden = !process.env.CI;
 
-// adds verbosity for something that might be confusing
-console.warn(`${defaultHidden ? 'including' : 'excluding'} inaccessible elements by default`);
-
 testingLibrary.configure({
   // JSDOM logs errors otherwise on `getComputedStyle(element, pseudoElement)` calls.
   computedStyleSupportsPseudoElements: false,
@@ -24,7 +21,7 @@ testingLibrary.configure({
 
 failOnConsole({
   silenceMessage: (message) => {
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV === 'production' || process.env.IGNORE_ACT_WARNINGS === 'true') {
       // TODO: mock scheduler
       if (message.includes('act(...) is not supported in production builds of React')) {
         return true;


### PR DESCRIPTION
- The removed `console.warn` is unnecessarily verbose on the tests
- Allow skipping the act warnings as `X` packages have a lot of them and I would rather leave rewriting the tests to a later step.
