### PR TITLE
[api-docs-builder] Preserve multiline prop descriptions with `rawDescriptions` option

### DIFF
--- a/packages/api-docs-builder/buildApi.ts
+++ b/packages/api-docs-builder/buildApi.ts
@@ -224,6 +224,9 @@ export function escapeEntities(value: string) {
 export function escapeCell(value: string) {
   return rawDescriptionsCurrent ? value : _escapeCell(value);
 }
+export function removeNewLines(value: string) {
+  return rawDescriptionsCurrent ? value : value.replace(/\r*\n/g, ' ');
+}
 export function joinUnionTypes(value: string[]) {
   // Use unopinionated formatting for raw descriptions
   return rawDescriptionsCurrent ? value.join(' | ') : value.join('<br>&#124;&nbsp;');

--- a/packages/api-docs-builder/utils/generatePropDescription.ts
+++ b/packages/api-docs-builder/utils/generatePropDescription.ts
@@ -1,7 +1,7 @@
 import * as doctrine from 'doctrine';
 import * as recast from 'recast';
 import { PropTypeDescriptor } from 'react-docgen';
-import { escapeCell } from '../buildApi';
+import { escapeCell, removeNewLines } from '../buildApi';
 import {
   isElementTypeAcceptingRefProp,
   isElementAcceptingRefProp,
@@ -129,7 +129,7 @@ export default function generatePropDescription(
     // Remove new lines from tag descriptions to avoid markdown errors.
     annotation.tags.forEach((tag) => {
       if (tag.description) {
-        tag.description = tag.description.replace(/\r*\n/g, ' ');
+        tag.description = removeNewLines(tag.description);
       }
     });
 


### PR DESCRIPTION
Make sure that multiline descriptions aren't collapsed when `rawDescriptions` option is on (used by Base UI docs)