### PR TITLE
[docs-infra] Fix Sponsor design regression

### DIFF
--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -98,7 +98,6 @@ export default function DiamondSponsors() {
           ]}
         />
       </NativeLink>
-      <Divider />
       <Link
         href="/material-ui/discover-more/backers/#diamond-sponsors"
         sx={(theme) => ({


### PR DESCRIPTION
Fix a design regression that was introduced in #44474:
<img width="231" alt="SCR-20241123-rrrz" src="https://github.com/user-attachments/assets/6d9ebbaa-cddc-499c-aee8-6f35e0efe621">
https://mui.com/material-ui/getting-started/.

See https://deploy-preview-44473--material-ui.netlify.app/material-ui/getting-started/ as an example of how it was correct before. I noticed this regression fixing that: https://github.com/mui/mui-x/pull/15574. 

After: https://deploy-preview-44515--material-ui.netlify.app/material-ui/getting-started/