### PR TITLE
[api-docs-builder] Allow custom annotations

### DIFF
--- a/packages/api-docs-builder/types/ApiBuilder.types.ts
+++ b/packages/api-docs-builder/types/ApiBuilder.types.ts
@@ -33,6 +33,7 @@ interface CommonReactApi extends ReactDocgenApi {
    */
   apiDocsTranslationFolder?: string;
   deprecated: true | undefined;
+  customAnnotation?: string;
 }
 
 export interface PropsTableItem {

--- a/packages/api-docs-builder/types/utils.types.ts
+++ b/packages/api-docs-builder/types/utils.types.ts
@@ -58,6 +58,10 @@ export type ComponentInfo = {
    * If `true`, the component's name match one of the MUI System components.
    */
   isSystemComponent?: boolean;
+  /**
+   * If provided, this annotation will be used instead of the auto-generated demo & API links
+   */
+  customAnnotation?: string;
 };
 
 export type HookInfo = {
@@ -74,4 +78,8 @@ export type HookInfo = {
   getDemos: ComponentInfo['getDemos'];
   apiPagesDirectory: string;
   skipApiGeneration?: boolean;
+  /**
+   * If provided, this annotation will be used instead of the auto-generated demo & API links
+   */
+  customAnnotation?: string;
 };


### PR DESCRIPTION
In Base UI docs, all component docs and its API reference are placed on the same page

This PR updates the docs builder so that instead of separate API and docs URLs...

![image](https://github.com/user-attachments/assets/d9584320-15b8-44cf-82f3-8006bbe4a57d)

...we can use custom annotations provided from where the docs builder script runs:

![image](https://github.com/user-attachments/assets/b6ab4531-3f0b-4832-9fc4-9fd73c3f5e80)
