### PR TITLE
[material-ui] Fix slots typing for Tooltip and StepLabel

### DIFF
--- a/packages/mui-material/src/StepLabel/StepLabel.d.ts
+++ b/packages/mui-material/src/StepLabel/StepLabel.d.ts
@@ -15,7 +15,7 @@ export interface StepLabelSlots {
   /**
    * The component to render in place of the [`StepIcon`](https://mui.com/material-ui/api/step-icon/).
    */
-  stepIcon: React.ElementType<StepIconProps>;
+  stepIcon: React.ElementType;
 }
 
 export type StepLabelSlotsAndSlotProps = CreateSlotsAndSlotProps<

--- a/packages/mui-material/src/StepLabel/StepLabel.spec.tsx
+++ b/packages/mui-material/src/StepLabel/StepLabel.spec.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import StepLabel from '@mui/material/StepLabel';
+
+const SlotComponentRef = React.forwardRef<HTMLDivElement>((props, ref) => {
+  return <div />;
+});
+
+<StepLabel
+  slots={{
+    label: 'span',
+    stepIcon: 'div',
+  }}
+>
+  Step One
+</StepLabel>;
+
+<StepLabel
+  slots={{
+    label: SlotComponentRef,
+    stepIcon: SlotComponentRef,
+  }}
+>
+  Step One
+</StepLabel>;

--- a/packages/mui-material/src/Tooltip/Tooltip.d.ts
+++ b/packages/mui-material/src/Tooltip/Tooltip.d.ts
@@ -21,7 +21,7 @@ export interface TooltipSlots {
    * The component used for the popper.
    * @default Popper
    */
-  popper: React.ElementType<PopperProps>;
+  popper: React.ElementType;
   /**
    * The component used for the transition.
    * [Follow this guide](https://mui.com/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.

--- a/packages/mui-material/src/Tooltip/Tooltip.spec.tsx
+++ b/packages/mui-material/src/Tooltip/Tooltip.spec.tsx
@@ -1,15 +1,18 @@
 import * as React from 'react';
 import Tooltip from '@mui/material/Tooltip';
-import Popper from '@mui/material/Popper';
 
 <Tooltip title="Hello">
   <button type="button">Hover or touch me</button>
 </Tooltip>;
 
+const SlotComponentRef = React.forwardRef<HTMLDivElement>((props, ref) => {
+  return <div />;
+});
+
 <Tooltip
   title="Hello"
   slots={{
-    popper: Popper,
+    popper: 'div',
     arrow: 'span',
     tooltip: 'div',
     transition: 'div',
@@ -32,6 +35,18 @@ import Popper from '@mui/material/Popper';
     transition: {
       timeout: 500,
     },
+  }}
+>
+  <button type="button">Hover or touch me</button>
+</Tooltip>;
+
+<Tooltip
+  title="foo"
+  slots={{
+    popper: SlotComponentRef,
+    arrow: SlotComponentRef,
+    tooltip: SlotComponentRef,
+    transition: SlotComponentRef,
   }}
 >
   <button type="button">Hover or touch me</button>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes https://github.com/mui/material-ui/issues/44952

## Root cause

The previous slots types is too narrow

```js
export interface StepLabelSlots {
  /**
   * The component to render in place of the [`StepIcon`](https://mui.com/material-ui/api/step-icon/).
   */
  stepIcon: React.ElementType<StepIconProps>;
}
```

It's specific to `StepIconProps`, meaning using plain HTML like `"div"` or a custom component won't work.

```js
<StepLabel
  slots={{
    stepIcon: 'div', // ❌ type error
  }}
>
  Step One
</StepLabel>;
```

## Fix

Widening the types to just `React.ElementType` to include plain HTML and any custom React component.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
