### PR TITLE
[pigment-css] Make @pigment-css/react as peer dependency

### DIFF
--- a/docs/data/material/migration/upgrade-to-v6/migrating-to-pigment-css.md
+++ b/docs/data/material/migration/upgrade-to-v6/migrating-to-pigment-css.md
@@ -31,15 +31,15 @@ First, install the Material UI wrapper package for Pigment CSS:
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/material-pigment-css
+npm install @mui/material-pigment-css @pigment-css/react
 ```
 
 ```bash pnpm
-pnpm add @mui/material-pigment-css
+pnpm add @mui/material-pigment-css @pigment-css/react
 ```
 
 ```bash yarn
-yarn add @mui/material-pigment-css
+yarn add @mui/material-pigment-css @pigment-css/react
 ```
 
 </codeblock>

--- a/examples/material-ui-pigment-css-nextjs-ts/package.json
+++ b/examples/material-ui-pigment-css-nextjs-ts/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@mui/material": "latest",
     "@mui/material-pigment-css": "latest",
+    "@pigment-css/react": "latest",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"

--- a/examples/material-ui-pigment-css-vite-ts/package.json
+++ b/examples/material-ui-pigment-css-vite-ts/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@mui/material": "latest",
     "@mui/material-pigment-css": "latest",
+    "@pigment-css/react": "latest",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/mui-material-pigment-css/package.json
+++ b/packages/mui-material-pigment-css/package.json
@@ -40,8 +40,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@mui/system": "workspace:*",
-    "@pigment-css/react": "0.0.27"
+    "@mui/system": "workspace:*"
+  },
+  "peerDependencies": {
+    "@pigment-css/react": "^0.0.27"
   },
   "sideEffects": false,
   "publishConfig": {


### PR DESCRIPTION
This change helps in module resolution across different package
managers, especially pnpm, which expects the imports to be from direct
dependencies.
During sx prop transform, pigment-css plugin adds -

```js
import { sx } from '@pigment-css/react';
```

which would throw an error when using pnpm since @pigment-css/react was
not a direct dependency of the user's application.

Note: This is a breaking change.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
