### PR TITLE
[code-infra] Add "use client" directive to files with React APIs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -408,6 +408,20 @@ module.exports = /** @type {Config} */ ({
       },
     },
     {
+      files: ['packages/*/src/*/*.?(c|m)[jt]s?(x)'],
+      excludedFiles: [
+        '*.spec.tsx',
+        // deprecated library
+        '**/mui-base/**/*',
+        '**/mui-joy/**/*',
+        // used internally, not used on app router yet
+        '**/mui-docs/**/*',
+      ],
+      rules: {
+        'material-ui/disallow-react-api-in-server-components': 'error',
+      },
+    },
+    {
       files: ['packages/*/src/**/*.?(c|m)[jt]s?(x)'],
       excludedFiles: '*.spec.*',
       rules: {

--- a/packages/eslint-plugin-material-ui/src/index.js
+++ b/packages/eslint-plugin-material-ui/src/index.js
@@ -8,4 +8,5 @@ module.exports.rules = {
   'no-empty-box': require('./rules/no-empty-box'),
   'no-styled-box': require('./rules/no-styled-box'),
   'straight-quotes': require('./rules/straight-quotes'),
+  'disallow-react-api-in-server-components': require('./rules/disallow-react-api-in-server-components'),
 };

--- a/packages/eslint-plugin-material-ui/src/rules/disallow-react-api-in-server-components.js
+++ b/packages/eslint-plugin-material-ui/src/rules/disallow-react-api-in-server-components.js
@@ -1,0 +1,44 @@
+module.exports = {
+  create(context) {
+    let hasUseClientDirective = false;
+    const apis = new Set([
+      'useState',
+      'useEffect',
+      'useLayoutEffect',
+      'useReducer',
+      'useTransition',
+      'createContext',
+    ]);
+    return {
+      Program(node) {
+        hasUseClientDirective = node.body.some(
+          (statement) =>
+            statement.type === 'ExpressionStatement' &&
+            statement.expression.type === 'Literal' &&
+            statement.expression.value === 'use client',
+        );
+      },
+      CallExpression(node) {
+        if (
+          !hasUseClientDirective &&
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.name === 'React' &&
+          apis.has(node.callee.property.name)
+        ) {
+          context.report({
+            node,
+            message: `Using 'React.${node.callee.property.name}' is forbidden if the file doesn't have a 'use client' directive.`,
+            fix(fixer) {
+              const sourceCode = context.getSourceCode();
+              const firstToken = sourceCode.ast.body[0];
+              return fixer.insertTextBefore(firstToken, "'use client';\n");
+            },
+          });
+        }
+      },
+    };
+  },
+  meta: {
+    fixable: 'code',
+  },
+};

--- a/packages/mui-lab/src/Timeline/TimelineContext.ts
+++ b/packages/mui-lab/src/Timeline/TimelineContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 /**

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -1,4 +1,5 @@
 // @ts-check
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';

--- a/packages/mui-material/src/ButtonGroup/ButtonGroupButtonContext.ts
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroupButtonContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 type ButtonPositionClassName = string;

--- a/packages/mui-material/src/ButtonGroup/ButtonGroupContext.ts
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroupContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import type { ButtonGroupProps } from './ButtonGroup';
 

--- a/packages/mui-material/src/Checkbox/Checkbox.test.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/mui-material/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/mui-material/src/ClickAwayListener/ClickAwayListener.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { expect } from 'chai';

--- a/packages/mui-material/src/Dialog/Dialog.test.js
+++ b/packages/mui-material/src/Dialog/Dialog.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/mui-material/src/Dialog/DialogContext.ts
+++ b/packages/mui-material/src/Dialog/DialogContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 interface DialogContextValue {

--- a/packages/mui-material/src/FormControl/FormControl.test.js
+++ b/packages/mui-material/src/FormControl/FormControl.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/mui-material/src/FormControl/FormControlContext.ts
+++ b/packages/mui-material/src/FormControl/FormControlContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import type { FormControlProps } from './FormControl';
 

--- a/packages/mui-material/src/Grow/Grow.test.js
+++ b/packages/mui-material/src/Grow/Grow.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/mui-material/src/Hidden/withWidth.js
+++ b/packages/mui-material/src/Hidden/withWidth.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import getDisplayName from '@mui/utils/getDisplayName';

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';

--- a/packages/mui-material/src/Menu/Menu.test.js
+++ b/packages/mui-material/src/Menu/Menu.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { expect } from 'chai';

--- a/packages/mui-material/src/Popper/Popper.test.js
+++ b/packages/mui-material/src/Popper/Popper.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';

--- a/packages/mui-material/src/Portal/Portal.test.tsx
+++ b/packages/mui-material/src/Portal/Portal.test.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/mui-material/src/RadioGroup/RadioGroupContext.ts
+++ b/packages/mui-material/src/RadioGroup/RadioGroupContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 export interface RadioGroupContextValue {

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';

--- a/packages/mui-material/src/Slide/Slide.test.js
+++ b/packages/mui-material/src/Slide/Slide.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { spy, stub } from 'sinon';

--- a/packages/mui-material/src/Snackbar/Snackbar.test.js
+++ b/packages/mui-material/src/Snackbar/Snackbar.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/mui-material/src/Step/StepContext.ts
+++ b/packages/mui-material/src/Step/StepContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 export interface StepContextType {

--- a/packages/mui-material/src/Stepper/StepperContext.ts
+++ b/packages/mui-material/src/Stepper/StepperContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 export interface StepperContextType {

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/mui-material/src/Table/Tablelvl2Context.js
+++ b/packages/mui-material/src/Table/Tablelvl2Context.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 /**

--- a/packages/mui-material/src/TablePagination/TablePagination.test.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/mui-material/src/Tabs/Tabs.test.js
+++ b/packages/mui-material/src/Tabs/Tabs.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/mui-material/src/TextareaAutosize/TextareaAutosize.test.tsx
+++ b/packages/mui-material/src/TextareaAutosize/TextareaAutosize.test.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import sinon, { spy, stub } from 'sinon';

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroupButtonContext.ts
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroupButtonContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 type ToggleButtonPositionClassName = string;

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroupContext.ts
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroupContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import type { ToggleButtonGroupProps } from './ToggleButtonGroup';
 

--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { expect } from 'chai';

--- a/packages/mui-material/src/internal/SwitchBase.test.js
+++ b/packages/mui-material/src/internal/SwitchBase.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
+++ b/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, screen, fireEvent } from '@mui/internal-test-utils';

--- a/packages/mui-material/src/usePagination/usePagination.test.js
+++ b/packages/mui-material/src/usePagination/usePagination.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { createRenderer } from '@mui/internal-test-utils';
 import { expect } from 'chai';

--- a/packages/mui-material/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/mui-material/src/useScrollTrigger/useScrollTrigger.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';

--- a/packages/mui-private-theming/src/useTheme/ThemeContext.js
+++ b/packages/mui-private-theming/src/useTheme/ThemeContext.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 const ThemeContext = React.createContext(null);

--- a/packages/mui-styles/src/StylesProvider/StylesProvider.js
+++ b/packages/mui-styles/src/StylesProvider/StylesProvider.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { exactProp } from '@mui/utils';

--- a/packages/mui-styles/src/StylesProvider/StylesProvider.test.js
+++ b/packages/mui-styles/src/StylesProvider/StylesProvider.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import { expect } from 'chai';

--- a/packages/mui-styles/src/makeStyles/makeStyles.js
+++ b/packages/mui-styles/src/makeStyles/makeStyles.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { getDynamicStyles } from 'jss';
 import mergeClasses from '../mergeClasses';

--- a/packages/mui-styles/src/makeStyles/makeStyles.test.js
+++ b/packages/mui-styles/src/makeStyles/makeStyles.test.js
@@ -1,3 +1,4 @@
+'use client';
 import { expect } from 'chai';
 import * as React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/mui-system/src/RtlProvider/index.js
+++ b/packages/mui-system/src/RtlProvider/index.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { GlobalStyles } from '@mui/styled-engine';

--- a/packages/mui-system/src/cssVars/useCurrentColorScheme.test.js
+++ b/packages/mui-system/src/cssVars/useCurrentColorScheme.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/mui-utils/src/getDisplayName/getDisplayName.test.tsx
+++ b/packages/mui-utils/src/getDisplayName/getDisplayName.test.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/prefer-stateless-function */
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import getDisplayName from './getDisplayName';

--- a/packages/mui-utils/src/useForkRef/useForkRef.test.js
+++ b/packages/mui-utils/src/useForkRef/useForkRef.test.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';

--- a/packages/mui-utils/src/useIsFocusVisible/useIsFocusVisible.test.js
+++ b/packages/mui-utils/src/useIsFocusVisible/useIsFocusVisible.test.js
@@ -1,3 +1,4 @@
+'use client';
 import { expect } from 'chai';
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';


### PR DESCRIPTION
This otherwise breaks react server components in Next.js when moving to full ESM