### PR TITLE
[figma] Clarify that Material UI Sync plugin is experimental

### DIFF
--- a/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
+++ b/docs/data/material/design-resources/material-ui-sync/material-ui-sync.md
@@ -1,17 +1,18 @@
-# Material UI Sync plugin
+# Material UI Sync plugin 🧪
 
 <p class="description">Sync is a Figma plugin that generates Material UI themes directly from design to code.</p>
+
+:::warning
+This plugin is experimental.
+:::
 
 ## Introduction
 
 [Material UI Sync](https://www.figma.com/community/plugin/1336346114713490235/material-ui-sync) is a Figma plugin that lets you generate a theme from the [Material UI for Figma Design Kit](https://www.figma.com/community/file/912837788133317724/material-ui-for-figma-and-mui-x).
 
-:::warning
-Sync works in combination with the [Material UI for Figma Design Kit v5.16.0](https://github.com/mui/mui-design-kits/releases) and later.
-Other kits, such as the Joy UI Design Kit, are not supported yet.
-:::
-
 <img src="/static/material-ui/design-resources/sync.png" style="width: 814px;" alt="Customizing the Material UI Switch component in Figma with the Sync plugin running." width="1628" height="400" />
+
+Sync works in combination with the [Material UI for Figma Design Kit v5.16.0](https://github.com/mui/mui-design-kits/releases) and later.
 
 ## Running the plugin
 

--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -373,7 +373,7 @@ const pages: MuiPage[] = [
       {
         pathname: '/material-ui/design-resources/material-ui-sync',
         title: 'Figma Sync plugin',
-        beta: true,
+        unstable: true,
       },
     ],
   },


### PR DESCRIPTION
Seeing https://github.com/mui/mui-design-kits/issues/435 makes me feel that it's not usable in real life, it's a technical preview, so better be clear about it. (the other issues point in the same direction)

I'm going ahead as it's unclear who was going to work on https://www.notion.so/mui-org/core-General-meeting-2024-12-23-165cbfe7b660800b8535eea8f63052ec?pvs=4#165cbfe7b6608148b580d1ea2b0d75b3 and I was directly in the context looking at that GitHub issue.