### PR TITLE
[test][Autocomplete] Make virtualize regression screenshots deterministic

### DIFF
--- a/test/regressions/fixtures/Autocomplete/Virtualize.js
+++ b/test/regressions/fixtures/Autocomplete/Virtualize.js
@@ -111,17 +111,6 @@ ListboxComponent.propTypes = {
   children: PropTypes.node,
 };
 
-function random(length) {
-  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  let result = '';
-
-  for (let i = 0; i < length; i += 1) {
-    result += characters.charAt(Math.floor(Math.random() * characters.length));
-  }
-
-  return result;
-}
-
 const StyledPopper = styled(Popper)({
   [`& .${autocompleteClasses.listbox}`]: {
     boxSizing: 'border-box',
@@ -132,8 +121,10 @@ const StyledPopper = styled(Popper)({
   },
 });
 
-const OPTIONS = Array.from(new Array(10000))
-  .map(() => random(10 + Math.ceil(Math.random() * 20)))
+const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+const OPTIONS = [...Array(100).keys()]
+  .map((number) => `${characters[number % characters.length].repeat(10)}${Math.floor(number / characters.length)}`)
   .sort((a, b) => a.toUpperCase().localeCompare(b.toUpperCase()));
 
 export default function Virtualize() {

--- a/test/regressions/fixtures/Autocomplete/Virtualize.js
+++ b/test/regressions/fixtures/Autocomplete/Virtualize.js
@@ -124,7 +124,10 @@ const StyledPopper = styled(Popper)({
 const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
 const OPTIONS = [...Array(100).keys()]
-  .map((number) => `${characters[number % characters.length].repeat(10)}${Math.floor(number / characters.length)}`)
+  .map(
+    (number) =>
+      `${characters[number % characters.length].repeat(10)}${Math.floor(number / characters.length)}`,
+  )
   .sort((a, b) => a.toUpperCase().localeCompare(b.toUpperCase()));
 
 export default function Virtualize() {


### PR DESCRIPTION
An oversight of https://github.com/mui/material-ui/pull/44382. The regression test was not deterministic, so the screenshots were unstable. This fixes it by creating the options deterministically while maintaining a similar behavior from the demo.
