### PR TITLE
[Rating] Fix Rating returns NaN when using user event

### DIFF
--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -419,8 +419,16 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
       onMouseMove(event);
     }
 
+    setFocusVisible(false);
+
     const rootNode = rootRef.current;
     const { right, left, width: containerWidth } = rootNode.getBoundingClientRect();
+
+    if (!containerWidth) {
+      // Workaround for test scenario using userEvent since jsdom defaults getBoundingClientRect to 0
+      // Fix https://github.com/mui/material-ui/issues/38828
+      return;
+    }
 
     let percent;
 
@@ -441,8 +449,6 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
             focus: newHover,
           },
     );
-
-    setFocusVisible(false);
 
     if (onChangeActive && hover !== newHover) {
       onChangeActive(event, newHover);

--- a/packages/mui-material/src/Rating/Rating.test.js
+++ b/packages/mui-material/src/Rating/Rating.test.js
@@ -4,6 +4,7 @@ import { stub, spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import Rating, { ratingClasses as classes } from '@mui/material/Rating';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
+import userEvent from '@testing-library/user-event';
 import describeConformance from '../../test/describeConformance';
 
 describe('<Rating />', () => {
@@ -165,6 +166,25 @@ describe('<Rating />', () => {
     expect(handleChange.args[0][1]).to.deep.equal(3);
     const checked = container.querySelector('input[name="rating-test"]:checked');
     expect(checked.value).to.equal('2');
+  });
+
+  it('should select the rating with user clicks using user-event', async () => {
+    if (!/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const user = userEvent.setup();
+    const handleChange = spy();
+
+    const { container } = render(<Rating name="rating-test" onChange={handleChange} />);
+
+    await user.click(screen.getByLabelText('3 Stars'));
+
+    expect(handleChange.callCount).to.equal(1);
+    expect(handleChange.args[0][1]).to.deep.equal(3);
+
+    const checked = container.querySelector('input[name="rating-test"]:checked');
+    expect(checked.value).to.equal('3');
   });
 
   it('should change the value to null', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #38828 
