### PR TITLE
[material-ui][Chip] Fixed Clickable area such that it do not depend on the inline height

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -103,6 +103,20 @@ const ChipRoot = styled('div', {
       padding: 0, // Remove `button` padding
       verticalAlign: 'middle',
       boxSizing: 'border-box',
+
+      // gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+      '& > *': {
+        cursor: 'inherit', // Inherit cursor from parent
+      },
+      '&.clickable': {
+        cursor: 'pointer',
+        userSelect: 'none',
+        WebkitTapHighlightColor: 'transparent',
+      },
+      '&.clickable > *': {
+        pointerEvents: 'none', // Prevent nested elements from capturing pointer events
+      },
+      // gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
       [`&.${chipClasses.disabled}`]: {
         opacity: (theme.vars || theme).palette.action.disabledOpacity,
         pointerEvents: 'none',
@@ -228,9 +242,6 @@ const ChipRoot = styled('div', {
         {
           props: { clickable: true },
           style: {
-            userSelect: 'none',
-            WebkitTapHighlightColor: 'transparent',
-            cursor: 'pointer',
             '&:hover': {
               backgroundColor: theme.vars
                 ? `rgba(${theme.vars.palette.action.selectedChannel} / calc(${theme.vars.palette.action.selectedOpacity} + ${theme.vars.palette.action.hoverOpacity}))`
@@ -506,7 +517,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   return (
     <ChipRoot
       as={component}
-      className={clsx(classes.root, className)}
+      className={clsx(classes.root, className, clickable ? 'clickable' : '')}
       disabled={clickable && disabled ? true : undefined}
       onClick={onClick}
       onKeyDown={handleKeyDown}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Added an explicit clickable class to the root element when the chip is clickable

Before changes
![WhatsApp Image 2025-01-24 at 01 15 27_5c27c3c8](https://github.com/user-attachments/assets/b66a224b-b811-40f9-8884-36e188756acf)

After changes
![WhatsApp Image 2025-01-24 at 01 15 51_fc1fcc05](https://github.com/user-attachments/assets/fd4fd4c2-3743-4274-ad9a-adc4ab3430e8)


so you can clearly see that click can be shown only when you are on the button 


closes #45097 
