### PR TITLE
Add warning when using `noSsr` incorrectly

### DIFF
--- a/packages/mui-material/src/styles/ThemeProviderNoVars.tsx
+++ b/packages/mui-material/src/styles/ThemeProviderNoVars.tsx
@@ -8,11 +8,25 @@ export interface ThemeProviderNoVarsProps<Theme = DefaultTheme> {
   theme: Partial<Theme> | ((outerTheme: Theme) => Theme);
 }
 
+let warnedOnceNoSsr = false;
+
 export default function ThemeProviderNoVars<Theme = DefaultTheme>({
   theme: themeInput,
   ...props
 }: ThemeProviderNoVarsProps<Theme>): React.ReactElement<ThemeProviderNoVarsProps<Theme>> {
   const scopedTheme = THEME_ID in themeInput ? themeInput[THEME_ID] : undefined;
+  if (process.env.NODE_ENV !== 'production') {
+    // @ts-ignore
+    if (process.env.NODE_ENV !== 'test' && props.noSsr && !warnedOnceNoSsr) {
+      console.error(
+        [
+          'MUI: The `noSsr` prop must be used with the theme that contains light and dark colorSchemes.',
+          'See https://mui.com/material-ui/customization/dark-mode/#built-in-support for more details.',
+        ].join('\n'),
+      );
+      warnedOnceNoSsr = true;
+    }
+  }
   return (
     <SystemThemeProvider
       {...props}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #44576 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
