### PR TITLE
[docs-infra] Disable flaky demos for visual regression test

### DIFF
--- a/apps/pigment-css-vite-app/src/pages/fixtures/index.test.js
+++ b/apps/pigment-css-vite-app/src/pages/fixtures/index.test.js
@@ -83,6 +83,7 @@ async function main() {
       path: screenshotPath,
       type: 'png',
       animations: 'disabled',
+      mask: [page.locator('css=[data-playwright-masked]')],
     });
   }
 

--- a/apps/pigment-css-vite-app/src/pages/material-ui/react-progress.tsx
+++ b/apps/pigment-css-vite-app/src/pages/material-ui/react-progress.tsx
@@ -73,7 +73,8 @@ export default function Progress() {
       </section>
       <section>
         <h2> Linear Determinate</h2>
-        <div className="demo-container">
+        <div className="demo-container" data-playwright-masked>
+          {/* masked when taking screenshot with playwright because this demo is a flaky one */}
           <LinearDeterminate />
         </div>
       </section>

--- a/apps/pigment-css-vite-app/vite.config.ts
+++ b/apps/pigment-css-vite-app/vite.config.ts
@@ -3,23 +3,12 @@ import reactPlugin from '@vitejs/plugin-react';
 import Pages from 'vite-plugin-pages';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import { pigment } from '@pigment-css/vite-plugin';
-import { extendTheme } from '@mui/material/styles';
+import { createTheme } from '@mui/material/styles';
 
-const theme = extendTheme({
-  getSelector: function getSelector(colorScheme, css) {
-    if (colorScheme) {
-      return {
-        [`@media (prefers-color-scheme: ${colorScheme})`]: {
-          ':root': css,
-        },
-      };
-    }
-    return ':root';
-  },
+const theme = createTheme({
+  cssVariables: true,
+  colorSchemes: { light: true, dark: true },
 });
-theme.getColorSchemeSelector = (colorScheme) => {
-  return `@media (prefers-color-scheme: ${colorScheme})`;
-};
 
 export default defineConfig({
   plugins: [

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -217,6 +217,7 @@ const blacklist = [
   'docs-getting-started-templates', // No public components
   'docs-getting-started-usage/Usage.png', // No public components
   'docs-getting-started-supported-components/MaterialUIComponents.png', // No public components
+  'docs-getting-started-templates-dashboard-components/MainGrid.png', // No public components
   'docs-landing', // Mostly images, redundant
   'docs-production-error', // No components, page for DX
   'docs-styles-advanced', // Redundant


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

There are 2 flaky regressions recently based on https://app.argos-ci.com/mui/material-ui:

1. Disable Dashboard MainGrid

  <img width="2037" alt="image" src="https://github.com/user-attachments/assets/7bbf6b44-ad4e-426b-82c5-537a3ce8b672" />

2. Disable Pigment CSS x Material UI Progress by masking the flaky demo using `data-playwright-masked` attribute on the element.

  <img width="424" alt="image" src="https://github.com/user-attachments/assets/cd4ede84-06dd-47f7-9fa8-0f7fc1d60e32" />


---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
