### PR TITLE
[docs-infra] Fix display when ad-block triggers

### DIFF
--- a/packages/mui-docs/src/Ad/Ad.tsx
+++ b/packages/mui-docs/src/Ad/Ad.tsx
@@ -232,7 +232,6 @@ export function Ad() {
       data-ga-event-category="ad"
       data-ga-event-action="click"
       data-ga-event-label={eventLabel}
-      className="Ad-root"
     >
       <AdErrorBoundary eventLabel={eventLabel}>{children}</AdErrorBoundary>
     </Box>

--- a/packages/mui-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx
+++ b/packages/mui-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx
@@ -13,8 +13,9 @@ import W3CIcon from '../svgIcons/W3CIcon';
 import MaterialDesignIcon from '../svgIcons/MaterialDesignIcon';
 import { useTranslate } from '../i18n';
 
-const Root = styled('ul')({
+const Root = styled('ul')(({ theme }) => ({
   margin: 0,
+  marginTop: theme.spacing(3),
   padding: 0,
   listStyle: 'none',
   display: 'flex',
@@ -30,7 +31,7 @@ const Root = styled('ul')({
       fontSize: 14,
     },
   },
-});
+}));
 
 const defaultPackageNames: Record<string, string | undefined> = {
   'material-ui': '@mui/material',

--- a/packages/mui-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx
+++ b/packages/mui-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx
@@ -15,7 +15,7 @@ import { useTranslate } from '../i18n';
 
 const Root = styled('ul')(({ theme }) => ({
   margin: 0,
-  marginTop: theme.spacing(3),
+  marginTop: theme.spacing(2),
   padding: 0,
   listStyle: 'none',
   display: 'flex',

--- a/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
+++ b/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
@@ -137,7 +137,7 @@ const Root = styled('div')(
       // Allows to remove link arrows for images
       display: 'none',
     },
-    '& .Ad-root a::after': {
+    '& .ad.description a::after': {
       // Remove link arrow for ads
       display: 'none',
     },


### PR DESCRIPTION
Since https://github.com/easylist/easylist/issues/20644 is live, e.g. with uBlock Origin, the docs look broken: 

<img width="784" alt="SCR-20241126-tjum" src="https://github.com/user-attachments/assets/c376dee7-e262-4303-a584-352bca992080">

https://mui.com/material-ui/react-alert/

Instead, we can add some margin, in case the block gets removed.

I also used the opportunity to make it harder to have selectors that reliably work for this block.

Preview: 

- https://deploy-preview-44567--material-ui.netlify.app/material-ui/react-toggle-button/
- https://deploy-preview-44567--material-ui.netlify.app/material-ui/react-alert/