### PR TITLE
[docs] 301 redirect `/base-ui` to `base-ui.com`

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -509,6 +509,7 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /material-ui/experimental-api/css-theme-variables/overview/ /material-ui/customization/css-theme-variables/overview/ 301
 /material-ui/experimental-api/css-theme-variables/usage/ /material-ui/customization/css-theme-variables/usage/ 301
 /material-ui/experimental-api/css-theme-variables/customization/ /material-ui/customization/css-theme-variables/configuration/ 301
+/base-ui https://base-ui.com 301
 
 # Proxies
 


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/44910

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
