### PR TITLE
[docs-infra] Inline script in <head>

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -43,6 +43,8 @@ export default class MyDocument extends Document {
     return (
       <Html lang={userLanguage} data-mui-color-scheme="light" data-joy-color-scheme="light">
         <Head>
+          <MuiInitColorSchemeScript defaultMode="system" />
+          <JoyInitColorSchemeScript defaultMode="system" />
           {/*
             manifest.json provides metadata used when your web app is added to the
             homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
@@ -188,8 +190,6 @@ export default class MyDocument extends Document {
           />
         </Head>
         <body>
-          <MuiInitColorSchemeScript defaultMode="system" />
-          <JoyInitColorSchemeScript defaultMode="system" />
           <Main />
           <script
             // eslint-disable-next-line react/no-danger


### PR DESCRIPTION
During the loading of the page, style recalculation is pointed at this logic, so curious to see if we move it to the top, it help.

<img width="537" alt="SCR-20250103-bymn" src="https://github.com/user-attachments/assets/b8496006-af5f-419a-a090-61ab17dc5282" />
