### PR TITLE
[material-ui][Box] Add missing `component` to `BoxProps` type

### DIFF
--- a/packages/mui-material/src/Box/Box.d.ts
+++ b/packages/mui-material/src/Box/Box.d.ts
@@ -18,6 +18,8 @@ declare const Box: OverridableComponent<BoxTypeMap<{}, 'div', MaterialTheme>>;
 export type BoxProps<
   RootComponent extends React.ElementType = BoxTypeMap['defaultComponent'],
   AdditionalProps = {},
-> = OverrideProps<BoxTypeMap<AdditionalProps, RootComponent, MaterialTheme>, RootComponent>;
+> = OverrideProps<BoxTypeMap<AdditionalProps, RootComponent, MaterialTheme>, RootComponent> & {
+  component?: React.ElementType;
+};
 
 export default Box;

--- a/packages/mui-material/src/Box/Box.spec.tsx
+++ b/packages/mui-material/src/Box/Box.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Box as SystemBox, createBox } from '@mui/system';
+import { Box as SystemBox, BoxProps as SystemBoxProps, createBox } from '@mui/system';
 import { expectType } from '@mui/types';
-import Box from '@mui/material/Box';
+import Box, { BoxProps as MaterialBoxProps } from '@mui/material/Box';
 import { createTheme } from '@mui/material/styles';
 
 function ThemeValuesCanBeSpread() {
@@ -39,3 +39,5 @@ function ColorTest() {
     sx={(theme) => ({ backgroundColor: theme.vars.palette.background.default })}
   />;
 }
+
+expectType<SystemBoxProps['component'], MaterialBoxProps['component']>;


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/issues/43955

This was an oversight of https://github.com/mui/material-ui/pull/43384, as the System `BoxProps` had the `component` property, but Material UI's didn't. They should be equivalent. I added a test for it as well.
