### PR TITLE
[docs][material-ui] Fix crashing of DraggableDialog demo

### DIFF
--- a/docs/data/material/components/dialogs/DraggableDialog.js
+++ b/docs/data/material/components/dialogs/DraggableDialog.js
@@ -9,12 +9,14 @@ import Paper from '@mui/material/Paper';
 import Draggable from 'react-draggable';
 
 function PaperComponent(props) {
+  const nodeRef = React.useRef(null);
   return (
     <Draggable
+      nodeRef={nodeRef}
       handle="#draggable-dialog-title"
       cancel={'[class*="MuiDialogContent-root"]'}
     >
-      <Paper {...props} />
+      <Paper {...props} ref={nodeRef} />
     </Draggable>
   );
 }

--- a/docs/data/material/components/dialogs/DraggableDialog.tsx
+++ b/docs/data/material/components/dialogs/DraggableDialog.tsx
@@ -9,12 +9,14 @@ import Paper, { PaperProps } from '@mui/material/Paper';
 import Draggable from 'react-draggable';
 
 function PaperComponent(props: PaperProps) {
+  const nodeRef = React.useRef<HTMLDivElement>(null);
   return (
     <Draggable
+      nodeRef={nodeRef as React.RefObject<HTMLDivElement>}
       handle="#draggable-dialog-title"
       cancel={'[class*="MuiDialogContent-root"]'}
     >
-      <Paper {...props} />
+      <Paper {...props} ref={nodeRef} />
     </Draggable>
   );
 }


### PR DESCRIPTION
fixes https://github.com/mui/material-ui/issues/44810

Logic taken from https://github.com/mui/material-ui/pull/44747 applied to v5.x branch

working preview: https://deploy-preview-44811--material-ui.netlify.app/material-ui/react-dialog/#draggable-dialog
