### PR TITLE
[material-ui][Input] Remove unused classes from InputClasses interface

### DIFF
--- a/docs/pages/material-ui/api/input.json
+++ b/docs/pages/material-ui/api/input.json
@@ -70,12 +70,6 @@
   "imports": ["import Input from '@mui/material/Input';", "import { Input } from '@mui/material';"],
   "classes": [
     {
-      "key": "colorSecondary",
-      "className": "MuiInput-colorSecondary",
-      "description": "Styles applied to the root element if color secondary.",
-      "isGlobal": false
-    },
-    {
       "key": "disabled",
       "className": "Mui-disabled",
       "description": "Styles applied to the root element if `disabled={true}`.",
@@ -92,12 +86,6 @@
       "className": "Mui-focused",
       "description": "Styles applied to the root element if the component is focused.",
       "isGlobal": true
-    },
-    {
-      "key": "formControl",
-      "className": "MuiInput-formControl",
-      "description": "Styles applied to the root element if the component is a descendant of `FormControl`.",
-      "isGlobal": false
     },
     {
       "key": "fullWidth",

--- a/docs/translations/api-docs/input/input.json
+++ b/docs/translations/api-docs/input/input.json
@@ -86,11 +86,6 @@
     }
   },
   "classDescriptions": {
-    "colorSecondary": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "color secondary"
-    },
     "disabled": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
@@ -105,11 +100,6 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "the component is focused"
-    },
-    "formControl": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "the component is a descendant of <code>FormControl</code>"
     },
     "fullWidth": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",

--- a/packages/mui-material/src/Input/Input.test.js
+++ b/packages/mui-material/src/Input/Input.test.js
@@ -4,6 +4,7 @@ import { createRenderer } from '@mui/internal-test-utils';
 import InputBase from '@mui/material/InputBase';
 import Input, { inputClasses as classes } from '@mui/material/Input';
 import describeConformance from '../../test/describeConformance';
+import FormControl from '../FormControl';
 
 describe('<Input />', () => {
   const { render } = createRenderer();
@@ -46,5 +47,21 @@ describe('<Input />', () => {
       <Input data-test="test" multiline sx={{ [`&.${classes.multiline}`]: { mt: '10px' } }} />,
     );
     expect(document.querySelector('[data-test=test]')).toHaveComputedStyle({ marginTop: '10px' });
+  });
+
+  it('should not have colorSecondary class on Input', () => {
+    render(<Input color="secondary" />);
+    expect(document.querySelector(`.MuiInput-colorSecondary`)).to.equal(null);
+    expect(document.querySelector(`.MuiInputBase-colorSecondary`)).to.not.equal(null);
+  });
+
+  it('should not have formControl class on Input', () => {
+    render(
+      <FormControl>
+        <Input />
+      </FormControl>,
+    );
+    expect(document.querySelector(`.MuiInput-formControl`)).to.equal(null);
+    expect(document.querySelector(`.MuiInputBase-formControl`)).to.not.equal(null);
   });
 });

--- a/packages/mui-material/src/Input/inputClasses.ts
+++ b/packages/mui-material/src/Input/inputClasses.ts
@@ -5,14 +5,10 @@ import { inputBaseClasses } from '../InputBase';
 export interface InputClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the root element if the component is a descendant of `FormControl`. */
-  formControl: string;
   /** Styles applied to the root element if the component is focused. */
   focused: string;
   /** Styles applied to the root element if `disabled={true}`. */
   disabled: string;
-  /** Styles applied to the root element if color secondary. */
-  colorSecondary: string;
   /** Styles applied to the root element unless `disableUnderline={true}`. */
   underline: string;
   /** State class applied to the root element if `error={true}`. */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
