### PR TITLE
[core] Switch back to useCallback to avoid ESLint error

### DIFF
--- a/packages/mui-utils/src/useEventCallback/useEventCallback.ts
+++ b/packages/mui-utils/src/useEventCallback/useEventCallback.ts
@@ -19,10 +19,11 @@ function useEventCallback<Args extends unknown[], Return>(
   useEnhancedEffect(() => {
     ref.current = fn;
   });
-  return React.useRef((...args: Args) =>
-    // @ts-expect-error hide `this`
-    (0, ref.current!)(...args),
-  ).current;
+  return React.useCallback(
+    (...args: Args) =>
+      ref.current(...args),
+    [],
+  );
 }
 
 export default useEventCallback;

--- a/packages/mui-utils/src/useEventCallback/useEventCallback.ts
+++ b/packages/mui-utils/src/useEventCallback/useEventCallback.ts
@@ -19,11 +19,7 @@ function useEventCallback<Args extends unknown[], Return>(
   useEnhancedEffect(() => {
     ref.current = fn;
   });
-  return React.useCallback(
-    (...args: Args) =>
-      ref.current(...args),
-    [],
-  );
+  return React.useCallback((...args: Args) => ref.current(...args), []);
 }
 
 export default useEventCallback;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
 Revert back to previous implementation from #39078, with some minor adjustments. The reason for this is that eslint-plugin-react-compiler gives an ESLint error when ref.current is being accessed inside the useRef which from our understanding can cause inconsistencies. If this inconsistency is already handled in other ways, then the leaner version from #39078 can be kept, and an explicit ignore of this error could be added. This warning was noticed when working on #44591, and we felt it might be relevant to get rid of this ESLint warning as well. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
