### PR TITLE
[docs-infra] Improve locator finding using visible option

### DIFF
--- a/docs/data/material/getting-started/templates/dashboard/components/AppNavbar.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/AppNavbar.js
@@ -68,7 +68,7 @@ export default function AppNavbar() {
               Dashboard
             </Typography>
           </Stack>
-          <ColorModeIconDropdown data-screenshot="" />
+          <ColorModeIconDropdown />
           <MenuButton aria-label="menu" onClick={toggleDrawer(true)}>
             <MenuRoundedIcon />
           </MenuButton>

--- a/docs/data/material/getting-started/templates/dashboard/components/AppNavbar.tsx
+++ b/docs/data/material/getting-started/templates/dashboard/components/AppNavbar.tsx
@@ -68,7 +68,7 @@ export default function AppNavbar() {
               Dashboard
             </Typography>
           </Stack>
-          <ColorModeIconDropdown data-screenshot="" />
+          <ColorModeIconDropdown />
           <MenuButton aria-label="menu" onClick={toggleDrawer(true)}>
             <MenuRoundedIcon />
           </MenuButton>

--- a/docs/scripts/generateTemplateScreenshots.ts
+++ b/docs/scripts/generateTemplateScreenshots.ts
@@ -79,43 +79,47 @@ const names = new Set(process.argv.slice(2));
             (file) => `/${project}/getting-started/templates/${file.replace(/\.(js|tsx)$/, '/')}`,
           );
 
+        async function toggleMode() {
+          await page.locator('css=[data-screenshot="toggle-mode"]').locator('visible=true').click();
+        }
+
         async function captureDarkMode(outputPath: string) {
           const btn = await page.$('[data-screenshot="toggle-mode"]');
           if (btn) {
             if ((await btn.getAttribute('aria-haspopup')) === 'true') {
-              await page.click('[data-screenshot="toggle-mode"]');
+              await toggleMode();
               await page.getByRole('menuitem').filter({ hasText: /dark/i }).click();
               await page.waitForLoadState('networkidle'); // changing to dark mode might trigger image loading
               await sleep(100); // give time for image decoding, resizing, rendering
 
               await page.screenshot({ path: outputPath, animations: 'disabled' });
 
-              await page.click('[data-screenshot="toggle-mode"]');
+              await toggleMode();
               await page
                 .getByRole('menuitem')
                 .filter({ hasText: /system/i })
                 .click(); // switch back to light
             } else if ((await btn.getAttribute('aria-haspopup')) === 'listbox') {
-              await page.click('[data-screenshot="toggle-mode"]');
+              await toggleMode();
               await page.getByRole('option').filter({ hasText: /dark/i }).click();
               await page.waitForLoadState('networkidle'); // changing to dark mode might trigger image loading
               await sleep(100); // give time for image decoding, resizing, rendering
 
               await page.screenshot({ path: outputPath, animations: 'disabled' });
 
-              await page.click('[data-screenshot="toggle-mode"]');
+              await toggleMode();
               await page
                 .getByRole('option')
                 .filter({ hasText: /system/i })
                 .click(); // switch back to light
             } else {
-              await page.click('[data-screenshot="toggle-mode"]');
+              await toggleMode();
               await page.waitForLoadState('networkidle'); // changing to dark mode might trigger image loading
               await sleep(100); // give time for image decoding, resizing, rendering
 
               await page.screenshot({ path: outputPath, animations: 'disabled' });
 
-              await page.click('[data-screenshot="toggle-mode"]'); // switch back to light
+              await toggleMode(); // switch back to light
             }
           }
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

A change in https://github.com/mui/material-ui/pull/44253#discussion_r1824662018 is a hack. This PR is better because it can locate the visible element without specifying empty `data-screenshot=""` to the element.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
