### PR TITLE
[code-infra] Stabilize flaky pigment progressbar tests

### DIFF
--- a/apps/pigment-css-vite-app/src/pages/material-ui/react-progress.tsx
+++ b/apps/pigment-css-vite-app/src/pages/material-ui/react-progress.tsx
@@ -9,7 +9,6 @@ import CircularWithValueLabel from '../../../../../docs/data/material/components
 import CustomizedProgressBars from '../../../../../docs/data/material/components/progress/CustomizedProgressBars.tsx';
 import DelayingAppearance from '../../../../../docs/data/material/components/progress/DelayingAppearance.tsx';
 import LinearColor from '../../../../../docs/data/material/components/progress/LinearColor.tsx';
-import LinearDeterminate from '../../../../../docs/data/material/components/progress/LinearDeterminate.tsx';
 import LinearIndeterminate from '../../../../../docs/data/material/components/progress/LinearIndeterminate.tsx';
 import LinearWithValueLabel from '../../../../../docs/data/material/components/progress/LinearWithValueLabel.tsx';
 
@@ -69,12 +68,6 @@ export default function Progress() {
         <h2> Linear Color</h2>
         <div className="demo-container">
           <LinearColor />
-        </div>
-      </section>
-      <section>
-        <h2> Linear Determinate</h2>
-        <div className="demo-container">
-          <LinearDeterminate />
         </div>
       </section>
       <section>

--- a/apps/pigment-css-vite-app/src/pages/material-ui/react-progress.tsx
+++ b/apps/pigment-css-vite-app/src/pages/material-ui/react-progress.tsx
@@ -1,4 +1,7 @@
 import * as React from 'react';
+import LinearProgress, { LinearProgressProps } from '@mui/material/LinearProgress';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
 import MaterialUILayout from '../../Layout';
 import CircularColor from '../../../../../docs/data/material/components/progress/CircularColor.tsx';
 import CircularDeterminate from '../../../../../docs/data/material/components/progress/CircularDeterminate.tsx';
@@ -10,6 +13,22 @@ import CustomizedProgressBars from '../../../../../docs/data/material/components
 import DelayingAppearance from '../../../../../docs/data/material/components/progress/DelayingAppearance.tsx';
 import LinearColor from '../../../../../docs/data/material/components/progress/LinearColor.tsx';
 import LinearIndeterminate from '../../../../../docs/data/material/components/progress/LinearIndeterminate.tsx';
+
+function LinearProgressWithLabel(props: LinearProgressProps & { value: number }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      <Box sx={{ width: '100%', mr: 1 }}>
+        <LinearProgress variant="determinate" {...props} />
+      </Box>
+      <Box sx={{ minWidth: 35 }}>
+        <Typography
+          variant="body2"
+          sx={{ color: 'text.secondary' }}
+        >{`${Math.round(props.value)}%`}</Typography>
+      </Box>
+    </Box>
+  );
+}
 
 export default function Progress() {
   return (
@@ -64,15 +83,39 @@ export default function Progress() {
         </div>
       </section>
       <section>
+        <h2> Linear Buffer</h2>
+        <div className="demo-container">
+          <Box sx={{ width: '100%' }}>
+            <LinearProgress variant="buffer" value={10} valueBuffer={30} />
+          </Box>
+        </div>
+      </section>
+      <section>
         <h2> Linear Color</h2>
         <div className="demo-container">
           <LinearColor />
         </div>
       </section>
       <section>
+        <h2> Linear Determinate</h2>
+        <div className="demo-container">
+          <Box sx={{ width: '100%' }}>
+            <LinearProgress variant="determinate" value={10} />
+          </Box>
+        </div>
+      </section>
+      <section>
         <h2> Linear Indeterminate</h2>
         <div className="demo-container">
           <LinearIndeterminate />
+        </div>
+      </section>
+      <section>
+        <h2> Linear With Value Label</h2>
+        <div className="demo-container">
+          <Box sx={{ width: '100%' }}>
+            <LinearProgressWithLabel value={10} />
+          </Box>
         </div>
       </section>
     </MaterialUILayout>

--- a/apps/pigment-css-vite-app/src/pages/material-ui/react-progress.tsx
+++ b/apps/pigment-css-vite-app/src/pages/material-ui/react-progress.tsx
@@ -10,7 +10,6 @@ import CustomizedProgressBars from '../../../../../docs/data/material/components
 import DelayingAppearance from '../../../../../docs/data/material/components/progress/DelayingAppearance.tsx';
 import LinearColor from '../../../../../docs/data/material/components/progress/LinearColor.tsx';
 import LinearIndeterminate from '../../../../../docs/data/material/components/progress/LinearIndeterminate.tsx';
-import LinearWithValueLabel from '../../../../../docs/data/material/components/progress/LinearWithValueLabel.tsx';
 
 export default function Progress() {
   return (
@@ -74,12 +73,6 @@ export default function Progress() {
         <h2> Linear Indeterminate</h2>
         <div className="demo-container">
           <LinearIndeterminate />
-        </div>
-      </section>
-      <section>
-        <h2> Linear With Value Label</h2>
-        <div className="demo-container">
-          <LinearWithValueLabel />
         </div>
       </section>
     </MaterialUILayout>


### PR DESCRIPTION
Revert and inline https://github.com/mui/material-ui/pull/43959, stabilize other progress indicaters that are JS animated. we can just inline the demos end set static values for the props.