### PR TITLE
[lab] Fix TabList type exports

### DIFF
--- a/packages/mui-lab/src/TabList/TabList.d.ts
+++ b/packages/mui-lab/src/TabList/TabList.d.ts
@@ -3,7 +3,7 @@ import { TabsTypeMap } from '@mui/material/Tabs';
 import { DistributiveOmit } from '@mui/types';
 import { OverridableComponent, OverrideProps } from '@mui/material/OverridableComponent';
 
-interface TabListOwnProps extends DistributiveOmit<TabsTypeMap['props'], 'children' | 'value'> {
+export interface TabListOwnProps extends DistributiveOmit<TabsTypeMap['props'], 'children' | 'value'> {
   /**
    * A list of `<Tab />` elements.
    */


### PR DESCRIPTION
This change exports TabListOwnProps to fix a typescript error when styling the TabList component.

Example:

```ts
export const StyledTabList = styled(TabList)({
  height: `min-content`,
  minHeight: `auto`,
  overflow: `visible`,
  [`.${tabsClasses.scroller}`]: {
    height: `fit-content`,
  },
});
```

Create's the following error:
```
TS4023: Exported variable `StyledTabList` has or is using name `TabListOwnProps` from external module
```

Exporting the type fixes the issue.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
