### PR TITLE
[material-ui] Add `mergeSlotProps` for extending components

### DIFF
--- a/docs/data/material/guides/composition/composition.md
+++ b/docs/data/material/guides/composition/composition.md
@@ -22,6 +22,41 @@ WrappedIcon.muiName = Icon.muiName;
 
 {{"demo": "Composition.js"}}
 
+### Forwarding slot props
+
+To properly combine custom props and slot props to forward to Material UI components, use the `mergeSlotProps` utility function.
+If the arguments are functions, they will be resolved before merging. The result from the first argument will override the second.
+
+```jsx
+import Tooltip, { TooltipProps } from '@mui/material/Tooltip';
+import { mergeSlotProps } from '@mui/material/utils';
+
+export const CustomTooltip = (props: TooltipProps) => {
+  const { children, title, sx: sxProps } = props;
+
+  return (
+    <Tooltip
+      {...props}
+      title={<Box sx={{ p: 4 }}>{title}</Box>}
+      slotProps={{
+        ...props.slotProps,
+        popper: mergeSlotProps(props.slotProps?.popper, {
+          className: 'custom-tooltip-popper',
+          disablePortal: true,
+          placement: 'top',
+        }),
+      }}
+    >
+      {children}
+    </Tooltip>
+  );
+};
+```
+
+:::info
+`className` values will always be concatenated, it will not override each other.
+:::
+
 ## Component prop
 
 Material UI allows you to change the root element that will be rendered via a prop called `component`.

--- a/packages/mui-material/src/utils/index.d.ts
+++ b/packages/mui-material/src/utils/index.d.ts
@@ -16,4 +16,5 @@ export { default as unsupportedProp } from './unsupportedProp';
 export { default as useControlled } from './useControlled';
 export { default as useEventCallback } from './useEventCallback';
 export { default as useForkRef } from './useForkRef';
+export { default as mergeSlotProps } from './mergeSlotProps';
 export * from './types';

--- a/packages/mui-material/src/utils/index.js
+++ b/packages/mui-material/src/utils/index.js
@@ -18,6 +18,7 @@ export { default as unsupportedProp } from './unsupportedProp';
 export { default as useControlled } from './useControlled';
 export { default as useEventCallback } from './useEventCallback';
 export { default as useForkRef } from './useForkRef';
