### PR TITLE
[material-ui][TextareaAutosize] Temporarily disconnect ResizeObserver to avoid loop error

### DIFF
--- a/packages/mui-material/src/TextareaAutosize/TextareaAutosize.tsx
+++ b/packages/mui-material/src/TextareaAutosize/TextareaAutosize.tsx
@@ -36,16 +36,17 @@ type TextareaStyles = {
   overflowing: boolean;
 };
 
-function isEmpty(obj: TextareaStyles) {
-  return (
-    obj === undefined ||
-    obj === null ||
-    Object.keys(obj).length === 0 ||
-    (obj.outerHeightStyle === 0 && !obj.overflowing)
-  );
+function isObjectEmpty(object: TextareaStyles) {
+  // eslint-disable-next-line
+  for (const _ in object) {
+    return false;
+  }
+  return true;
 }
 
-const supportsResizeObserver = typeof ResizeObserver !== 'undefined';
+function isEmpty(obj: TextareaStyles) {
+  return isObjectEmpty(obj) || (obj.outerHeightStyle === 0 && !obj.overflowing);
+}
 
 /**
  *
@@ -64,16 +65,21 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
   const { onChange, maxRows, minRows = 1, style, value, ...other } = props;
 
   const { current: isControlled } = React.useRef(value != null);
-  const inputRef = React.useRef<HTMLTextAreaElement>(null);
-  const handleRef = useForkRef(forwardedRef, inputRef);
-  const heightRef = React.useRef<number>(null);
-  const shadowRef = React.useRef<HTMLTextAreaElement>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+  const handleRef = useForkRef(forwardedRef, textareaRef);
+  const heightRef = React.useRef<number | null>(null);
+  const hiddenTextareaRef = React.useRef<HTMLTextAreaElement>(null);
 
   const calculateTextareaStyles = React.useCallback(() => {
-    const input = inputRef.current!;
+    const textarea = textareaRef.current;
+    const hiddenTextarea = hiddenTextareaRef.current;
 
-    const containerWindow = ownerWindow(input);
-    const computedStyle = containerWindow.getComputedStyle(input);
+    if (!textarea || !hiddenTextarea) {
+      return undefined;
+    }
+
+    const containerWindow = ownerWindow(textarea);
+    const computedStyle = containerWindow.getComputedStyle(textarea);
 
     // If input's width is shrunk and it's not visible, don't sync height.
     if (computedStyle.width === '0px') {
@@ -83,15 +89,13 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
       };
     }
 
-    const inputShallow = shadowRef.current!;
-
-    inputShallow.style.width = computedStyle.width;
-    inputShallow.value = input.value || props.placeholder || 'x';
-    if (inputShallow.value.slice(-1) === '\n') {
+    hiddenTextarea.style.width = computedStyle.width;
+    hiddenTextarea.value = textarea.value || props.placeholder || 'x';
+    if (hiddenTextarea.value.slice(-1) === '\n') {
       // Certain fonts which overflow the line height will cause the textarea
       // to report a different scrollHeight depending on whether the last line
       // is empty. Make it non-empty to avoid this issue.
-      inputShallow.value += ' ';
+      hiddenTextarea.value += ' ';
     }
 
     const boxSizing = computedStyle.boxSizing;
@@ -101,11 +105,11 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
       getStyleValue(computedStyle.borderBottomWidth) + getStyleValue(computedStyle.borderTopWidth);
 
     // The height of the inner content
-    const innerHeight = inputShallow.scrollHeight;
+    const innerHeight = hiddenTextarea.scrollHeight;
 
     // Measure height of a textarea with a single row
-    inputShallow.value = 'x';
-    const singleRowHeight = inputShallow.scrollHeight;
+    hiddenTextarea.value = 'x';
+    const singleRowHeight = hiddenTextarea.scrollHeight;
 
     // The height of the outer content
     let outerHeight = innerHeight;
@@ -126,55 +130,50 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
   }, [maxRows, minRows, props.placeholder]);
 
   const syncHeight = React.useCallback(() => {
+    const textarea = textareaRef.current;
     const textareaStyles = calculateTextareaStyles();
 
-    if (isEmpty(textareaStyles)) {
+    if (!textarea || !textareaStyles || isEmpty(textareaStyles)) {
       return;
     }
 
     const outerHeightStyle = textareaStyles.outerHeightStyle;
-    const input = inputRef.current!;
     if (heightRef.current !== outerHeightStyle) {
       heightRef.current = outerHeightStyle;
-      input.style.height = `${outerHeightStyle}px`;
+      textarea.style.height = `${outerHeightStyle}px`;
     }
-    input.style.overflow = textareaStyles.overflowing ? 'hidden' : '';
+    textarea.style.overflow = textareaStyles.overflowing ? 'hidden' : '';
   }, [calculateTextareaStyles]);
 
   const frameRef = React.useRef(-1);
 
   useEnhancedEffect(() => {
-    function handleResize() {
-      syncHeight();
+    const debounceHandleResize = debounce(() => syncHeight());
+    const textarea = textareaRef?.current;
+
+    if (!textarea) {
+      return undefined;
     }
-    // Workaround a "ResizeObserver loop completed with undelivered notifications" error
-    // in test.
-    // Note that we might need to use this logic in production per https://github.com/WICG/resize-observer/issues/38
-    // Also see https://github.com/mui/mui-x/issues/8733
-    // const rAFHandleResize = () => {
-    //   cancelAnimationFrame(frameRef.current);
-    //   frameRef.current = requestAnimationFrame(() => {
-    //     handleResize();
-    //   });
-    // };
-    const debounceHandleResize = debounce(handleResize);
-    const input = inputRef.current!;
-    const containerWindow = ownerWindow(input);
+
+    const containerWindow = ownerWindow(textarea);
 
     containerWindow.addEventListener('resize', debounceHandleResize);
 
     let resizeObserver: ResizeObserver;
 
-    if (supportsResizeObserver) {
+    if (typeof ResizeObserver !== 'undefined') {
       resizeObserver = new ResizeObserver(() => {
-        resizeObserver.unobserve(input);
+        // avoid "ResizeObserver loop completed with undelivered notifications" error
+        // by temporarily unobserving the textarea element while manipulating the height
+        // and reobserving one frame later
+        resizeObserver.unobserve(textarea);
         cancelAnimationFrame(frameRef.current);
-        handleResize();
+        syncHeight();
         frameRef.current = requestAnimationFrame(() => {
-          resizeObserver.observe(input);
+          resizeObserver.observe(textarea);
         });
       });
-      resizeObserver.observe(input);
+      resizeObserver.observe(textarea);
     }
 
     return () => {
@@ -216,7 +215,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
         aria-hidden
         className={props.className}
         readOnly
-        ref={shadowRef}
+        ref={hiddenTextareaRef}
         tabIndex={-1}
         style={{
           ...styles.shadow,

--- a/packages/mui-material/src/TextareaAutosize/TextareaAutosize.tsx
+++ b/packages/mui-material/src/TextareaAutosize/TextareaAutosize.tsx
@@ -67,7 +67,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
   const { current: isControlled } = React.useRef(value != null);
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
   const handleRef = useForkRef(forwardedRef, textareaRef);
-  const heightRef = React.useRef<number | null>(null);
+  const heightRef = React.useRef<number>(null);
   const hiddenTextareaRef = React.useRef<HTMLTextAreaElement>(null);
 
   const calculateTextareaStyles = React.useCallback(() => {


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/43718
Fixes https://github.com/mui/material-ui/issues/44140

Demo: https://codesandbox.io/p/sandbox/immutable-architecture-nslxvr?file=%2Fsrc%2FApp.js%3A33%2C1 (forked from the [original repro](https://github.com/mui/material-ui/issues/43718#issue-2520950148))

This was very hard to repro locally, but I believe the "loop" is caused when we change the height of the element in the RO callback, while it is still being observed, which fires the callback again (and again…)

The fix is to un-observe the element, manipulate the height then re-observe one frame later, instead of manipulating the height one frame later suggested [here](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/TextareaAutosize/TextareaAutosize.tsx#L146-L156) (or [here](https://github.com/mui/material-ui/issues/43718#issuecomment-2344882830)).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
