### PR TITLE
[examples] Update Next.js examples Next.js and React versions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -541,6 +541,7 @@ module.exports = /** @type {Config} */ ({
         'import/order': 'off',
         // Reset the default until https://github.com/jsx-eslint/eslint-plugin-react/issues/3672 is fixed.
         'react/jsx-no-target-blank': ['error', { allowReferrer: false }],
+        'react/prop-types': 'off',
       },
     },
     {

--- a/examples/material-ui-nextjs-pages-router-ts/README.md
+++ b/examples/material-ui-nextjs-pages-router-ts/README.md
@@ -41,11 +41,6 @@ If you prefer, you can [use styled-components instead](https://mui.com/material-
 The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/material-ui-nextjs-pages-router-ts) provides an adapter for the use of [Next.js's Link component](https://nextjs.org/docs/pages/api-reference/components/link) with Material UI.
 More information [in the documentation](https://mui.com/material-ui/integrations/routing/#next-js-pages-router).
 
-## Upgrading to Next.js 15
-
-This example uses Next.js 14.
-To upgrade to version 15, please follow the [official upgrade guide](https://nextjs.org/docs/app/building-your-application/upgrading/version-15) in the Next.js docs.
-
 ## What's next?
 
 <!-- #default-branch-switch -->

--- a/examples/material-ui-nextjs-pages-router-ts/package.json
+++ b/examples/material-ui-nextjs-pages-router-ts/package.json
@@ -18,15 +18,15 @@
     "@mui/material": "latest",
     "@mui/material-nextjs": "latest",
     "clsx": "latest",
-    "next": "^14.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@types/node": "latest",
-    "@types/react": "latest",
+    "@types/react": "^19.0.0",
     "eslint": "latest",
-    "eslint-config-next": "^14.0.0",
+    "eslint-config-next": "^15.0.0",
     "typescript": "latest"
   }
 }

--- a/examples/material-ui-nextjs-pages-router-ts/pages/_app.tsx
+++ b/examples/material-ui-nextjs-pages-router-ts/pages/_app.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Head from 'next/head';
 import { AppProps } from 'next/app';
-import { AppCacheProvider } from '@mui/material-nextjs/v14-pagesRouter';
+import { AppCacheProvider } from '@mui/material-nextjs/v15-pagesRouter';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../src/theme';

--- a/examples/material-ui-nextjs-pages-router-ts/pages/_document.tsx
+++ b/examples/material-ui-nextjs-pages-router-ts/pages/_document.tsx
@@ -4,7 +4,7 @@ import {
   DocumentHeadTags,
   DocumentHeadTagsProps,
   documentGetInitialProps,
-} from '@mui/material-nextjs/v14-pagesRouter';
+} from '@mui/material-nextjs/v15-pagesRouter';
 import theme, { roboto } from '../src/theme';
 
 export default function MyDocument(props: DocumentProps & DocumentHeadTagsProps) {

--- a/examples/material-ui-nextjs-pages-router/README.md
+++ b/examples/material-ui-nextjs-pages-router/README.md
@@ -41,11 +41,6 @@ If you prefer, you can [use styled-components instead](https://mui.com/material-
 The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/material-ui-nextjs-pages-router) provides an adapter for the use of [Next.js's Link component](https://nextjs.org/docs/pages/api-reference/components/link) with Material UI.
 More information [in the documentation](https://mui.com/material-ui/integrations/routing/#next-js-pages-router).
 
-## Upgrading to Next.js 15
-
-This example uses Next.js 14.
-To upgrade to version 15, please follow the [official upgrade guide](https://nextjs.org/docs/app/building-your-application/upgrading/version-15) in the Next.js docs.
-
 ## What's next?
 
 <!-- #default-branch-switch -->

--- a/examples/material-ui-nextjs-pages-router/package.json
+++ b/examples/material-ui-nextjs-pages-router/package.json
@@ -18,13 +18,12 @@
     "@mui/material": "latest",
     "@mui/material-nextjs": "latest",
     "clsx": "latest",
-    "next": "^14.0.0",
-    "prop-types": "latest",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "eslint": "latest",
-    "eslint-config-next": "^14.0.0"
+    "eslint-config-next": "^15.0.0"
   }
 }

--- a/examples/material-ui-nextjs-pages-router/pages/_app.js
+++ b/examples/material-ui-nextjs-pages-router/pages/_app.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Head from 'next/head';
-import { AppCacheProvider } from '@mui/material-nextjs/v14-pagesRouter';
+import { AppCacheProvider } from '@mui/material-nextjs/v15-pagesRouter';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../src/theme';

--- a/examples/material-ui-nextjs-pages-router/pages/_app.js
+++ b/examples/material-ui-nextjs-pages-router/pages/_app.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import Head from 'next/head';
 import { AppCacheProvider } from '@mui/material-nextjs/v14-pagesRouter';
 import { ThemeProvider } from '@mui/material/styles';
@@ -22,8 +21,3 @@ export default function MyApp(props) {
     </AppCacheProvider>
   );
 }
-
-MyApp.propTypes = {
-  Component: PropTypes.elementType.isRequired,
-  pageProps: PropTypes.object.isRequired,
-};

--- a/examples/material-ui-nextjs-pages-router/pages/_document.js
+++ b/examples/material-ui-nextjs-pages-router/pages/_document.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Html, Head, Main, NextScript } from 'next/document';
-import { DocumentHeadTags, documentGetInitialProps } from '@mui/material-nextjs/v14-pagesRouter';
+import { DocumentHeadTags, documentGetInitialProps } from '@mui/material-nextjs/v15-pagesRouter';
 import theme from '../src/theme';
 
 export default function MyDocument(props) {

--- a/examples/material-ui-nextjs-pages-router/src/Link.js
+++ b/examples/material-ui-nextjs-pages-router/src/Link.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import NextLink from 'next/link';
@@ -38,19 +37,6 @@ export const NextLinkComposed = React.forwardRef(function NextLinkComposed(props
     </NextLink>
   );
 });
-
-NextLinkComposed.propTypes = {
-  href: PropTypes.any,
-  legacyBehavior: PropTypes.bool,
-  linkAs: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  locale: PropTypes.string,
-  passHref: PropTypes.bool,
-  prefetch: PropTypes.bool,
-  replace: PropTypes.bool,
-  scroll: PropTypes.bool,
-  shallow: PropTypes.bool,
-  to: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
-};
 
 // A styled version of the Next.js Link component:
 // https://nextjs.org/docs/pages/api-reference/components/link
@@ -104,21 +90,5 @@ const Link = React.forwardRef(function Link(props, ref) {
     />
   );
 });
