### PR TITLE
[Grid2] Fix theme scoping error

### DIFF
--- a/packages/mui-material/src/Grid2/Grid2.test.js
+++ b/packages/mui-material/src/Grid2/Grid2.test.js
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import { createRenderer } from '@mui/internal-test-utils';
+import { ThemeProvider, THEME_ID, createTheme } from '@mui/material/styles';
 import Grid2, { grid2Classes as classes } from '@mui/material/Grid2';
 import describeConformance from '../../test/describeConformance';
 
@@ -20,4 +22,17 @@ describe('<Grid2 />', () => {
     testVariantProps: { container: true, spacing: 5 },
     skip: ['componentsProp', 'classesRoot'],
   }));
+
+  it('should not crash with theme scoping', () => {
+    expect(() =>
+      render(
+        <ThemeProvider theme={{ [THEME_ID]: createTheme() }}>
+          <Grid2 container spacing={2}>
+            <Grid2 size={{ xs: 12, md: 6 }}>6</Grid2>
+            <Grid2 size={{ xs: 12, md: 6 }}>6</Grid2>
+          </Grid2>
+        </ThemeProvider>,
+      ),
+    ).not.throw();
+  });
 });

--- a/packages/mui-material/src/Grid2/Grid2.tsx
+++ b/packages/mui-material/src/Grid2/Grid2.tsx
@@ -6,6 +6,7 @@ import { OverridableComponent, OverrideProps } from '@mui/types';
 import requirePropFactory from '../utils/requirePropFactory';
 import { Theme, styled, Breakpoint } from '../styles';
 import { useDefaultProps } from '../DefaultPropsProvider';
+import useTheme from '../styles/useTheme';
 
 type ResponsiveStyleValue<T> = T | Array<T | null> | { [key in Breakpoint]?: T | null };
 
@@ -131,6 +132,7 @@ const Grid2 = createGrid2({
   }),
   componentName: 'MuiGrid2',
   useThemeProps: (inProps) => useDefaultProps({ props: inProps, name: 'MuiGrid2' }),
+  useTheme,
 }) as OverridableComponent<Grid2TypeMap>;
 
 Grid2.propTypes /* remove-proptypes */ = {

--- a/packages/mui-system/src/Grid/createGrid.tsx
+++ b/packages/mui-system/src/Grid/createGrid.tsx
@@ -7,7 +7,7 @@ import generateUtilityClass from '@mui/utils/generateUtilityClass';
 import composeClasses from '@mui/utils/composeClasses';
 import systemStyled from '../styled';
 import useThemePropsSystem from '../useThemeProps';
-import useTheme from '../useTheme';
+import useThemeSystem from '../useTheme';
 import { extendSxProp } from '../styleFunctionSx';
 import createTheme, { Breakpoint, Breakpoints } from '../createTheme';
 import {
@@ -46,6 +46,7 @@ export default function createGrid(
   options: {
     createStyledComponent?: typeof defaultCreateStyledComponent;
     useThemeProps?: typeof useThemePropsDefault;
+    useTheme?: typeof useThemeSystem;
     componentName?: string;
   } = {},
 ) {
@@ -53,6 +54,7 @@ export default function createGrid(
     // This will allow adding custom styled fn (for example for custom sx style function)
     createStyledComponent = defaultCreateStyledComponent,
     useThemeProps = useThemePropsDefault,
+    useTheme = useThemeSystem,
     componentName = 'MuiGrid',
   } = options;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #44539

The Grid2 does not work properly when theme scoping is configure because it's using theme directly from `@mui/system`.

The fix is to pass `useTheme` from Material UI when creating Grid2 component.

Test added.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
