### PR TITLE
[material-ui][Tabs] Cherry pick `ScrollbarSize` ref being overriden fix

### DIFF
--- a/packages/mui-material/src/Tabs/ScrollbarSize.js
+++ b/packages/mui-material/src/Tabs/ScrollbarSize.js
@@ -49,7 +49,7 @@ export default function ScrollbarSize(props) {
     onChange(scrollbarHeight.current);
   }, [onChange]);
 
-  return <div style={styles} ref={nodeRef} {...other} />;
+  return <div style={styles} {...other} ref={nodeRef} />;
 }
 
 ScrollbarSize.propTypes = {


### PR DESCRIPTION
Cherry-pick https://github.com/mui/material-ui/pull/44593
Part of https://github.com/mui/material-ui/issues/44413
