### PR TITLE
[system] Fix dark mode flicker using `useEnhancedEffect`

### DIFF
--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { GlobalStyles } from '@mui/styled-engine';
 import { useTheme as muiUseTheme } from '@mui/private-theming';
+import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import ThemeProvider from '../ThemeProvider';
 import InitColorSchemeScript, {
   DEFAULT_COLOR_SCHEME_STORAGE_KEY,
@@ -173,7 +174,7 @@ export default function createCssVarsProvider(options) {
     // 5. Declaring effects
     // 5.1 Updates the selector value to use the current color scheme which tells CSS to use the proper stylesheet.
     const colorSchemeSelector = restThemeProp.colorSchemeSelector;
-    React.useEffect(() => {
+    useEnhancedEffect(() => {
       if (
         colorScheme &&
         colorSchemeNode &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This is a bug on client-side apps only.
For server-side apps, the `mode` is correctly set before the app render by `InitColorSchemeScript` component.

## Root cause

The logic of updating the html's class attribute lives within `useEffect` instead of `useLayoutEffect`.

Even though, the first render has mode `dark` based on `noSsr` prop, the `class="dark"` applied to `<html>` happens after Browser has painted the first render.

The fix is to use `useEnhancedEffect` (a wrapper of `useLayoutEffect` for client-side) to attach `class="dark"` before browser paint.

**Before**:

The right button renders with default blue before turning red.

https://github.com/user-attachments/assets/56cb8009-9ae9-43af-accb-bcd37385fee8

**After**:

https://github.com/user-attachments/assets/f7a4e8a2-bca0-4f05-a68e-af0f1ecb0527



- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
