### PR TITLE
[docs][Select] Update docs to reflect the omission of placeholder prop

### DIFF
--- a/docs/data/material/components/selects/selects.md
+++ b/docs/data/material/components/selects/selects.md
@@ -34,6 +34,10 @@ The Select component is implemented as a custom `<input>` element of the [InputB
 It extends the [text field components](/material-ui/react-text-field/) subcomponents, either the [OutlinedInput](/material-ui/api/outlined-input/), [Input](/material-ui/api/input/), or [FilledInput](/material-ui/api/filled-input/), depending on the variant selected.
 It shares the same styles and many of the same props. Refer to the respective component's API page for details.
 
+:::warning
+The `placeholder` prop is NOT shared.
+:::
+
 ### Filled and standard variants
 
 {{"demo": "SelectVariants.js"}}

--- a/docs/data/material/components/selects/selects.md
+++ b/docs/data/material/components/selects/selects.md
@@ -35,7 +35,7 @@ It extends the [text field components](/material-ui/react-text-field/) subcompon
 It shares the same styles and many of the same props. Refer to the respective component's API page for details.
 
 :::warning
-The `placeholder` prop is NOT shared.
+Unlike input components, the `placeholder` prop is not available in Select. To add a placeholder, refer to the [placeholder](#placeholder) section below.
 :::
 
 ### Filled and standard variants


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/44821

This PR adds a warning to the Select docs page to point out that the `placeholder` prop is not available in Select. The Select API page is not updated in this PR as it needs docs infra work to add such a one-off text.


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
