### PR TITLE
Fix indeterminate CircularProgress animation to be symmetric and smooth

### DIFF
--- a/packages/mui-material/src/CircularProgress/CircularProgress.js
+++ b/packages/mui-material/src/CircularProgress/CircularProgress.js
@@ -35,8 +35,8 @@ const circularDashKeyframe = keyframes`
   }
 
   100% {
-    stroke-dasharray: 100px, 200px;
-    stroke-dashoffset: -125px;
+    stroke-dasharray: 1px, 200px;
+    stroke-dashoffset: -126px;
   }
 `;
 


### PR DESCRIPTION
Changes Made:

Updated the @keyframes circular-rotate animation in CircularProgress.js:
Changed the stroke-dasharray value from 100px to 1px for the 100% keyframe.
Adjusted the stroke-dashoffset value to -126px for greater precision.

Before:

The animation shows an odd "jump" as the arc moves quickly and then stops suddenly between the 50% and 100% phases.

After:

The animation is smooth and symmetric, with the arc contracting back to 1px between the 50% and 100% phases.

- [X ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
