### PR TITLE
[material-ui][Dialog] Fix crashing of DraggableDialog demo

### DIFF
--- a/docs/data/material/components/dialogs/DraggableDialog.js
+++ b/docs/data/material/components/dialogs/DraggableDialog.js
@@ -9,12 +9,14 @@ import Paper from '@mui/material/Paper';
 import Draggable from 'react-draggable';
 
 function PaperComponent(props) {
+  const nodeRef = React.useRef(null);
   return (
     <Draggable
+      nodeRef={nodeRef}
       handle="#draggable-dialog-title"
       cancel={'[class*="MuiDialogContent-root"]'}
     >
-      <Paper {...props} />
+      <Paper {...props} ref={nodeRef} />
     </Draggable>
   );
 }

--- a/docs/data/material/components/dialogs/DraggableDialog.tsx
+++ b/docs/data/material/components/dialogs/DraggableDialog.tsx
@@ -9,7 +9,7 @@ import Paper, { PaperProps } from '@mui/material/Paper';
 import Draggable from 'react-draggable';
 
 function PaperComponent(props: PaperProps) {
-  const nodeRef = React.useRef<HTMLDivElement>(null);
+  const nodeRef = React.useRef<HTMLDivElement | null>(null);
   return (
     <Draggable
       nodeRef={nodeRef}

--- a/docs/data/material/components/dialogs/DraggableDialog.tsx
+++ b/docs/data/material/components/dialogs/DraggableDialog.tsx
@@ -9,7 +9,7 @@ import Paper, { PaperProps } from '@mui/material/Paper';
 import Draggable from 'react-draggable';
 
 function PaperComponent(props: PaperProps) {
-  const nodeRef = React.useRef(null);
+  const nodeRef = React.useRef<HTMLDivElement>(null);
   return (
     <Draggable
       nodeRef={nodeRef}

--- a/docs/data/material/components/dialogs/DraggableDialog.tsx
+++ b/docs/data/material/components/dialogs/DraggableDialog.tsx
@@ -9,7 +9,7 @@ import Paper, { PaperProps } from '@mui/material/Paper';
 import Draggable from 'react-draggable';
 
 function PaperComponent(props: PaperProps) {
-  const nodeRef = React.useRef<HTMLDivElement | null>(null);
+  const nodeRef = React.useRef<HTMLDivElement>(null);
   return (
     <Draggable
       nodeRef={nodeRef}

--- a/docs/data/material/components/dialogs/DraggableDialog.tsx
+++ b/docs/data/material/components/dialogs/DraggableDialog.tsx
@@ -12,7 +12,7 @@ function PaperComponent(props: PaperProps) {
   const nodeRef = React.useRef<HTMLDivElement>(null);
   return (
     <Draggable
-      nodeRef={nodeRef}
+      nodeRef={nodeRef as React.RefObject<HTMLDivElement>}
       handle="#draggable-dialog-title"
       cancel={'[class*="MuiDialogContent-root"]'}
     >

--- a/docs/data/material/components/dialogs/DraggableDialog.tsx
+++ b/docs/data/material/components/dialogs/DraggableDialog.tsx
@@ -9,12 +9,14 @@ import Paper, { PaperProps } from '@mui/material/Paper';
 import Draggable from 'react-draggable';
 
 function PaperComponent(props: PaperProps) {
+  const nodeRef = React.useRef(null);
   return (
     <Draggable
+      nodeRef={nodeRef}
       handle="#draggable-dialog-title"
       cancel={'[class*="MuiDialogContent-root"]'}
     >
-      <Paper {...props} />
+      <Paper {...props} ref={nodeRef} />
     </Draggable>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes https://github.com/mui/material-ui/issues/44732

Error occurs because react-draggable is using the deprecated findDOMNode method. On updating code to use refs fixed the issue

before: https://mui.com/material-ui/react-dialog/#draggable-dialog

after: https://deploy-preview-44747--material-ui.netlify.app/material-ui/react-dialog/#draggable-dialog

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
