### PR TITLE
[core][utils] Fix useTimeout clear lifecycle

### DIFF
--- a/packages/mui-utils/src/useTimeout/useTimeout.ts
+++ b/packages/mui-utils/src/useTimeout/useTimeout.ts
@@ -1,6 +1,6 @@
 'use client';
-import useLazyRef from '../useLazyRef/useLazyRef';
-import useOnMount from '../useOnMount/useOnMount';
+import useLazyRef from '../useLazyRef';
+import useEnhancedEffect from '../useEnhancedEffect';
 
 export class Timeout {
   static create() {
@@ -35,7 +35,8 @@ export class Timeout {
 export default function useTimeout() {
   const timeout = useLazyRef(Timeout.create).current;
 
-  useOnMount(timeout.disposeEffect);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEnhancedEffect(timeout.disposeEffect, []);
 
   return timeout;
 }


### PR DESCRIPTION
As far as I know, using `useOnMount` is wrong in this context https://github.com/facebook/react/issues/19671. We need to clear the timeout synchronously with the component unmounting.

It seems the root cause of https://github.com/mui/mui-x/issues/14987#issuecomment-2489361758.