### PR TITLE
[material-ui][FilledInput] Remove unused classes from FilledInputClasses interface

### DIFF
--- a/docs/pages/material-ui/api/filled-input.json
+++ b/docs/pages/material-ui/api/filled-input.json
@@ -86,12 +86,6 @@
       "isGlobal": false
     },
     {
-      "key": "colorSecondary",
-      "className": "MuiFilledInput-colorSecondary",
-      "description": "Styles applied to the root element if color secondary.",
-      "isGlobal": false
-    },
-    {
       "key": "disabled",
       "className": "Mui-disabled",
       "description": "State class applied to the root element if `disabled={true}`.",

--- a/docs/translations/api-docs/filled-input/filled-input.json
+++ b/docs/translations/api-docs/filled-input/filled-input.json
@@ -99,11 +99,6 @@
       "nodeName": "the root element",
       "conditions": "<code>startAdornment</code> is provided"
     },
-    "colorSecondary": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "color secondary"
-    },
     "disabled": {
       "description": "State class applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",

--- a/packages/mui-material/src/FilledInput/FilledInput.test.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.test.js
@@ -106,4 +106,10 @@ describe('<FilledInput />', () => {
     expect(root).to.have.class(classes.adornedEnd);
     expect(root).to.have.class(classes.adornedStart);
   });
+
+  it('should not have colorSecondary class on FilledInput', () => {
+    render(<FilledInput color="secondary" />);
+    expect(document.querySelector(`.MuiFilledInput-colorSecondary`)).to.equal(null);
+    expect(document.querySelector(`.MuiInputBase-colorSecondary`)).to.not.equal(null);
+  });
 });

--- a/packages/mui-material/src/FilledInput/filledInputClasses.ts
+++ b/packages/mui-material/src/FilledInput/filledInputClasses.ts
@@ -5,8 +5,6 @@ import { inputBaseClasses } from '../InputBase';
 export interface FilledInputClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the root element if color secondary. */
-  colorSecondary: string;
   /** Styles applied to the root element unless `disableUnderline={true}`. */
   underline: string;
   /** State class applied to the root element if the component is focused. */


### PR DESCRIPTION
This PR removes used class from FilledInputClasses interface, removed class isn't present in DOM but present in interface.

I found this while working on deprecation of FilledInput composed classes