### PR TITLE
[material-ui][Tooltip] Warn instead of error when trigger is disabled

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -386,7 +386,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
         title !== '' &&
         childNode.tagName.toLowerCase() === 'button'
       ) {
-        console.error(
+        console.warn(
           [
             'MUI: You are providing a disabled `button` child to the Tooltip component.',
             'A disabled element does not fire events.',

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -706,7 +706,7 @@ describe('<Tooltip />', () => {
             </button>
           </Tooltip>,
         );
-      }).toErrorDev('MUI: You are providing a disabled `button` child to the Tooltip component');
+      }).toWarnDev('MUI: You are providing a disabled `button` child to the Tooltip component');
     });
 
     it('should not raise a warning when we are controlled', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes https://github.com/mui/material-ui/issues/40355

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
