### PR TITLE
[docs-infra] Remove no longer support `optimizeFonts` Next.js option

### DIFF
--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -49,8 +49,6 @@ process.env.DEPLOY_ENV = DEPLOY_ENV;
 function withDocsInfra(nextConfig) {
   return {
     trailingSlash: true,
-    // TODO: Remove when upgrading to Next.js 15, see https://github.com/vercel/next.js/pull/69137
-    optimizeFonts: false,
     reactStrictMode: true,
     ...nextConfig,
     env: {


### PR DESCRIPTION
Follow-up on https://github.com/mui/material-ui/pull/43469.
Noticed after bumping to Next@15 on mui-x.