### PR TITLE
[docs-infra] Correctly flatten the pages tree

### DIFF
--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -57,6 +57,8 @@ const FooterLink = styled(Link)(({ theme }) => {
  */
 
 /**
+ * This function is flattening the pages tree and extracts all the leaves that are internal pages.
+ * To extract the leaves, it skips all the nodes that have at least one child.
  * @param {MuiPage[]} pages
  * @param {MuiPage[]} [current]
  * @returns {OrderedMuiPage[]}
@@ -64,10 +66,10 @@ const FooterLink = styled(Link)(({ theme }) => {
 function orderedPages(pages, current = []) {
   return pages
     .reduce((items, item) => {
-      if (item.children && item.children.length > 1) {
+      if (item.children && item.children.length > 0) {
         items = orderedPages(item.children, items);
       } else {
-        items.push(item.children && item.children.length === 1 ? item.children[0] : item);
+        items.push(item);
       }
       return items;
     }, current)


### PR DESCRIPTION
This logic has been buggy for a long time, we were lucky up until now to not hit it, but with https://github.com/mui/mui-x/pull/15014, we started to see it:

- Go to https://next.mui.com/x/react-charts/#supported-features, see how the previous page "API reference" link is broken: 
<img width="453" alt="SCR-20241123-risk" src="https://github.com/user-attachments/assets/fd242557-0aa5-4f1c-9d34-af5fdaa215dd">

- Go to https://next.mui.com/x/api/charts/bar-chart/ see how there is no prev/next links:
<img width="326" alt="SCR-20241123-riut" src="https://github.com/user-attachments/assets/c5e4844f-b874-4abd-9997-d519ff6f7890">

This happens because in MUI X v8, we added `subheader`, breaking the previous heuristic: if there is a single child, then this child is a leaf. Nop, not true ever since we support subheaders.

Preview: https://mui.com/material-ui/getting-started/. On Material UI, nothing should change.