### PR TITLE
[material-ui] Update `mergeSlotProps` to merge `style`

### DIFF
--- a/docs/data/material/guides/composition/composition.md
+++ b/docs/data/material/guides/composition/composition.md
@@ -66,7 +66,7 @@ The popper slot in the original example would now have both classes applied to i
 :::
 
 :::info
-`style` object are shallow merged rather than replacing one another. The style keys from the first argument will override the second.
+`style` object are shallow merged rather than replacing one another. The style keys from the first argument have higher priority.
 :::
 
 ## Component prop

--- a/docs/data/material/guides/composition/composition.md
+++ b/docs/data/material/guides/composition/composition.md
@@ -65,6 +65,10 @@ If you added another `className` via the `slotProps` prop on the Custom Tooltip�
 The popper slot in the original example would now have both classes applied to it, in addition to any others that may be present: `"[…] custom-tooltip-popper foo"`.
 :::
 
+:::info
+`style` object are shallow merged rather than replacing one another. The style keys from the first argument will override the second.
+:::
+
 ## Component prop
 
 Material UI allows you to change the root element that will be rendered via a prop called `component`.

--- a/packages/mui-material/src/utils/mergeSlotProps.test.ts
+++ b/packages/mui-material/src/utils/mergeSlotProps.test.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { expect } from 'chai';
 
 import mergeSlotProps from './mergeSlotProps';
@@ -5,6 +6,7 @@ import mergeSlotProps from './mergeSlotProps';
 type OwnerState = {
   className: string;
   'aria-label'?: string;
+  style?: React.CSSProperties;
 };
 
 describe('utils/index.js', () => {
@@ -18,6 +20,27 @@ describe('utils/index.js', () => {
       ).to.deep.equal({
         className: 'default',
         'aria-label': 'foo',
+      });
+    });
+
+    it('merge styles', () => {
+      expect(
+        mergeSlotProps<{ style: React.CSSProperties }>(
+          { style: { color: 'red' } },
+          { style: { backgroundColor: 'blue' } },
+        ),
+      ).to.deep.equal({
+        style: { color: 'red', backgroundColor: 'blue' },
+      });
+
+      // external styles should override
+      expect(
+        mergeSlotProps<{ style: React.CSSProperties }>(
+          { style: { backgroundColor: 'red' } },
+          { style: { backgroundColor: 'blue' } },
+        ),
+      ).to.deep.equal({
+        style: { backgroundColor: 'red' },
       });
     });
 
@@ -75,6 +98,35 @@ describe('utils/index.js', () => {
       ).to.deep.equal({
         className: 'base default external',
         'aria-label': 'foo',
+      });
+    });
+
+    it('merge styles for callbacks', () => {
+      expect(
+        mergeSlotProps(
+          () => ({
+            style: { color: 'red' },
+          }),
+          () => ({
+            style: { backgroundColor: 'blue' },
+          }),
+        )(),
+      ).to.deep.equal({
+        style: { color: 'red', backgroundColor: 'blue' },
+      });
+
+      // external styles should override
+      expect(
+        mergeSlotProps(
+          () => ({
+            style: { backgroundColor: 'red' },
+          }),
+          () => ({
+            style: { backgroundColor: 'blue' },
+          }),
+        )(),
+      ).to.deep.equal({
+        style: { backgroundColor: 'red' },
       });
     });
 

--- a/packages/mui-material/src/utils/mergeSlotProps.ts
+++ b/packages/mui-material/src/utils/mergeSlotProps.ts
@@ -28,6 +28,10 @@ export default function mergeSlotProps<
         ...defaultSlotPropsValue,
         ...externalSlotPropsValue,
         ...(!!className && { className }),
+        ...(defaultSlotPropsValue?.style &&
+          externalSlotPropsValue?.style && {
+            style: { ...defaultSlotPropsValue.style, ...externalSlotPropsValue.style },
+          }),
       };
     }) as U;
   }
@@ -39,5 +43,9 @@ export default function mergeSlotProps<
     ...defaultSlotProps,
     ...externalSlotProps,
     ...(!!className && { className }),
+    ...((defaultSlotProps as Record<string, any>)?.style &&
+      externalSlotProps?.style && {
+        style: { ...(defaultSlotProps as Record<string, any>).style, ...externalSlotProps.style },
+      }),
   } as U;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Continue from #44809, this PR merge the `style` instead of replacing between default slot props and external slot props.

I think it's more common from user perspective to have `style` merged rather than replace.

Some of the Material UI components, e.g. [SwipeableDrawer](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js#L607-L610), also merge the style. So this PR will benefit both internal and users.

If the user wants to remove some style from the default style, they can provide `null` as a value:

```js
// default `pointerEvents` is "none"
<CustomSwipeableDrawer slotProps={{ paper: { style: { pointerEvents: null } }}>
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
