### PR TITLE
[website] Fix career equipment description

### DIFF
--- a/docs/src/components/careers/PerksBenefits.tsx
+++ b/docs/src/components/careers/PerksBenefits.tsx
@@ -118,15 +118,15 @@ export default function PerksBenefits() {
           <Box sx={{ maxWidth: 500 }}>
             {[
               ['100% remote work', 'Our entire company is globally distributed.'],
+              ['Time off', 'We provide 33 days of paid time off globally.'],
               [
                 'Retreats',
-                'We meet up every 8 months for a week of working & having fun together!',
+                'We meet up every 8+ months for a week of working & having fun together!',
               ],
               [
                 'Equipment',
-                'We provide the hardware of your choice (initial grant of $2,500 USD).',
+                'We let you choose the hardware of your choice (within a given budget).',
               ],
-              ['Time off', 'We provide 33 days of paid time off globally.'],
             ].map((textArray) => (
               <Box
                 key={textArray[0]}


### PR DESCRIPTION
## Problem

<img width="495" alt="SCR-20241223-uhjc" src="https://github.com/user-attachments/assets/6220215a-7905-4e81-9252-33e2cf9bea99" />

https://mui.com/careers/

This is not true. The current budget is $2,750 for engineers and $1,750 for non-engineers, plus an extra budget for designers. It's too complex now to only list one number. People can find all the details in the public handbook https://www.notion.so/mui-org/Work-equipment-a2c2a3f1a5984bd8bdd4b698fa3f0a16.

## Solution

I guess we can simply remove the hard-coded value, and emphasize that it's more free selection.

Preview: https://deploy-preview-44848--material-ui.netlify.app/careers/