### PR TITLE
[material-ui][Pagination] Use correct `aria-current` value

### DIFF
--- a/packages/mui-material/src/Pagination/Pagination.test.js
+++ b/packages/mui-material/src/Pagination/Pagination.test.js
@@ -33,7 +33,7 @@ describe('<Pagination />', () => {
 
     // previous, page 1
     const [, page1] = getAllByRole('button');
-    expect(page1).to.have.attribute('aria-current', 'true');
+    expect(page1).to.have.attribute('aria-current', 'page');
     // verifying no regression from previous bug where `page` wasn't intercepted
     expect(container.querySelector('[page]')).to.equal(null);
   });

--- a/packages/mui-material/src/usePagination/usePagination.js
+++ b/packages/mui-material/src/usePagination/usePagination.js
@@ -124,7 +124,7 @@ export default function usePagination(props = {}) {
           page: item,
           selected: item === page,
           disabled,
-          'aria-current': item === page ? 'true' : undefined,
+          'aria-current': item === page ? 'page' : undefined,
         }
       : {
           onClick: (event) => {


### PR DESCRIPTION
The current pagination mechanism in the docs reads the current page in the screen reader as "current item". By using `aria-current="page"` instead of `aria-current="true"`, the screen reader reads it more clearly as "current page".

This is correct property described in the [pagination w3c spec](https://design-system.w3.org/components/pagination.html).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
