### PR TITLE
[core] Extract useRippleHandler outside of ButtonBase

### DIFF
--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -68,6 +68,21 @@ export const ButtonBaseRoot = styled('button', {
   },
 });
 
+function useRippleHandler(ripple, rippleAction, eventCallback, skipRippleAction = false) {
+  return useEventCallback((event) => {
+    if (eventCallback) {
+      eventCallback(event);
+    }
+
+    const ignore = skipRippleAction;
+    if (!ignore) {
+      ripple[rippleAction](event);
+    }
+
+    return true;
+  });
+}
+
 /**
  * `ButtonBase` contains as few styles as possible.
  * It aims to be a simple building block for creating a button.
@@ -137,38 +152,29 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
     }
   }, [disableRipple, focusRipple, focusVisible, ripple]);
 
-  function useRippleHandler(rippleAction, eventCallback, skipRippleAction = disableTouchRipple) {
-    return useEventCallback((event) => {
-      if (eventCallback) {
-        eventCallback(event);
+  const handleMouseDown = useRippleHandler(ripple, 'start', onMouseDown, disableTouchRipple);
+  const handleContextMenu = useRippleHandler(ripple, 'stop', onContextMenu, disableTouchRipple);
+  const handleDragLeave = useRippleHandler(ripple, 'stop', onDragLeave, disableTouchRipple);
+  const handleMouseUp = useRippleHandler(ripple, 'stop', onMouseUp, disableTouchRipple);
+  const handleMouseLeave = useRippleHandler(
+    ripple,
+    'stop',
+    (event) => {
+      if (focusVisible) {
+        event.preventDefault();
       }
-
-      const ignore = skipRippleAction;
-      if (!ignore) {
-        ripple[rippleAction](event);
+      if (onMouseLeave) {
+        onMouseLeave(event);
       }
-
-      return true;
-    });
-  }
-
-  const handleMouseDown = useRippleHandler('start', onMouseDown);
-  const handleContextMenu = useRippleHandler('stop', onContextMenu);
-  const handleDragLeave = useRippleHandler('stop', onDragLeave);
-  const handleMouseUp = useRippleHandler('stop', onMouseUp);
-  const handleMouseLeave = useRippleHandler('stop', (event) => {
-    if (focusVisible) {
-      event.preventDefault();
-    }
-    if (onMouseLeave) {
-      onMouseLeave(event);
-    }
-  });
-  const handleTouchStart = useRippleHandler('start', onTouchStart);
-  const handleTouchEnd = useRippleHandler('stop', onTouchEnd);
-  const handleTouchMove = useRippleHandler('stop', onTouchMove);
+    },
+    disableTouchRipple,
+  );
+  const handleTouchStart = useRippleHandler(ripple, 'start', onTouchStart, disableTouchRipple);
+  const handleTouchEnd = useRippleHandler(ripple, 'stop', onTouchEnd, disableTouchRipple);
+  const handleTouchMove = useRippleHandler(ripple, 'stop', onTouchMove, disableTouchRipple);
 
   const handleBlur = useRippleHandler(
+    ripple,
     'stop',
     (event) => {
       if (!isFocusVisible(event.target)) {

--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -68,21 +68,6 @@ export const ButtonBaseRoot = styled('button', {
   },
 });
 
-function useRippleHandler(ripple, rippleAction, eventCallback, skipRippleAction = false) {
-  return useEventCallback((event) => {
-    if (eventCallback) {
-      eventCallback(event);
-    }
-
-    const ignore = skipRippleAction;
-    if (!ignore) {
-      ripple[rippleAction](event);
-    }
-
-    return true;
-  });
-}
-
 /**
  * `ButtonBase` contains as few styles as possible.
  * It aims to be a simple building block for creating a button.
@@ -331,6 +316,20 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
     </ButtonBaseRoot>
   );
 });
+
+function useRippleHandler(ripple, rippleAction, eventCallback, skipRippleAction = false) {
+  return useEventCallback((event) => {
+    if (eventCallback) {
+      eventCallback(event);
+    }
+
+    if (!skipRippleAction) {
+      ripple[rippleAction](event);
+    }
+
+    return true;
+  });
+}
 
 ButtonBase.propTypes /* remove-proptypes */ = {
   // ┌────────────────────────────── Warning ──────────────────────────────┐


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Suggested fix for #42564 with ButtonBase.js

This solves the invalid-hook-call-warning ESLint warning with the useRippleHandler hook. 

There are still ref.current ESLint warnings with the current version of eslint-plugin-react-compiler, but when eslint-plugin-react-compiler is updated to the newest version, these are gone. From our understanding of the ESLint warning, it is a false positive, so the newer version is correct while the current one is not. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
