### PR TITLE
[docs] Fix Dashboard sidenav sroll

### DIFF
--- a/docs/data/material/getting-started/templates/dashboard/components/CardAlert.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/CardAlert.js
@@ -7,7 +7,7 @@ import AutoAwesomeRoundedIcon from '@mui/icons-material/AutoAwesomeRounded';
 
 export default function CardAlert() {
   return (
-    <Card variant="outlined" sx={{ m: 1.5, p: 1.5 }}>
+    <Card variant="outlined" sx={{ m: 1.5, flexShrink: 0 }}>
       <CardContent>
         <AutoAwesomeRoundedIcon fontSize="small" />
         <Typography gutterBottom sx={{ fontWeight: 600 }}>

--- a/docs/data/material/getting-started/templates/dashboard/components/CardAlert.tsx
+++ b/docs/data/material/getting-started/templates/dashboard/components/CardAlert.tsx
@@ -7,7 +7,7 @@ import AutoAwesomeRoundedIcon from '@mui/icons-material/AutoAwesomeRounded';
 
 export default function CardAlert() {
   return (
-    <Card variant="outlined" sx={{ m: 1.5, p: 1.5 }}>
+    <Card variant="outlined" sx={{ m: 1.5, flexShrink: 0 }}>
       <CardContent>
         <AutoAwesomeRoundedIcon fontSize="small" />
         <Typography gutterBottom sx={{ fontWeight: 600 }}>

--- a/docs/data/material/getting-started/templates/dashboard/components/CustomizedDataGrid.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/CustomizedDataGrid.js
@@ -5,7 +5,6 @@ import { columns, rows } from '../internals/data/gridData';
 export default function CustomizedDataGrid() {
   return (
     <DataGrid
-      autoHeight
       checkboxSelection
       rows={rows}
       columns={columns}

--- a/docs/data/material/getting-started/templates/dashboard/components/CustomizedDataGrid.tsx
+++ b/docs/data/material/getting-started/templates/dashboard/components/CustomizedDataGrid.tsx
@@ -5,7 +5,6 @@ import { columns, rows } from '../internals/data/gridData';
 export default function CustomizedDataGrid() {
   return (
     <DataGrid
-      autoHeight
       checkboxSelection
       rows={rows}
       columns={columns}

--- a/docs/data/material/getting-started/templates/dashboard/components/MenuContent.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/MenuContent.js
@@ -39,7 +39,6 @@ export default function MenuContent() {
           </ListItem>
         ))}
       </List>
-
       <List dense>
         {secondaryListItems.map((item, index) => (
           <ListItem key={index} disablePadding sx={{ display: 'block' }}>

--- a/docs/data/material/getting-started/templates/dashboard/components/MenuContent.tsx
+++ b/docs/data/material/getting-started/templates/dashboard/components/MenuContent.tsx
@@ -39,7 +39,6 @@ export default function MenuContent() {
           </ListItem>
         ))}
       </List>
-
       <List dense>
         {secondaryListItems.map((item, index) => (
           <ListItem key={index} disablePadding sx={{ display: 'block' }}>

--- a/docs/data/material/getting-started/templates/dashboard/components/SideMenu.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/SideMenu.js
@@ -45,8 +45,17 @@ export default function SideMenu() {
         <SelectContent />
       </Box>
       <Divider />
-      <MenuContent />
-      <CardAlert />
+      <Box
+        sx={{
+          overflow: 'auto',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <MenuContent />
+        <CardAlert />
+      </Box>
       <Stack
         direction="row"
         sx={{

--- a/docs/data/material/getting-started/templates/dashboard/components/SideMenu.tsx
+++ b/docs/data/material/getting-started/templates/dashboard/components/SideMenu.tsx
@@ -45,8 +45,17 @@ export default function SideMenu() {
         <SelectContent />
       </Box>
       <Divider />
-      <MenuContent />
-      <CardAlert />
+      <Box
+        sx={{
+          overflow: 'auto',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <MenuContent />
+        <CardAlert />
+      </Box>
       <Stack
         direction="row"
         sx={{

--- a/docs/data/material/getting-started/templates/dashboard/components/SideMenuMobile.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/SideMenuMobile.js
@@ -8,7 +8,6 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
 import NotificationsRoundedIcon from '@mui/icons-material/NotificationsRounded';
-
 import MenuButton from './MenuButton';
 import MenuContent from './MenuContent';
 import CardAlert from './CardAlert';

--- a/docs/data/material/getting-started/templates/dashboard/components/SideMenuMobile.tsx
+++ b/docs/data/material/getting-started/templates/dashboard/components/SideMenuMobile.tsx
@@ -7,7 +7,6 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
 import NotificationsRoundedIcon from '@mui/icons-material/NotificationsRounded';
-
 import MenuButton from './MenuButton';
 import MenuContent from './MenuContent';
 import CardAlert from './CardAlert';


### PR DESCRIPTION
A small fix while I was looking at why the INP on the dashboard page [is poor](https://app.ahrefs.com/site-audit/3524616/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2Cpsi_request_status%2Cpsi_crux_cls_percentile%2Cpsi_crux_cls_category%2Cpsi_crux_fid_percentile%2Cpsi_crux_fid_category%2Cpsi_crux_lcp_percentile%2Cpsi_crux_lcp_category%2Cpsi_crux_inp_percentile%2Cpsi_crux_inp_category%2Cpsi_lighthouse_score%2Cpsi_lighthouse_cls_value%2Cpsi_lighthouse_tbt_value%2Cpsi_lighthouse_lcp_value%2Cdepth%2Ccompliant%2CincomingLinks%2Corigin&current=25-12-2024T023056&filterId=803558da95d9c83d362ecca5192ca260&issueId=85c01513-d747-49f5-8235-2b356bb4c686&sorting=-pageRating),

<img width="183" alt="SCR-20241228-pwtx" src="https://github.com/user-attachments/assets/5b89c211-d09d-4d21-b894-d233fe6615f7" />

Reported in https://github.com/mui/mui-x/issues/16018.

---

Before: https://mui.com/material-ui/getting-started/templates/dashboard/

https://github.com/user-attachments/assets/bd1d73f3-9090-4bc3-ae4c-e6145e3fbb6c

After: https://deploy-preview-44876--material-ui.netlify.app/material-ui/getting-started/templates/dashboard/

https://github.com/user-attachments/assets/addb23f2-25e2-48b4-856e-70ee74203cef

It uses https://ui.shadcn.com/docs/components/sidebar as inspiration.

