### PR TITLE
[autocomplete][docs] Improve Google Maps search example

### DIFF
--- a/docs/data/material/components/autocomplete/GitHubLabel.js
+++ b/docs/data/material/components/autocomplete/GitHubLabel.js
@@ -19,13 +19,19 @@ const StyledAutocompletePopper = styled('div')(({ theme }) => ({
     fontSize: 13,
   },
   [`& .${autocompleteClasses.listbox}`]: {
-    backgroundColor: '#fff',
     padding: 0,
+    backgroundColor: '#fff',
+    ...theme.applyStyles('dark', {
+      backgroundColor: '#1c2128',
+    }),
     [`& .${autocompleteClasses.option}`]: {
       minHeight: 'auto',
       alignItems: 'flex-start',
       padding: 8,
-      borderBottom: `1px solid  ${' #eaecef'}`,
+      borderBottom: '1px solid #eaecef',
+      ...theme.applyStyles('dark', {
+        borderBottom: '1px solid #30363d',
+      }),
       '&[aria-selected="true"]': {
         backgroundColor: 'transparent',
       },
@@ -33,13 +39,7 @@ const StyledAutocompletePopper = styled('div')(({ theme }) => ({
         {
           backgroundColor: theme.palette.action.hover,
         },
-      ...theme.applyStyles('dark', {
-        borderBottom: `1px solid  ${'#30363d'}`,
-      }),
     },
-    ...theme.applyStyles('dark', {
-      backgroundColor: '#1c2128',
-    }),
   },
   [`&.${autocompleteClasses.popperDisablePortal}`]: {
     position: 'relative',
@@ -58,7 +58,7 @@ PopperComponent.propTypes = {
 };
 
 const StyledPopper = styled(Popper)(({ theme }) => ({
-  border: `1px solid ${'#e1e4e8'}`,
+  border: '1px solid #e1e4e8',
   boxShadow: `0 8px 24px ${'rgba(149, 157, 165, 0.2)'}`,
   color: '#24292e',
   backgroundColor: '#fff',
@@ -67,8 +67,8 @@ const StyledPopper = styled(Popper)(({ theme }) => ({
   zIndex: theme.zIndex.modal,
   fontSize: 13,
   ...theme.applyStyles('dark', {
-    border: `1px solid ${'#30363d'}`,
-    boxShadow: `0 8px 24px ${'rgb(1, 4, 9)'}`,
+    border: '1px solid #30363d',
+    boxShadow: '0 8px 24px rgb(1, 4, 9)',
     color: '#c9d1d9',
     backgroundColor: '#1c2128',
   }),
@@ -77,30 +77,30 @@ const StyledPopper = styled(Popper)(({ theme }) => ({
 const StyledInput = styled(InputBase)(({ theme }) => ({
   padding: 10,
   width: '100%',
-  borderBottom: `1px solid ${'#30363d'}`,
+  borderBottom: '1px solid #eaecef',
+  ...theme.applyStyles('dark', {
+    borderBottom: '1px solid #30363d',
+  }),
   '& input': {
     borderRadius: 4,
-    backgroundColor: '#fff',
-    border: `1px solid ${'#30363d'}`,
     padding: 8,
     transition: theme.transitions.create(['border-color', 'box-shadow']),
     fontSize: 14,
+    backgroundColor: '#fff',
+    border: '1px solid #30363d',
+    ...theme.applyStyles('dark', {
+      backgroundColor: '#0d1117',
+      border: '1px solid #eaecef',
+    }),
     '&:focus': {
-      boxShadow: `0px 0px 0px 3px ${'rgba(3, 102, 214, 0.3)'}`,
+      boxShadow: '0px 0px 0px 3px rgba(3, 102, 214, 0.3)',
       borderColor: '#0366d6',
       ...theme.applyStyles('dark', {
-        boxShadow: `0px 0px 0px 3px ${'rgb(12, 45, 107)'}`,
+        boxShadow: '0px 0px 0px 3px rgb(12, 45, 107)',
         borderColor: '#388bfd',
       }),
     },
-    ...theme.applyStyles('dark', {
-      backgroundColor: '#0d1117',
-      border: `1px solid ${'#eaecef'}`,
-    }),
   },
-  ...theme.applyStyles('dark', {
-    borderBottom: `1px solid ${'#eaecef'}`,
-  }),
 }));
 
 const Button = styled(ButtonBase)(({ theme }) => ({
@@ -108,8 +108,11 @@ const Button = styled(ButtonBase)(({ theme }) => ({
   width: '100%',
   textAlign: 'left',
   paddingBottom: 8,
-  color: '#586069',
   fontWeight: 600,
+  color: '#586069',
+  ...theme.applyStyles('dark', {
+    color: '#8b949e',
+  }),
   '&:hover,&:focus': {
     color: '#0366d6',
     ...theme.applyStyles('dark', {
@@ -123,9 +126,6 @@ const Button = styled(ButtonBase)(({ theme }) => ({
     width: 16,
     height: 16,
   },
-  ...theme.applyStyles('dark', {
-    color: '#8b949e',
-  }),
 }));
 
 export default function GitHubLabel() {
@@ -182,11 +182,11 @@ export default function GitHubLabel() {
           <div>
             <Box
               sx={(t) => ({
-                borderBottom: `1px solid ${'#30363d'}`,
+                borderBottom: '1px solid #30363d',
                 padding: '8px 10px',
                 fontWeight: 600,
                 ...t.applyStyles('light', {
-                  borderBottom: `1px solid ${'#eaecef'}`,
+                  borderBottom: '1px solid #eaecef',
                 }),
               })}
             >

--- a/docs/data/material/components/autocomplete/GitHubLabel.tsx
+++ b/docs/data/material/components/autocomplete/GitHubLabel.tsx
@@ -27,15 +27,19 @@ const StyledAutocompletePopper = styled('div')(({ theme }) => ({
     fontSize: 13,
   },
   [`& .${autocompleteClasses.listbox}`]: {
-    backgroundColor: '#fff',
-
     padding: 0,
+    backgroundColor: '#fff',
+    ...theme.applyStyles('dark', {
+      backgroundColor: '#1c2128',
+    }),
     [`& .${autocompleteClasses.option}`]: {
       minHeight: 'auto',
       alignItems: 'flex-start',
       padding: 8,
-      borderBottom: `1px solid  ${' #eaecef'}`,
-
+      borderBottom: '1px solid #eaecef',
+      ...theme.applyStyles('dark', {
+        borderBottom: '1px solid #30363d',
+      }),
       '&[aria-selected="true"]': {
         backgroundColor: 'transparent',
       },
@@ -43,13 +47,7 @@ const StyledAutocompletePopper = styled('div')(({ theme }) => ({
         {
           backgroundColor: theme.palette.action.hover,
         },
-      ...theme.applyStyles('dark', {
-        borderBottom: `1px solid  ${'#30363d'}`,
-      }),
     },
-    ...theme.applyStyles('dark', {
-      backgroundColor: '#1c2128',
-    }),
   },
   [`&.${autocompleteClasses.popperDisablePortal}`]: {
     position: 'relative',
@@ -62,7 +60,7 @@ function PopperComponent(props: PopperComponentProps) {
 }
 
 const StyledPopper = styled(Popper)(({ theme }) => ({
-  border: `1px solid ${'#e1e4e8'}`,
+  border: '1px solid #e1e4e8',
   boxShadow: `0 8px 24px ${'rgba(149, 157, 165, 0.2)'}`,
   color: '#24292e',
   backgroundColor: '#fff',
@@ -71,8 +69,8 @@ const StyledPopper = styled(Popper)(({ theme }) => ({
   zIndex: theme.zIndex.modal,
   fontSize: 13,
   ...theme.applyStyles('dark', {
-    border: `1px solid ${'#30363d'}`,
-    boxShadow: `0 8px 24px ${'rgb(1, 4, 9)'}`,
+    border: '1px solid #30363d',
+    boxShadow: '0 8px 24px rgb(1, 4, 9)',
     color: '#c9d1d9',
     backgroundColor: '#1c2128',
   }),
@@ -81,30 +79,30 @@ const StyledPopper = styled(Popper)(({ theme }) => ({
 const StyledInput = styled(InputBase)(({ theme }) => ({
   padding: 10,
   width: '100%',
-  borderBottom: `1px solid ${'#30363d'}`,
+  borderBottom: '1px solid #eaecef',
+  ...theme.applyStyles('dark', {
+    borderBottom: '1px solid #30363d',
+  }),
   '& input': {
     borderRadius: 4,
-    backgroundColor: '#fff',
-    border: `1px solid ${'#30363d'}`,
     padding: 8,
     transition: theme.transitions.create(['border-color', 'box-shadow']),
     fontSize: 14,
+    backgroundColor: '#fff',
+    border: '1px solid #30363d',
+    ...theme.applyStyles('dark', {
+      backgroundColor: '#0d1117',
+      border: '1px solid #eaecef',
+    }),
     '&:focus': {
-      boxShadow: `0px 0px 0px 3px ${'rgba(3, 102, 214, 0.3)'}`,
+      boxShadow: '0px 0px 0px 3px rgba(3, 102, 214, 0.3)',
       borderColor: '#0366d6',
       ...theme.applyStyles('dark', {
-        boxShadow: `0px 0px 0px 3px ${'rgb(12, 45, 107)'}`,
+        boxShadow: '0px 0px 0px 3px rgb(12, 45, 107)',
         borderColor: '#388bfd',
       }),
     },
-    ...theme.applyStyles('dark', {
-      backgroundColor: '#0d1117',
-      border: `1px solid ${'#eaecef'}`,
-    }),
   },
-  ...theme.applyStyles('dark', {
-    borderBottom: `1px solid ${'#eaecef'}`,
-  }),
 }));
 
 const Button = styled(ButtonBase)(({ theme }) => ({
@@ -112,8 +110,11 @@ const Button = styled(ButtonBase)(({ theme }) => ({
   width: '100%',
   textAlign: 'left',
   paddingBottom: 8,
-  color: '#586069',
   fontWeight: 600,
+  color: '#586069',
+  ...theme.applyStyles('dark', {
+    color: '#8b949e',
+  }),
   '&:hover,&:focus': {
     color: '#0366d6',
     ...theme.applyStyles('dark', {
@@ -127,9 +128,6 @@ const Button = styled(ButtonBase)(({ theme }) => ({
     width: 16,
     height: 16,
   },
-  ...theme.applyStyles('dark', {
-    color: '#8b949e',
-  }),
 }));
 
 export default function GitHubLabel() {
@@ -186,11 +184,11 @@ export default function GitHubLabel() {
           <div>
             <Box
               sx={(t) => ({
-                borderBottom: `1px solid ${'#30363d'}`,
+                borderBottom: '1px solid #30363d',
                 padding: '8px 10px',
                 fontWeight: 600,
                 ...t.applyStyles('light', {
-                  borderBottom: `1px solid ${'#eaecef'}`,
+                  borderBottom: '1px solid #eaecef',
                 }),
               })}
             >

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -3,91 +3,124 @@ import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Autocomplete from '@mui/material/Autocomplete';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
-import Grid from '@mui/material/Grid';
+import Grid2 from '@mui/material/Grid2';
 import Typography from '@mui/material/Typography';
 import parse from 'autosuggest-highlight/parse';
-import { debounce } from '@mui/material/utils';
+import throttle from 'lodash/throttle';
 
 // This key was created specifically for the demo in mui.com.
 // You need to create a new one for your application.
 const GOOGLE_MAPS_API_KEY = 'AIzaSyC3aviU6KHXAjoSnxcw6qbOhjnFctbxPkE';
 
-function loadScript(src, position, id) {
-  if (!position) {
-    return;
-  }
+const useEnhancedEffect =
+  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
 
+function loadScript(src, position) {
   const script = document.createElement('script');
   script.setAttribute('async', '');
-  script.setAttribute('id', id);
   script.src = src;
   position.appendChild(script);
+  return script;
 }
 
-const autocompleteService = { current: null };
+const fetch = throttle(async (request, callback) => {
+  const { suggestions } =
+    await window.google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions(
+      request,
+    );
+
+  callback(
+    suggestions.map((suggestion) => {
+      const place = suggestion.placePrediction;
+      // Map to the old AutocompleteService.getPlacePredictions format
+      // https://developers.google.com/maps/documentation/javascript/places-migration-autocomplete
+      return {
+        description: place.text.text,
+        structured_formatting: {
+          main_text: place.mainText.text,
+          main_text_matched_substrings: place.mainText.matches.map((match) => ({
+            offset: match.startOffset,
+            length: match.endOffset - match.startOffset,
+          })),
+          secondary_text: place.secondaryText?.text,
+        },
+      };
+    }),
+  );
+}, 300);
+
+const emptyOptions = [];
+let sessionToken;
 
 export default function GoogleMaps() {
   const [value, setValue] = React.useState(null);
   const [inputValue, setInputValue] = React.useState('');
-  const [options, setOptions] = React.useState([]);
-  const loaded = React.useRef(false);
+  const [options, setOptions] = React.useState(emptyOptions);
+  const callbackId = React.useId().replace(/:/g, '');
+  const [loaded, setLoaded] = React.useState(false);
 
-  if (typeof window !== 'undefined' && !loaded.current) {
+  if (typeof window !== 'undefined') {
     if (!document.querySelector('#google-maps')) {
-      loadScript(
-        `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}&libraries=places`,
-        document.querySelector('head'),
-        'google-maps',
-      );
-    }
+      const GOOGLE_NAMESPACE = '_google_callback';
+      const globalContext =
+        window[GOOGLE_NAMESPACE] || (window[GOOGLE_NAMESPACE] = {});
+      globalContext[callbackId] = () => {
+        setLoaded(true);
+      };
 
-    loaded.current = true;
+      const script = loadScript(
+        `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}&libraries=places&loading=async&callback=${GOOGLE_NAMESPACE}.${callbackId}`,
+        document.querySelector('head'),
+      );
+      script.id = 'google-maps';
+    } else if (window.google && !loaded) {
+      setLoaded(true);
+    }
   }
 
-  const fetch = React.useMemo(
-    () =>
-      debounce((request, callback) => {
-        autocompleteService.current.getPlacePredictions(request, callback);
-      }, 400),
-    [],
-  );
-
-  React.useEffect(() => {
-    let active = true;
-
-    if (!autocompleteService.current && window.google) {
-      autocompleteService.current =
-        new window.google.maps.places.AutocompleteService();
-    }
-    if (!autocompleteService.current) {
+  useEnhancedEffect(() => {
+    if (!loaded) {
       return undefined;
     }
 
     if (inputValue === '') {
-      setOptions(value ? [value] : []);
+      setOptions(value ? [value] : emptyOptions);
       return undefined;
     }
 
-    fetch({ input: inputValue }, (results) => {
-      if (active) {
-        let newOptions = [];
+    // Allow to resolve the out of order request resolution.
+    let active = true;
+
+    if (!sessionToken) {
+      sessionToken = new window.google.maps.places.AutocompleteSessionToken();
+    }
+
+    fetch({ input: inputValue, sessionToken }, (results) => {
+      if (!active) {
+        return;
+      }
+
+      let newOptions = [];
+
+      if (results) {
+        newOptions = results;
 
         if (value) {
-          newOptions = [value];
+          newOptions = [
+            value,
+            ...results.filter((result) => result.description !== value.description),
+          ];
         }
-
-        if (results) {
-          newOptions = [...newOptions, ...results];
-        }
-
-        setOptions(newOptions);
+      } else if (value) {
+        newOptions = [value];
       }
+      setOptions(newOptions);
     });
 
     return () => {
       active = false;
     };
-  }, [value, inputValue, fetch]);
+  }, [value, inputValue, loaded]);
 
   return (
     <Autocomplete
@@ -114,8 +147,7 @@ export default function GoogleMaps() {
       )}
       renderOption={(props, option) => {
         const { key, ...optionProps } = props;
-        const matches =
-          option.structured_formatting.main_text_matched_substrings || [];
+        const matches = option.structured_formatting.main_text_matched_substrings;
 
         const parts = parse(
           option.structured_formatting.main_text,
@@ -123,25 +155,31 @@ export default function GoogleMaps() {
         );
         return (
           <li key={key} {...optionProps}>
-            <Grid container sx={{ alignItems: 'center' }}>
-              <Grid item sx={{ display: 'flex', width: 44 }}>
+            <Grid2 container sx={{ alignItems: 'center' }}>
+              <Grid2 sx={{ display: 'flex', width: 44 }}>
                 <LocationOnIcon sx={{ color: 'text.secondary' }} />
-              </Grid>
-              <Grid item sx={{ width: 'calc(100% - 44px)', wordWrap: 'break-word' }}>
+              </Grid2>
+              <Grid2 sx={{ width: 'calc(100% - 44px)', wordWrap: 'break-word' }}>
                 {parts.map((part, index) => (
                   <Box
                     key={index}
                     component="span"
-                    sx={{ fontWeight: part.highlight ? 'bold' : 'regular' }}
+                    sx={{
+                      fontWeight: part.highlight
+                        ? 'fontWeightBold'
+                        : 'fontWeightRegular',
+                    }}
                   >
                     {part.text}
                   </Box>
                 ))}
-                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                  {option.structured_formatting.secondary_text}
-                </Typography>
-              </Grid>
-            </Grid>
+                {option.structured_formatting.secondary_text ? (
+                  <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                    {option.structured_formatting.secondary_text}
+                  </Typography>
+                ) : null}
+              </Grid2>
+            </Grid2>
           </li>
         );
       }}

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -2,11 +2,16 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Autocomplete from '@mui/material/Autocomplete';
+import Paper, { PaperProps } from '@mui/material/Paper';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import Grid2 from '@mui/material/Grid2';
 import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
 import parse from 'autosuggest-highlight/parse';
-import throttle from 'lodash/throttle';
+// For the sake of this demo, we have to use debounce to reduce Google Maps Places API quote use
+// But prefer to use throttle in practice
+// import throttle from 'lodash/throttle';
+import { debounce } from '@mui/material/utils';
 
 // This key was created specifically for the demo in mui.com.
 // You need to create a new one for your application.
@@ -37,39 +42,80 @@ interface PlaceType {
   structured_formatting: StructuredFormatting;
 }
 
-const fetch = throttle(
+function CustomPaper(props: PaperProps) {
+  const theme = useTheme();
+
+  return (
+    <Paper {...props}>
+      {props.children}
+      {/* Legal requirment https://developers.google.com/maps/documentation/javascript/policies#logo */}
+      <Box
+        sx={(staticTheme) => ({
+          display: 'flex',
+          justifyContent: 'flex-end',
+          p: 1,
+          pt: '1px',
+          ...staticTheme.applyStyles('dark', {
+            opacity: 0.8,
+          }),
+        })}
+      >
+        <img
+          src={
+            theme.palette.mode === 'dark'
+              ? 'https://maps.gstatic.com/mapfiles/api-3/images/powered-by-google-on-non-white3_hdpi.png'
+              : 'https://maps.gstatic.com/mapfiles/api-3/images/powered-by-google-on-white3_hdpi.png'
+          }
+          alt=""
+          width="120"
+          height="14"
+        />
+      </Box>
+    </Paper>
+  );
+}
+
+const fetch = debounce(
   async (
     request: { input: string; sessionToken: any },
     callback: (results?: readonly PlaceType[]) => void,
   ) => {
-    const { suggestions } = await (
-      window as any
-    ).google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions(
-      request,
-    );
+    try {
+      const { suggestions } = await (
+        window as any
+      ).google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions(
+        request,
+      );
 
-    callback(
-      suggestions.map((suggestion: any) => {
-        const place = suggestion.placePrediction;
-        // Map to the old AutocompleteService.getPlacePredictions format
-        // https://developers.google.com/maps/documentation/javascript/places-migration-autocomplete
-        return {
-          description: place.text.text,
-          structured_formatting: {
-            main_text: place.mainText.text,
-            main_text_matched_substrings: place.mainText.matches.map(
-              (match: any) => ({
-                offset: match.startOffset,
-                length: match.endOffset - match.startOffset,
-              }),
-            ),
-            secondary_text: place.secondaryText?.text,
-          },
-        };
-      }),
-    );
+      callback(
+        suggestions.map((suggestion: any) => {
+          const place = suggestion.placePrediction;
+          // Map to the old AutocompleteService.getPlacePredictions format
+          // https://developers.google.com/maps/documentation/javascript/places-migration-autocomplete
+          return {
+            description: place.text.text,
+            structured_formatting: {
+              main_text: place.mainText.text,
+              main_text_matched_substrings: place.mainText.matches.map(
+                (match: any) => ({
+                  offset: match.startOffset,
+                  length: match.endOffset - match.startOffset,
+                }),
+              ),
+              secondary_text: place.secondaryText?.text,
+            },
+          };
+        }),
+      );
+    } catch (err: any) {
+      if (err.message === 'Quota exceeded for quota') {
+        callback(request.input.length === 1 ? fakeAnswer.p : fakeAnswer.paris);
+      }
+
+      throw err;
+    }
   },
-  300,
+  400,
 );
 
 const emptyOptions = [] as any;
@@ -155,6 +201,9 @@ export default function GoogleMaps() {
         typeof option === 'string' ? option : option.description
       }
       filterOptions={(x) => x}
+      slots={{
+        paper: CustomPaper,
+      }}
       options={options}
       autoComplete
       includeInputInList
@@ -212,3 +261,87 @@ export default function GoogleMaps() {
     />
   );
 }
+
+// Fake data in case Google Map Places API returns a rate limit.
+const fakeAnswer = {
+  p: [
+    {
+      description: 'Portugal',
+      structured_formatting: {
+        main_text: 'Portugal',
+        main_text_matched_substrings: [{ offset: 0, length: 1 }],
+      },
+    },
+    {
+      description: 'Puerto Rico',
+      structured_formatting: {
+        main_text: 'Puerto Rico',
+        main_text_matched_substrings: [{ offset: 0, length: 1 }],
+      },
+    },
+    {
+      description: 'Pakistan',
+      structured_formatting: {
+        main_text: 'Pakistan',
+        main_text_matched_substrings: [{ offset: 0, length: 1 }],
+      },
+    },
+    {
+      description: 'Philippines',
+      structured_formatting: {
+        main_text: 'Philippines',
+        main_text_matched_substrings: [{ offset: 0, length: 1 }],
+      },
+    },
+    {
+      description: 'Paris, France',
+      structured_formatting: {
+        main_text: 'Paris',
+        main_text_matched_substrings: [{ offset: 0, length: 1 }],
+        secondary_text: 'France',
+      },
+    },
+  ],
+  paris: [
+    {
+      description: 'Paris, France',
+      structured_formatting: {
+        main_text: 'Paris',
+        main_text_matched_substrings: [{ offset: 0, length: 5 }],
+        secondary_text: 'France',
+      },
+    },
+    {
+      description: 'Paris, TX, USA',
+      structured_formatting: {
+        main_text: 'Paris',
+        main_text_matched_substrings: [{ offset: 0, length: 5 }],
+        secondary_text: 'TX, USA',
+      },
+    },
+    {
+      description: "Paris Beauvais Airport, Route de l'Aéroport, Tillé, France",
+      structured_formatting: {
+        main_text: 'Paris Beauvais Airport',
+        main_text_matched_substrings: [{ offset: 0, length: 5 }],
+        secondary_text: "Route de l'Aéroport, Tillé, France",
+      },
+    },
+    {
+      description: 'Paris Las Vegas, South Las Vegas Boulevard, Las Vegas, NV, USA',
+      structured_formatting: {
+        main_text: 'Paris Las Vegas',
+        main_text_matched_substrings: [{ offset: 0, length: 5 }],
+        secondary_text: 'South Las Vegas Boulevard, Las Vegas, NV, USA',
+      },
+    },
+    {
+      description: "Paris La Défense Arena, Jardin de l'Arche, Nanterre, France",
+      structured_formatting: {
+        main_text: 'Paris La Défense Arena',
+        main_text_matched_substrings: [{ offset: 0, length: 5 }],
+        secondary_text: "Jardin de l'Arche, Nanterre, France",
+      },
+    },
+  ],
+};

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -3,28 +3,25 @@ import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Autocomplete from '@mui/material/Autocomplete';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
-import Grid from '@mui/material/Grid';
+import Grid2 from '@mui/material/Grid2';
 import Typography from '@mui/material/Typography';
 import parse from 'autosuggest-highlight/parse';
-import { debounce } from '@mui/material/utils';
+import throttle from 'lodash/throttle';
 
 // This key was created specifically for the demo in mui.com.
 // You need to create a new one for your application.
 const GOOGLE_MAPS_API_KEY = 'AIzaSyC3aviU6KHXAjoSnxcw6qbOhjnFctbxPkE';
 
-function loadScript(src: string, position: HTMLElement | null, id: string) {
-  if (!position) {
-    return;
-  }
+const useEnhancedEffect =
+  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
 
+function loadScript(src: string, position: HTMLElement) {
   const script = document.createElement('script');
   script.setAttribute('async', '');
-  script.setAttribute('id', id);
   script.src = src;
   position.appendChild(script);
+  return script;
 }
-
-const autocompleteService = { current: null };
 
 interface MainTextMatchedSubstrings {
   offset: number;
@@ -32,86 +29,124 @@ interface MainTextMatchedSubstrings {
 }
 interface StructuredFormatting {
   main_text: string;
-  secondary_text: string;
-  main_text_matched_substrings?: readonly MainTextMatchedSubstrings[];
+  main_text_matched_substrings: readonly MainTextMatchedSubstrings[];
+  secondary_text?: string;
 }
 interface PlaceType {
   description: string;
   structured_formatting: StructuredFormatting;
 }
 
+const fetch = throttle(
+  async (
+    request: { input: string; sessionToken: any },
+    callback: (results?: readonly PlaceType[]) => void,
+  ) => {
+    const { suggestions } = await (
+      window as any
+    ).google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions(
+      request,
+    );
+
+    callback(
+      suggestions.map((suggestion: any) => {
+        const place = suggestion.placePrediction;
+        // Map to the old AutocompleteService.getPlacePredictions format
+        // https://developers.google.com/maps/documentation/javascript/places-migration-autocomplete
+        return {
+          description: place.text.text,
+          structured_formatting: {
+            main_text: place.mainText.text,
+            main_text_matched_substrings: place.mainText.matches.map(
+              (match: any) => ({
+                offset: match.startOffset,
+                length: match.endOffset - match.startOffset,
+              }),
+            ),
+            secondary_text: place.secondaryText?.text,
+          },
+        };
+      }),
+    );
+  },
+  300,
+);
+
+const emptyOptions = [] as any;
+let sessionToken: any;
+
 export default function GoogleMaps() {
   const [value, setValue] = React.useState<PlaceType | null>(null);
   const [inputValue, setInputValue] = React.useState('');
-  const [options, setOptions] = React.useState<readonly PlaceType[]>([]);
-  const loaded = React.useRef(false);
+  const [options, setOptions] = React.useState<readonly PlaceType[]>(emptyOptions);
+  const callbackId = React.useId().replace(/:/g, '');
+  const [loaded, setLoaded] = React.useState(false);
 
-  if (typeof window !== 'undefined' && !loaded.current) {
+  if (typeof window !== 'undefined') {
     if (!document.querySelector('#google-maps')) {
-      loadScript(
-        `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}&libraries=places`,
-        document.querySelector('head'),
-        'google-maps',
-      );
-    }
+      const GOOGLE_NAMESPACE = '_google_callback';
+      const globalContext =
+        // @ts-ignore
+        window[GOOGLE_NAMESPACE] || (window[GOOGLE_NAMESPACE] = {});
+      globalContext[callbackId] = () => {
+        setLoaded(true);
+      };
 
-    loaded.current = true;
+      const script = loadScript(
+        `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}&libraries=places&loading=async&callback=${GOOGLE_NAMESPACE}.${callbackId}`,
+        document.querySelector('head')!,
+      );
+      script.id = 'google-maps';
+    } else if ((window as any).google && !loaded) {
+      setLoaded(true);
+    }
   }
 
-  const fetch = React.useMemo(
-    () =>
-      debounce(
-        (
-          request: { input: string },
-          callback: (results?: readonly PlaceType[]) => void,
-        ) => {
-          (autocompleteService.current as any).getPlacePredictions(
-            request,
-            callback,
-          );
-        },
-        400,
-      ),
-    [],
-  );
-
-  React.useEffect(() => {
-    let active = true;
-
-    if (!autocompleteService.current && (window as any).google) {
-      autocompleteService.current = new (
-        window as any
-      ).google.maps.places.AutocompleteService();
-    }
-    if (!autocompleteService.current) {
+  useEnhancedEffect(() => {
+    if (!loaded) {
       return undefined;
     }
 
     if (inputValue === '') {
-      setOptions(value ? [value] : []);
+      setOptions(value ? [value] : emptyOptions);
       return undefined;
     }
 
-    fetch({ input: inputValue }, (results?: readonly PlaceType[]) => {
-      if (active) {
-        let newOptions: readonly PlaceType[] = [];
+    // Allow to resolve the out of order request resolution.
+    let active = true;
+
+    if (!sessionToken) {
+      sessionToken = new (
+        window as any
+      ).google.maps.places.AutocompleteSessionToken();
+    }
+
+    fetch({ input: inputValue, sessionToken }, (results?: readonly PlaceType[]) => {
+      if (!active) {
+        return;
+      }
+
+      let newOptions: readonly PlaceType[] = [];
+
+      if (results) {
+        newOptions = results;
 
         if (value) {
-          newOptions = [value];
+          newOptions = [
+            value,
+            ...results.filter((result) => result.description !== value.description),
+          ];
         }
-
-        if (results) {
-          newOptions = [...newOptions, ...results];
-        }
-
-        setOptions(newOptions);
+      } else if (value) {
+        newOptions = [value];
       }
+      setOptions(newOptions);
     });
 
     return () => {
       active = false;
     };
-  }, [value, inputValue, fetch]);
+  }, [value, inputValue, loaded]);
 
   return (
     <Autocomplete
@@ -138,8 +173,7 @@ export default function GoogleMaps() {
       )}
       renderOption={(props, option) => {
         const { key, ...optionProps } = props;
-        const matches =
-          option.structured_formatting.main_text_matched_substrings || [];
+        const matches = option.structured_formatting.main_text_matched_substrings;
 
         const parts = parse(
           option.structured_formatting.main_text,
@@ -147,25 +181,31 @@ export default function GoogleMaps() {
         );
         return (
           <li key={key} {...optionProps}>
-            <Grid container sx={{ alignItems: 'center' }}>
-              <Grid item sx={{ display: 'flex', width: 44 }}>
+            <Grid2 container sx={{ alignItems: 'center' }}>
+              <Grid2 sx={{ display: 'flex', width: 44 }}>
                 <LocationOnIcon sx={{ color: 'text.secondary' }} />
-              </Grid>
-              <Grid item sx={{ width: 'calc(100% - 44px)', wordWrap: 'break-word' }}>
+              </Grid2>
+              <Grid2 sx={{ width: 'calc(100% - 44px)', wordWrap: 'break-word' }}>
                 {parts.map((part, index) => (
                   <Box
                     key={index}
                     component="span"
-                    sx={{ fontWeight: part.highlight ? 'bold' : 'regular' }}
+                    sx={{
+                      fontWeight: part.highlight
+                        ? 'fontWeightBold'
+                        : 'fontWeightRegular',
+                    }}
                   >
                     {part.text}
                   </Box>
                 ))}
-                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                  {option.structured_formatting.secondary_text}
-                </Typography>
-              </Grid>
-            </Grid>
+                {option.structured_formatting.secondary_text ? (
+                  <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                    {option.structured_formatting.secondary_text}
+                  </Typography>
+                ) : null}
+              </Grid2>
+            </Grid2>
           </li>
         );
       }}

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -215,11 +215,9 @@ overriding the `filterOptions` prop:
 A customized UI for Google Maps Places Autocomplete.
 For this demo, we need to load the [Google Maps JavaScript](https://developers.google.com/maps/documentation/javascript/overview) and [Google Places](https://developers.google.com/maps/documentation/places/web-service/overview) API.
 
-:::info
-The following demo relies on [autosuggest-highlight](https://github.com/moroshko/autosuggest-highlight), a small (1 kB) utility for highlighting text in autosuggest and autocomplete components.
-:::
-
 {{"demo": "GoogleMaps.js"}}
+
+The demo relies on [autosuggest-highlight](https://github.com/moroshko/autosuggest-highlight), a small (1 kB) utility for highlighting text in autosuggest and autocomplete components.
 
 :::error
 Before you can start using the Google Maps JavaScript API and Places API, you need to get your own [API key](https://developers.google.com/maps/documentation/javascript/get-api-key).

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -220,7 +220,7 @@ For this demo, we need to load the [Google Maps JavaScript](https://developers.g
 The demo relies on [autosuggest-highlight](https://github.com/moroshko/autosuggest-highlight), a small (1 kB) utility for highlighting text in autosuggest and autocomplete components.
 
 :::error
-Before you can start using the Google Maps JavaScript API and Places API, you need to get your own [API key](https://developers.google.com/maps/documentation/javascript/get-api-key).
+Before you can start using the Google Maps JavaScript API and Places API, you need to get your own [API key](https://developers.google.com/maps/documentation/javascript/get-api-key).
 
 This demo has limited quotas to make API requests. When your quota exceeds, you will see the response for "Paris".
 :::

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -221,6 +221,8 @@ The demo relies on [autosuggest-highlight](https://github.com/moroshko/autosugge
 
 :::error
 Before you can start using the Google Maps JavaScript API and Places API, you need to get your own [API key](https://developers.google.com/maps/documentation/javascript/get-api-key).
+
+This demo has limited quotas to make API requests. When your quota exceeds, you will see the response for "Paris".
 :::
 
 ## Multiple values

--- a/packages/mui-docs/src/Ad/AdCarbon.tsx
+++ b/packages/mui-docs/src/Ad/AdCarbon.tsx
@@ -47,6 +47,11 @@ function AdCarbonImage() {
     //
     // To solve the issue, for example StrictModel double effect execution, we debounce the load action.
     const load = setTimeout(() => {
+      // The DOM node could have unmounted at this point.
+      if (!ref.current) {
+        return;
+      }
+
       const script = loadScript(
         'https://cdn.carbonads.com/carbon.js?serve=CKYIL27L&placement=material-uicom',
         ref.current,

--- a/packages/mui-docs/src/utils/loadScript.ts
+++ b/packages/mui-docs/src/utils/loadScript.ts
@@ -1,10 +1,7 @@
-export default function loadScript(src: string, position: HTMLElement | null) {
+export default function loadScript(src: string, position: HTMLElement) {
   const script = document.createElement('script');
   script.setAttribute('async', '');
   script.src = src;
-  if (position) {
-    position.appendChild(script);
-  }
-
+  position.appendChild(script);
   return script;
 }


### PR DESCRIPTION
Initially, I thought I could quickly handle https://developers.google.com/maps/documentation/javascript/places-migration-autocomplete. It was much harder than expected 😅

Preview: https://deploy-preview-44708--material-ui.netlify.app/material-ui/react-autocomplete/#google-maps-place

I have tried to make the demo crash, like in #35391 but couldn't find a way.

We can use https://console.cloud.google.com/google/maps-apis/metrics?hl=en&inv=1&invt=Abjs3A&project=material-ui-docs to keep track of the API usage, make sure it's still OK.

---

As for why work on this, see https://github.com/NiazMorshed2007/shadcn-address-autocomplete/, unless the community builds this, we need to stay up to date to stay relevant.

---

Side note, we are supposed to give logo attribution: https://developers.google.com/maps/documentation/javascript/policies#logo

> If your application uses search fields with or without autocomplete, the logo must be displayed inline.

e.g. https://developers.google.com/maps/documentation/javascript/place-autocomplete-new 

<img width="324" alt="SCR-20241215-tpel" src="https://github.com/user-attachments/assets/ef291f2b-c2bd-4167-b455-010ae97657c0" />

- https://github.com/wellyshen/use-places-autocomplete/issues/179
- https://github.com/NiazMorshed2007/shadcn-address-autocomplete/issues/3