### PR TITLE
[release] MUI Joy `5.0.0-beta.50`

### DIFF
--- a/packages/mui-joy/package.json
+++ b/packages/mui-joy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/joy",
-  "version": "5.0.0-beta.48",
+  "version": "5.0.0-beta.50",
   "private": false,
   "author": "MUI Team",
   "description": "Joy UI is an open-source React component library that implements MUI's own design principles. It's comprehensive and can be used in production out of the box.",


### PR DESCRIPTION
Release for React 19 support. Dev dependencies haven't been updated yet but that shouldn't impact end users.

I checked with `pnpm release:changelog` and there are no Joy-specific commits since the last release from this branch (which was [alongside 5.16.1](https://github.com/mui/material-ui/pull/42897))