-
-Link.propTypes = {
-  activeClassName: PropTypes.string,
-  as: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  className: PropTypes.string,
-  href: PropTypes.any,
-  legacyBehavior: PropTypes.bool,
-  linkAs: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  locale: PropTypes.string,
-  noLinkStyle: PropTypes.bool,
-  prefetch: PropTypes.bool,
-  replace: PropTypes.bool,
-  role: PropTypes.string,
-  scroll: PropTypes.bool,
-  shallow: PropTypes.bool,
-};
 
 export default Link;

--- a/examples/material-ui-nextjs-ts/README.md
+++ b/examples/material-ui-nextjs-ts/README.md
@@ -30,11 +30,6 @@ or:
 
 [![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/mui/material-ui/tree/master/examples/material-ui-nextjs-ts)
 
-## Upgrading to Next.js 15
-
-This example uses Next.js 14.
-To upgrade to version 15, please follow the [official upgrade guide](https://nextjs.org/docs/app/building-your-application/upgrading/version-15) in the Next.js docs.
-
 ## Learn more
 
 To learn more about this example:

--- a/examples/material-ui-nextjs-ts/next-env.d.ts
+++ b/examples/material-ui-nextjs-ts/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/material-ui-nextjs-ts/package.json
+++ b/examples/material-ui-nextjs-ts/package.json
@@ -16,16 +16,16 @@
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
     "@mui/material-nextjs": "latest",
-    "next": "^14.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@types/node": "latest",
-    "@types/react": "latest",
-    "@types/react-dom": "latest",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "eslint": "latest",
-    "eslint-config-next": "^14.0.0",
+    "eslint-config-next": "^15.0.0",
     "typescript": "latest"
   }
 }

--- a/examples/material-ui-nextjs-ts/src/app/layout.tsx
+++ b/examples/material-ui-nextjs-ts/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '@/theme';

--- a/examples/material-ui-nextjs/README.md
+++ b/examples/material-ui-nextjs/README.md
@@ -30,11 +30,6 @@ or:
 
 [![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/mui/material-ui/tree/master/examples/material-ui-nextjs)
 
-## Upgrading to Next.js 15
-
-This example uses Next.js 14.
-To upgrade to version 15, please follow the [official upgrade guide](https://nextjs.org/docs/app/building-your-application/upgrading/version-15) in the Next.js docs.
-
 ## Learn more
 
 To learn more about this example:

--- a/examples/material-ui-nextjs/package.json
+++ b/examples/material-ui-nextjs/package.json
@@ -16,9 +16,9 @@
     "@mui/material": "latest",
     "@mui/material-nextjs": "latest",
     "eslint": "latest",
-    "eslint-config-next": "^14.0.0",
-    "next": "^14.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "eslint-config-next": "^15.0.0",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/examples/material-ui-nextjs/src/app/layout.js
+++ b/examples/material-ui-nextjs/src/app/layout.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '@/theme';


### PR DESCRIPTION
Follow up on the React upgrade. Upgrade the Next.js examples to the latest Next.js version, as well as the latest React version.

Also remove prop-types as they're deprecated in React 19.
