### PR TITLE
[material-ui][Tabs] Fix `ScrollbarSize` ref being overriden

### DIFF
--- a/packages/mui-material/src/Tabs/ScrollbarSize.js
+++ b/packages/mui-material/src/Tabs/ScrollbarSize.js
@@ -49,7 +49,7 @@ export default function ScrollbarSize(props) {
     onChange(scrollbarHeight.current);
   }, [onChange]);
 
-  return <div style={styles} ref={nodeRef} {...other} />;
+  return <div style={styles} {...other} ref={nodeRef} />;
 }
 
 ScrollbarSize.propTypes = {


### PR DESCRIPTION
Closes: https://github.com/mui/material-ui/issues/41388
The explanation for the fix: https://github.com/mui/material-ui/issues/41388#issuecomment-2185339892

`ScrollbarSize` is an internal component, not exported, and we don't need to provide a ref, so there's no need for ref merging.

Before and after: https://github.com/DiegoAndai/material-ui-issue-41388-repro
Before is the [`main` branch](https://github.com/DiegoAndai/material-ui-issue-41388-repro/tree/main)
After is the [`with-fix` branch](https://github.com/DiegoAndai/material-ui-issue-41388-repro/tree/with-fix) that uses this PR's build
