### PR TITLE
[release] v5.16.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # [Versions](https://mui.com/versions/)
 
+## v5.16.12
+
+<!-- generated comparing v5.16.11..v5.x -->
+
+_Dec 13, 2024_
+
+Material UI v5 is now compatible with React 19 (#44672) @DiegoAndai
+
+### Core
+
+- Bump react 19 in v5 (#44720) @DiegoAndai
+
+All contributors of this release in alphabetical order: @DiegoAndai
+
 ## 5.16.11
 
 <!-- generated comparing v5.16.9..v5.x -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 <!-- generated comparing v5.16.11..v5.x -->
 
-_Dec 13, 2024_
+_Dec 16, 2024_
 
-Material UI v5 is now compatible with React 19 (#44672) @DiegoAndai
+Material UI v5 is now compatible with React 19 (#44720) @DiegoAndai
 
 ### Core
 
 - Bump react 19 in v5 (#44720) @DiegoAndai
+- Add `latest-v5` tag to v5 releases (#44757) @DiegoAndai
 
 All contributors of this release in alphabetical order: @DiegoAndai
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 _Dec 16, 2024_
 
-Material UI v5 is now compatible with React 19 (#44720) @DiegoAndai
+Material UI v5 is now compatible with React 19 (#44720) @DiegoAndai
 
 ### Core
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/monorepo",
-  "version": "5.16.11",
+  "version": "5.16.12",
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/base",
-  "version": "5.0.0-5.0.0-beta.40-0.0",
+  "version": "5.0.0-beta.40-0",
   "private": false,
   "author": "MUI Team",
   "description": "Base UI is a library of headless ('unstyled') React components and low-level hooks. You gain complete control over your app's CSS and accessibility features.",

--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/base",
-  "version": "5.0.0-beta.40",
+  "version": "5.0.0-5.0.0-beta.40-0.0",
   "private": false,
   "author": "MUI Team",
   "description": "Base UI is a library of headless ('unstyled') React components and low-level hooks. You gain complete control over your app's CSS and accessibility features.",

--- a/packages/mui-core-downloads-tracker/package.json
+++ b/packages/mui-core-downloads-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/core-downloads-tracker",
-  "version": "5.16.11",
+  "version": "5.16.12",
   "private": false,
   "author": "MUI Team",
   "description": "Internal package to track number of downloads of our design system libraries",

--- a/packages/mui-docs/package.json
+++ b/packages/mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/docs",
-  "version": "5.16.11",
+  "version": "5.16.12",
   "private": false,
   "author": "MUI Team",
   "description": "MUI Docs - Documentation building blocks.",

--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/icons-material",
-  "version": "5.16.11",
+  "version": "5.16.12",
   "private": false,
   "author": "MUI Team",
   "description": "Material Design icons distributed as SVG React components.",

--- a/packages/mui-joy/package.json
+++ b/packages/mui-joy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/joy",
-  "version": "5.0.0-beta.50",
+  "version": "5.0.0-beta.51",
   "private": false,
   "author": "MUI Team",
   "description": "Joy UI is an open-source React component library that implements MUI's own design principles. It's comprehensive and can be used in production out of the box.",

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/lab",
-  "version": "5.0.0-alpha.174",
+  "version": "5.0.0-alpha.175",
   "private": false,
   "author": "MUI Team",
   "description": "Laboratory for new MUI modules.",

--- a/packages/mui-material-nextjs/package.json
+++ b/packages/mui-material-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/material-nextjs",
-  "version": "5.16.8",
+  "version": "5.16.12",
   "private": false,
   "author": "MUI Team",
   "description": "Collection of utilities for integration between Material UI and Next.js.",

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/material",
-  "version": "5.16.11",
+  "version": "5.16.12",
   "private": false,
   "author": "MUI Team",
   "description": "Material UI is an open-source React component library that implements Google's Material Design. It's comprehensive and can be used in production out of the box.",

--- a/packages/mui-private-theming/package.json
+++ b/packages/mui-private-theming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/private-theming",
-  "version": "5.16.8",
+  "version": "5.16.12",
   "private": false,
   "author": "MUI Team",
   "description": "Private - The React theme context to be shared between `@mui/styles` and `@mui/material`.",

--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/styled-engine",
-  "version": "5.16.8",
+  "version": "5.16.12",
   "private": false,
   "author": "MUI Team",
   "description": "styled() API wrapper package for emotion.",

--- a/packages/mui-styles/package.json
+++ b/packages/mui-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/styles",
-  "version": "5.16.11",
+  "version": "5.16.12",
   "private": false,
   "author": "MUI Team",
   "description": "MUI Styles - The legacy JSS-based styling solution of Material UI.",

--- a/packages/mui-system/package.json
+++ b/packages/mui-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/system",
-  "version": "5.16.8",
+  "version": "5.16.12",
   "private": false,
   "author": "MUI Team",
   "description": "MUI System is a set of CSS utilities to help you build custom designs more efficiently. It makes it possible to rapidly lay out custom designs.",

--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/utils",
-  "version": "5.16.8",
+  "version": "5.16.12",
   "private": false,
   "author": "MUI Team",
   "description": "Utility functions for React components.",


### PR DESCRIPTION
PR to release

- v5.16.12 packages
- `@mui/joy` version `5.0.0-beta.51` which updates peer dependencies to include React 19
- `@mui/lab` version `5.0.0-alpha.175` which updates peer dependencies to include React 19
- `@mui/base` version `5.0.0-beta.40-0`. This package is usually released from the `master` branch (latest is `5.0.0-beta.66`), but this is a special version with updated peer dependencies to include React 19, to be used by the `@mui/joy`, `@mui/lab`, and `@mui/docs` packages released with this PR