### PR TITLE
[docs] Fix incorrect rendering in Typography docs

### DIFF
--- a/docs/data/material/components/typography/typography.md
+++ b/docs/data/material/components/typography/typography.md
@@ -49,7 +49,7 @@ Fontsource can be configured to load specific subsets, weights, and styles. Mate
 
 ### Google Web Fonts
 
-To install Roboto through the Google Web Fonts CDN, add the following code inside your project's <head /> tag:
+To install Roboto through the Google Web Fonts CDN, add the following code inside your project's `<head />` tag:
 
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
Adds missing backticks around the <head /> tag in the documentation to fix incorrect rendering.

