### PR TITLE
[typescript] Rescue missing backports v5

### DIFF
--- a/docs/src/components/markdown/MarkdownElement.tsx
+++ b/docs/src/components/markdown/MarkdownElement.tsx
@@ -34,7 +34,7 @@ const Root = styled('div')(({ theme }) => ({
 
 type MarkdownElementProps = {
   renderedMarkdown: string;
-} & Omit<JSX.IntrinsicElements['div'], 'ref'>;
+} & Omit<React.JSX.IntrinsicElements['div'], 'ref'>;
 
 const MarkdownElement = React.forwardRef<HTMLDivElement, MarkdownElementProps>(
   function MarkdownElement(props, ref) {

--- a/packages/mui-material/src/ClickAwayListener/ClickAwayListener.tsx
+++ b/packages/mui-material/src/ClickAwayListener/ClickAwayListener.tsx
@@ -36,7 +36,7 @@ export interface ClickAwayListenerProps {
   /**
    * The wrapped element.
    */
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   /**
    * If `true`, the React tree is ignored and only the DOM tree is considered.
    * This prop changes how portaled elements are handled.
@@ -72,7 +72,7 @@ export interface ClickAwayListenerProps {
  *
  * - [ClickAwayListener API](https://mui.com/material-ui/api/click-away-listener/)
  */
-function ClickAwayListener(props: ClickAwayListenerProps): JSX.Element {
+function ClickAwayListener(props: ClickAwayListenerProps): React.JSX.Element {
   const {
     children,
     disableReactTree = false,

--- a/packages/mui-material/src/NoSsr/NoSsr.tsx
+++ b/packages/mui-material/src/NoSsr/NoSsr.tsx
@@ -22,7 +22,7 @@ import { NoSsrProps } from './NoSsr.types';
  *
  * - [NoSsr API](https://mui.com/material-ui/api/no-ssr/)
  */
-function NoSsr(props: NoSsrProps): JSX.Element {
+function NoSsr(props: NoSsrProps): React.JSX.Element {
   const { children, defer = false, fallback = null } = props;
   const [mountedState, setMountedState] = React.useState(false);
 

--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
@@ -125,7 +125,7 @@ function defaultIsEnabled(): boolean {
 /**
  * @ignore - internal component.
  */
-function FocusTrap(props: FocusTrapProps): JSX.Element {
+function FocusTrap(props: FocusTrapProps): React.JSX.Element {
   const {
     children,
     disableAutoFocus = false,

--- a/packages/mui-material/src/utils/PolymorphicComponent.ts
+++ b/packages/mui-material/src/utils/PolymorphicComponent.ts
@@ -10,7 +10,7 @@ import { DistributiveOmit, OverridableTypeMap } from '@mui/types';
 export type PolymorphicComponent<TypeMap extends OverridableTypeMap> = {
   <RootComponent extends React.ElementType = TypeMap['defaultComponent']>(
     props: PolymorphicProps<TypeMap, RootComponent>,
-  ): JSX.Element | null;
+  ): React.JSX.Element | null;
   propTypes?: any;
   displayName?: string | undefined;
 };


### PR DESCRIPTION
Some React 19 JSX backports were missed when we removed the mui-base dependency. For some reason, even though the original PR has `React.JSX.Element` ([example](https://github.com/mui/material-ui/pull/42907/files#diff-cee63db515126a4c1c9c392d0763d7a6931b45f079e3765aebb7bc9cc34bcc8aR13)), the backport had `JSX.Element` ([example](https://github.com/mui/material-ui/pull/42917/files#diff-cee63db515126a4c1c9c392d0763d7a6931b45f079e3765aebb7bc9cc34bcc8aR13)).