### PR TITLE
[docs] Update `react-number-format` demo to use the recommended prop

### DIFF
--- a/docs/data/material/components/text-fields/FormattedInputs.js
+++ b/docs/data/material/components/text-fields/FormattedInputs.js
@@ -29,35 +29,6 @@ TextMaskCustom.propTypes = {
   onChange: PropTypes.func.isRequired,
 };
 
-const NumericFormatCustom = React.forwardRef(
-  function NumericFormatCustom(props, ref) {
-    const { onChange, ...other } = props;
-
-    return (
-      <NumericFormat
-        {...other}
-        getInputRef={ref}
-        onValueChange={(values) => {
-          onChange({
-            target: {
-              name: props.name,
-              value: values.value,
-            },
-          });
-        }}
-        thousandSeparator
-        valueIsNumericString
-        prefix="$"
-      />
-    );
-  },
-);
-
-NumericFormatCustom.propTypes = {
-  name: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-};
-
 export default function FormattedInputs() {
   const [values, setValues] = React.useState({
     textmask: '(100) 000-0000',
@@ -83,18 +54,15 @@ export default function FormattedInputs() {
           inputComponent={TextMaskCustom}
         />
       </FormControl>
-      <TextField
-        label="react-number-format"
+      <NumericFormat
         value={values.numberformat}
         onChange={handleChange}
-        name="numberformat"
-        id="formatted-numberformat-input"
-        slotProps={{
-          input: {
-            inputComponent: NumericFormatCustom,
-          },
-        }}
+        customInput={TextField}
+        thousandSeparator
+        valueIsNumericString
+        prefix="$"
         variant="standard"
+        label="react-number-format"
       />
     </Stack>
   );

--- a/docs/data/material/components/text-fields/FormattedInputs.tsx
+++ b/docs/data/material/components/text-fields/FormattedInputs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IMaskInput } from 'react-imask';
-import { NumericFormat, NumericFormatProps } from 'react-number-format';
+import { NumericFormat } from 'react-number-format';
 import Stack from '@mui/material/Stack';
 import Input from '@mui/material/Input';
 import InputLabel from '@mui/material/InputLabel';
@@ -25,30 +25,6 @@ const TextMaskCustom = React.forwardRef<HTMLInputElement, CustomProps>(
         inputRef={ref}
         onAccept={(value: any) => onChange({ target: { name: props.name, value } })}
         overwrite
-      />
-    );
-  },
-);
-
-const NumericFormatCustom = React.forwardRef<NumericFormatProps, CustomProps>(
-  function NumericFormatCustom(props, ref) {
-    const { onChange, ...other } = props;
-
-    return (
-      <NumericFormat
-        {...other}
-        getInputRef={ref}
-        onValueChange={(values) => {
-          onChange({
-            target: {
-              name: props.name,
-              value: values.value,
-            },
-          });
-        }}
-        thousandSeparator
-        valueIsNumericString
-        prefix="$"
       />
     );
   },
@@ -79,18 +55,15 @@ export default function FormattedInputs() {
           inputComponent={TextMaskCustom as any}
         />
       </FormControl>
-      <TextField
-        label="react-number-format"
+      <NumericFormat
         value={values.numberformat}
         onChange={handleChange}
-        name="numberformat"
-        id="formatted-numberformat-input"
-        slotProps={{
-          input: {
-            inputComponent: NumericFormatCustom as any,
-          },
-        }}
+        customInput={TextField}
+        thousandSeparator
+        valueIsNumericString
+        prefix="$"
         variant="standard"
+        label="react-number-format"
       />
     </Stack>
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #19922 based on https://s-yadav.github.io/react-number-format/docs/props#custominput-reactcomponentany

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
