### PR TITLE
[utils] Do not deep merge React component

### DIFF
--- a/packages/mui-utils/src/deepmerge/deepmerge.test.ts
+++ b/packages/mui-utils/src/deepmerge/deepmerge.test.ts
@@ -132,6 +132,17 @@ describe('deepmerge', () => {
     expect(result.element).to.equal(element2);
   });
 
+  it('should not deep clone React component', () => {
+    // most 3rd-party components use `forwardRef`
+    const Link = React.forwardRef((props, ref) => React.createElement('a', { ref, ...props }));
+    const result = deepmerge(
+      { defaultProps: { component: 'a' } },
+      { defaultProps: { component: Link } },
+    );
+
+    expect(result.defaultProps.component).to.equal(Link);
+  });
+
   it('should deep clone example correctly', () => {
     const result = deepmerge({ a: { b: 1 }, d: 2 }, { a: { c: 2 }, d: 4 });
 

--- a/packages/mui-utils/src/deepmerge/deepmerge.ts
+++ b/packages/mui-utils/src/deepmerge/deepmerge.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { isValidElementType } from 'react-is';
 
 // https://github.com/sindresorhus/is-plain-obj/blob/main/index.js
 export function isPlainObject(item: unknown): item is Record<keyof any, unknown> {
@@ -21,7 +22,7 @@ export interface DeepmergeOptions {
 }
 
 function deepClone<T>(source: T): T | Record<keyof any, unknown> {
-  if (React.isValidElement(source) || !isPlainObject(source)) {
+  if (React.isValidElement(source) || isValidElementType(source) || !isPlainObject(source)) {
     return source;
   }
 
@@ -61,7 +62,7 @@ export default function deepmerge<T>(
 
   if (isPlainObject(target) && isPlainObject(source)) {
     Object.keys(source).forEach((key) => {
-      if (React.isValidElement(source[key])) {
+      if (React.isValidElement(source[key]) || isValidElementType(source[key])) {
         (output as Record<keyof any, unknown>)[key] = source[key];
       } else if (
         isPlainObject(source[key]) &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #45052

## Root cause

`deepmerge` currently iterate a React component that's wrapped with `forwardRef` or `memo`. The issue arise when using Link from nextjs (contains recursive render) because `deepmerge` will iterate infinitely causing maximum callstack error from the usage below:

```js
import { createTheme } from '@mui/material/styles';
import Link from 'next/link';

const theme = createTheme({
  components: {
    MuiLink: {
      defaultProps: {
        component: Link,
      },
    },
  },
});
```

It does not make sense anyway to iterate fields inside a React component, so a side benefit of this PR is the performance improvement.

---


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
