### PR TITLE
[infra] Upgrade Cherry-pick workflow to latest

### DIFF
--- a/.github/workflows/cherry-pick-next-to-master.yml
+++ b/.github/workflows/cherry-pick-next-to-master.yml
@@ -1,34 +1,17 @@
-name: Cherry pick next to master
-
+name: Create cherry-pick PR
 on:
   pull_request_target:
     branches:
-      - next
+      - 'v*.x'
+      - 'master'
     types: ['closed']
 
 permissions: {}
 
 jobs:
-  cherry_pick_to_master:
-    runs-on: ubuntu-latest
-    name: Cherry pick into master
+  create_pr:
+    name: Create cherry-pick PR
+    uses: mui/mui-public/.github/workflows/prs_create-cherry-pick-pr.yml@master
     permissions:
-      pull-requests: write
       contents: write
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'needs cherry-pick') && github.event.pull_request.merged == true }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-      - name: Cherry pick and create the new PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: carloscastrojumo/github-cherry-pick-action@503773289f4a459069c832dc628826685b75b4b3 # v1.0.10
-        with:
-          branch: master
-          body: 'Cherry-pick of #{old_pull_request_id}'
-          cherry-pick-branch: ${{ format('cherry-pick-{0}', github.event.number) }}
-          title: '{old_title} (@${{ github.event.pull_request.user.login }})'
-          labels: |
-            cherry-pick
+      pull-requests: write

--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -2,6 +2,7 @@ name: Create cherry-pick PR
 on:
   pull_request_target:
     branches:
+      - 'next'
       - 'v*.x'
       - 'master'
     types: ['closed']


### PR DESCRIPTION
MUI X has built a workflow action to handle this, one that is more versatile. I believe we can simply adopt it. I only had to do https://github.com/mui/mui-public/pull/244 to support all the https://github.com/mui repositories. 

The initial version was #41742. More details on how this new one works: https://github.com/mui/mui-public/issues/221.

cc @aarongarciah for awareness.