### PR TITLE
[docs][dialog] Fix padding in SimpleDialog demo

### DIFF
--- a/docs/data/material/components/dialogs/SimpleDialogDemo.js
+++ b/docs/data/material/components/dialogs/SimpleDialogDemo.js
@@ -32,7 +32,7 @@ function SimpleDialog(props) {
       <DialogTitle>Set backup account</DialogTitle>
       <List sx={{ pt: 0 }}>
         {emails.map((email) => (
-          <ListItem disableGutters key={email}>
+          <ListItem disablePadding key={email}>
             <ListItemButton onClick={() => handleListItemClick(email)}>
               <ListItemAvatar>
                 <Avatar sx={{ bgcolor: blue[100], color: blue[600] }}>
@@ -43,7 +43,7 @@ function SimpleDialog(props) {
             </ListItemButton>
           </ListItem>
         ))}
-        <ListItem disableGutters>
+        <ListItem disablePadding>
           <ListItemButton
             autoFocus
             onClick={() => handleListItemClick('addAccount')}

--- a/docs/data/material/components/dialogs/SimpleDialogDemo.tsx
+++ b/docs/data/material/components/dialogs/SimpleDialogDemo.tsx
@@ -37,7 +37,7 @@ function SimpleDialog(props: SimpleDialogProps) {
       <DialogTitle>Set backup account</DialogTitle>
       <List sx={{ pt: 0 }}>
         {emails.map((email) => (
-          <ListItem disableGutters key={email}>
+          <ListItem disablePadding key={email}>
             <ListItemButton onClick={() => handleListItemClick(email)}>
               <ListItemAvatar>
                 <Avatar sx={{ bgcolor: blue[100], color: blue[600] }}>
@@ -48,7 +48,7 @@ function SimpleDialog(props: SimpleDialogProps) {
             </ListItemButton>
           </ListItem>
         ))}
-        <ListItem disableGutters>
+        <ListItem disablePadding>
           <ListItemButton
             autoFocus
             onClick={() => handleListItemClick('addAccount')}


### PR DESCRIPTION
I noticed this by chance, it has been broken for a long time, broken in #33970 (the second regression of the PR, the first one was #38580), and it looked quick to fix, so I was compelled to go after it.

Was correct https://v5-0-6.mui.com/components/dialogs/
<img width="365" alt="SCR-20241119-cnfw" src="https://github.com/user-attachments/assets/9d0ea66d-57f9-45fe-92a2-0311ab340b34">

Before: https://mui.com/material-ui/react-dialog/#introduction
<img width="378" alt="SCR-20241119-cngs" src="https://github.com/user-attachments/assets/063a62cb-62b2-44c0-894e-7bcbcac639b9">

After: https://deploy-preview-44467--material-ui.netlify.app/material-ui/react-dialog/
<img width="373" alt="SCR-20241119-cnec" src="https://github.com/user-attachments/assets/6832db73-147f-4228-b618-4bf34917f456">

For context, this demo is modeled after https://m1.material.io/components/dialogs.html#dialogs-simple-dialogs.