+export { default as mergeSlotProps } from './mergeSlotProps';
 // TODO: remove this export once ClassNameGenerator is stable
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const unstable_ClassNameGenerator = {

--- a/packages/mui-material/src/utils/mergeSlotProps.spec.tsx
+++ b/packages/mui-material/src/utils/mergeSlotProps.spec.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import TextField, { TextFieldProps } from '@mui/material/TextField';
+import { mergeSlotProps } from '@mui/material/utils';
+
+export function CustomTextField(props: TextFieldProps) {
+  const { slotProps = {}, ...otherProps } = props;
+  const TextFieldElement = (
+    <TextField
+      slotProps={{
+        inputLabel: { shrink: true, ...slotProps.inputLabel },
+        ...slotProps,
+      }}
+      {...otherProps}
+    />
+  );
+  return TextFieldElement;
+}

--- a/packages/mui-material/src/utils/mergeSlotProps.spec.tsx
+++ b/packages/mui-material/src/utils/mergeSlotProps.spec.tsx
@@ -1,10 +1,26 @@
 import * as React from 'react';
+import { expectType } from '@mui/types';
 import Box from '@mui/material/Box';
 import Tooltip, { TooltipProps } from '@mui/material/Tooltip';
-import { mergeSlotProps } from '@mui/material/utils';
+import { mergeSlotProps, SlotComponentProps } from '@mui/material/utils';
+
+// without explicit type
+const slotProps = mergeSlotProps(undefined, { className: 'foo', 'aria-label': 'bar' });
+expectType<SlotComponentProps<React.ElementType, {}, {}>, typeof slotProps>(slotProps);
+
+// explicit external slot props type
+const defaultProps = mergeSlotProps<{ foo: string }>(undefined, { foo: 'bar' });
+expectType<{ foo: string }, typeof defaultProps>(defaultProps);
+
+// explicit slot props type with function
+const externalSlotProps = mergeSlotProps<
+  (ownerState: { foo: string }) => { foo: string },
+  { foo: string }
+>(() => ({ foo: 'external' }), { foo: 'default' })({ foo: '' });
+expectType<{ foo: string }, typeof externalSlotProps>(externalSlotProps);
 
 export const CustomTooltip = (props: TooltipProps) => {
-  const { children, title, sx: sxProps } = props;
+  const { children, title } = props;
 
   return (
     <Tooltip
@@ -25,7 +41,7 @@ export const CustomTooltip = (props: TooltipProps) => {
 };
 
 export const CustomTooltip2 = (props: TooltipProps) => {
-  const { children, title, sx: sxProps } = props;
+  const { children, title } = props;
 
   // to ensure that the return type of `mergeSlotProps` is correctly inferred
   const popperProps = mergeSlotProps(props.slotProps?.popper, {

--- a/packages/mui-material/src/utils/mergeSlotProps.spec.tsx
+++ b/packages/mui-material/src/utils/mergeSlotProps.spec.tsx
@@ -1,17 +1,48 @@
 import * as React from 'react';
-import TextField, { TextFieldProps } from '@mui/material/TextField';
+import Box from '@mui/material/Box';
+import Tooltip, { TooltipProps } from '@mui/material/Tooltip';
 import { mergeSlotProps } from '@mui/material/utils';
 
-export function CustomTextField(props: TextFieldProps) {
-  const { slotProps = {}, ...otherProps } = props;
-  const TextFieldElement = (
-    <TextField
+export const CustomTooltip = (props: TooltipProps) => {
+  const { children, title, sx: sxProps } = props;
+
+  return (
+    <Tooltip
+      {...props}
+      title={<Box sx={{ p: 4 }}>{title}</Box>}
       slotProps={{
-        inputLabel: { shrink: true, ...slotProps.inputLabel },
-        ...slotProps,
+        ...props.slotProps,
+        popper: mergeSlotProps(props.slotProps?.popper, {
+          className: 'custom-tooltip',
+          disablePortal: true,
+          placement: 'top',
+        }),
       }}
-      {...otherProps}
-    />
+    >
+      {children}
+    </Tooltip>
   );
-  return TextFieldElement;
-}
+};
+
+export const CustomTooltip2 = (props: TooltipProps) => {
+  const { children, title, sx: sxProps } = props;
+
+  // to ensure that the return type of `mergeSlotProps` is correctly inferred
+  const popperProps = mergeSlotProps(props.slotProps?.popper, {
+    className: 'custom-tooltip',
+    disablePortal: true,
+    placement: 'top',
+  });
+  return (
+    <Tooltip
+      {...props}
+      title={<Box sx={{ p: 4 }}>{title}</Box>}
+      slotProps={{
+        ...props.slotProps,
+        popper: popperProps,
+      }}
+    >
+      {children}
+    </Tooltip>
+  );
+};

--- a/packages/mui-material/src/utils/mergeSlotProps.test.ts
+++ b/packages/mui-material/src/utils/mergeSlotProps.test.ts
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+
+import mergeSlotProps from './mergeSlotProps';
+
+type OwnerState = {
+  className: string;
+  'aria-label'?: string;
+};
+
+describe('utils/index.js', () => {
+  describe('mergeSlotProps', () => {
+    it('external slot props is undefined', () => {
+      expect(
+        mergeSlotProps<OwnerState>(undefined, {
+          className: 'default',
+          'aria-label': 'foo',
+        }),
+      ).to.deep.equal({
+        className: 'default',
+        'aria-label': 'foo',
+      });
+    });
+
+    it('external slot props should override', () => {
+      expect(
+        mergeSlotProps<OwnerState>(
+          { className: 'external' },
+          { className: 'default', 'aria-label': 'foo' },
+        ),
+      ).to.deep.equal({
+        className: 'default external',
+        'aria-label': 'foo',
+      });
+    });
+
+    it('external slot props is a function', () => {
+      expect(
+        mergeSlotProps<(ownerState: OwnerState) => OwnerState, OwnerState>(
+          () => ({
+            className: 'external',
+          }),
+          { className: 'default', 'aria-label': 'foo' },
+        )({ className: '' }),
+      ).to.deep.equal({
+        className: 'default external',
+        'aria-label': 'foo',
+      });
+    });
+
+    it('default slot props is a function', () => {
+      expect(
+        mergeSlotProps<OwnerState, (ownerState: OwnerState) => OwnerState>(
+          {
+            className: 'external',
+          },
+          () => ({ className: 'default', 'aria-label': 'foo' }),
+        )({ className: 'base' }),
+      ).to.deep.equal({
+        className: 'base default external',
+        'aria-label': 'foo',
+      });
+    });
+
+    it('both slot props are functions', () => {
+      expect(
+        mergeSlotProps<(ownerState: OwnerState) => OwnerState>(
+          () => ({
+            className: 'external',
+          }),
+          () => ({
+            className: 'default',
+            'aria-label': 'foo',
+          }),
+        )({ className: 'base' }),
+      ).to.deep.equal({
+        className: 'base default external',
+        'aria-label': 'foo',
+      });
+    });
+  });
+});

--- a/packages/mui-material/src/utils/mergeSlotProps.ts
+++ b/packages/mui-material/src/utils/mergeSlotProps.ts
@@ -1,0 +1,20 @@
+import { SlotComponentProps } from '@mui/utils';
+
+export default function mergeSlotProps<
+  T extends SlotComponentProps<React.ElementType, {}, {}>,
+  K extends T,
+>(externalSlotProps: T, defaultSlotProps: K) {
+  if (!externalSlotProps) {
+    return defaultSlotProps;
+  }
+  if (typeof externalSlotProps === 'function' || typeof defaultSlotProps === 'function') {
+    return ((ownerState) => {
+      const defaultSlotPropsValue =
+        typeof defaultSlotProps === 'function' ? defaultSlotProps(ownerState) : defaultSlotProps;
+      const externalSlotPropsValue =
+        typeof externalSlotProps === 'function' ? externalSlotProps(ownerState) : externalSlotProps;
+      return { ...defaultSlotPropsValue, ...externalSlotPropsValue };
+    }) as T;
+  }
+  return { ...defaultSlotProps, ...externalSlotProps };
+}

--- a/packages/mui-material/src/utils/mergeSlotProps.ts
+++ b/packages/mui-material/src/utils/mergeSlotProps.ts
@@ -1,25 +1,8 @@
 import { SlotComponentProps } from '@mui/utils';
+import clsx from 'clsx';
 
 type PickFn<T> = T extends Function ? T : never;
 type ExcludeFn<T> = Exclude<T, Function>;
-
-function concatClassName(
-  arg1: undefined | Record<string, any>,
-  arg2: undefined | Record<string, any>,
-  arg3?: Record<string, any>,
-) {
-  let className = '';
-  if (arg1?.className) {
-    className += arg1.className;
-  }
-  if (arg2?.className) {
-    className += `${className ? ` ` : ''}${arg2.className}`;
-  }
-  if (arg3?.className) {
-    className += `${className ? ` ` : ''}${arg3.className}`;
-  }
-  return className;
-}
 
 export default function mergeSlotProps<
   T extends SlotComponentProps<React.ElementType, {}, {}>,
@@ -44,7 +27,11 @@ export default function mergeSlotProps<
           ? externalSlotProps({ ...ownerState, ...defaultSlotPropsValue })
           : externalSlotProps;
 
-      const className = concatClassName(ownerState, defaultSlotPropsValue, externalSlotPropsValue);
+      const className = clsx(
+        ownerState?.className,
+        defaultSlotPropsValue?.className,
+        externalSlotPropsValue?.className,
+      );
       return {
         ...defaultSlotPropsValue,
         ...externalSlotPropsValue,
@@ -52,7 +39,10 @@ export default function mergeSlotProps<
       };
     }) as U;
   }
-  const className = concatClassName(defaultSlotProps as Record<string, any>, externalSlotProps);
+  const className = clsx(
+    (defaultSlotProps as Record<string, any>)?.className,
+    externalSlotProps?.className,
+  );
   return {
     ...defaultSlotProps,
     ...externalSlotProps,

--- a/packages/mui-material/src/utils/mergeSlotProps.ts
+++ b/packages/mui-material/src/utils/mergeSlotProps.ts
@@ -1,20 +1,61 @@
 import { SlotComponentProps } from '@mui/utils';
 
+type PickFn<T> = T extends Function ? T : never;
+type ExcludeFn<T> = Exclude<T, Function>;
+
+function concatClassName(
+  arg1: undefined | Record<string, any>,
+  arg2: undefined | Record<string, any>,
+  arg3?: Record<string, any>,
+) {
+  let className = '';
+  if (arg1?.className) {
+    className += arg1.className;
+  }
+  if (arg2?.className) {
+    className += `${className ? ` ` : ''}${arg2.className}`;
+  }
+  if (arg3?.className) {
+    className += `${className ? ` ` : ''}${arg3.className}`;
+  }
+  return className;
+}
+
 export default function mergeSlotProps<
   T extends SlotComponentProps<React.ElementType, {}, {}>,
-  K extends T,
->(externalSlotProps: T, defaultSlotProps: K) {
+  K = T,
+  U = T extends Function
+    ? PickFn<T>
+    : K extends Function
+      ? PickFn<K>
+      : T extends undefined
+        ? K
+        : ExcludeFn<T>,
+>(externalSlotProps: T | undefined, defaultSlotProps: K): U {
   if (!externalSlotProps) {
-    return defaultSlotProps;
+    return defaultSlotProps as unknown as U;
   }
   if (typeof externalSlotProps === 'function' || typeof defaultSlotProps === 'function') {
-    return ((ownerState) => {
+    return ((ownerState: Record<string, any>) => {
       const defaultSlotPropsValue =
         typeof defaultSlotProps === 'function' ? defaultSlotProps(ownerState) : defaultSlotProps;
       const externalSlotPropsValue =
-        typeof externalSlotProps === 'function' ? externalSlotProps(ownerState) : externalSlotProps;
-      return { ...defaultSlotPropsValue, ...externalSlotPropsValue };
-    }) as T;
+        typeof externalSlotProps === 'function'
+          ? externalSlotProps({ ...ownerState, ...defaultSlotPropsValue })
+          : externalSlotProps;
+
+      const className = concatClassName(ownerState, defaultSlotPropsValue, externalSlotPropsValue);
+      return {
+        ...defaultSlotPropsValue,
+        ...externalSlotPropsValue,
+        ...(!!className && { className }),
+      };
+    }) as U;
   }
-  return { ...defaultSlotProps, ...externalSlotProps };
+  const className = concatClassName(defaultSlotProps as Record<string, any>, externalSlotProps);
+  return {
+    ...defaultSlotProps,
+    ...externalSlotProps,
+    ...(!!className && { className }),
+  } as U;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

From https://github.com/mui/material-ui/pull/44350#issuecomment-2491889630.

Without the function, a lot of boilerplate code is required which I think user will create this kind of utility in their codebase anyway.

The `mergeSlotProps` resolves function type and merge. If the props contains `className` it will be concatenated to preserve the same behavior of the `slotProps`.

```js
mergeSlotProps(
  (ownerState) => ({ className: 'outside' }),
  { className: 'inside' },
)

// className = 'inside outside'
```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
