### PR TITLE
[joy-ui][docs] Fix Color mode button on Theme builder

### DIFF
--- a/docs/src/modules/components/JoyThemeBuilder.tsx
+++ b/docs/src/modules/components/JoyThemeBuilder.tsx
@@ -1496,7 +1496,7 @@ export default function JoyThemeBuilder() {
             value={colorMode}
             onChange={(event, newValue) => {
               if (newValue) {
-                setColorMode(newValue as 'light' | 'dark')
+                setColorMode(newValue as 'light' | 'dark');
               }
             }}
           >

--- a/docs/src/modules/components/JoyThemeBuilder.tsx
+++ b/docs/src/modules/components/JoyThemeBuilder.tsx
@@ -1494,7 +1494,11 @@ export default function JoyThemeBuilder() {
           <ToggleButtonGroup
             size="sm"
             value={colorMode}
-            onChange={(event, newValue) => setColorMode(newValue as 'light' | 'dark')}
+            onChange={(event, newValue) => {
+              if (newValue) {
+                setColorMode(newValue as 'light' | 'dark')
+              }
+            }}
           >
             <Button value="light">
               <LightMode />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Error on the client-side when clicking the same color on the Theme builder [page](https://mui.com/joy-ui/customization/theme-builder/).

https://github.com/user-attachments/assets/e62f6d10-91b6-461e-9c10-b417984d84db


### Before

There is an error when clicking the same color on the Theme builder page.

https://github.com/user-attachments/assets/a6742a1f-8fef-4d6a-9588-8600ee50a91a


### After

Set color mode only when `newValue` is not null.

https://github.com/user-attachments/assets/ad813d37-0353-435e-9725-fb73c5ab72d5


