### PR TITLE
[docs-infra] Move Ukraine banner to the bottom

### DIFF
--- a/docs/src/components/banner/TableOfContentsBanner.tsx
+++ b/docs/src/components/banner/TableOfContentsBanner.tsx
@@ -3,23 +3,22 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { alpha } from '@mui/material/styles';
 import { Link } from '@mui/docs/Link';
-import FEATURE_TOGGLE from 'docs/src/featureToggle';
 
 export default function TableOfContentsBanner() {
-  return FEATURE_TOGGLE.enable_toc_banner ? (
+  return (
     <Link
       href="https://war.ukraine.ua/support-ukraine/"
       target="_blank"
       sx={[
         (theme) => ({
-          mb: 2,
+          mt: 2,
           mx: 0.5,
+          mb: 2,
           p: 1,
           pl: '10px',
           display: 'flex',
           alignItems: 'center',
           gap: '10px',
-          backgroundColor: alpha(theme.palette.grey[50], 0.4),
           border: '1px solid',
           borderColor: (theme.vars || theme).palette.divider,
           borderRadius: 1,
@@ -53,5 +52,5 @@ export default function TableOfContentsBanner() {
         MUI stands in solidarity with Ukraine.
       </Typography>
     </Link>
-  ) : null;
+  );
 }

--- a/docs/src/featureToggle.js
+++ b/docs/src/featureToggle.js
@@ -1,7 +1,6 @@
 // need to use commonjs export so that @mui/internal-markdown can use
 module.exports = {
   enable_website_banner: false,
-  enable_toc_banner: true,
   enable_docsnav_banner: true,
   enable_job_banner: false,
 };

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -263,7 +263,6 @@ export default function AppTableOfContents(props) {
 
   return (
     <Nav aria-label={t('pageTOC')}>
-      <TableOfContentsBanner />
       <NoSsr>
         {showJobAd && (
           <Link
@@ -344,6 +343,7 @@ export default function AppTableOfContents(props) {
         </React.Fragment>
       ) : null}
       <DiamondSponsors />
+      <TableOfContentsBanner />
     </Nav>
   );
 }

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -44,7 +44,7 @@ export default function DiamondSponsors() {
   const t = useTranslate();
 
   return (
-    <Stack direction="column" sx={{ mt: 2 }}>
+    <Stack direction="column" sx={{ mt: 2, mx: 0.5 }}>
       <NativeLink
         data-ga-event-category="sponsor"
         data-ga-event-action="docs-premium"


### PR DESCRIPTION
A continuation of #34795. From https://github.com/mui/material-ui/pull/34795#issuecomment-1281365092, it seems that all the projects that are still maintained and that used to show a banner removed it. This change should help a bit with #40977 and the UX, reducing the visual distraction. At this stage, most people are pretty much aware of how we stand.

Related to #39495.

Preview: https://deploy-preview-45135--material-ui.netlify.app/material-ui/react-button-group/

<img width="284" alt="SCR-20250128-unoq" src="https://github.com/user-attachments/assets/7b593418-604c-496a-a805-2eed348e3e17" />

Context, I noticed this, because I was engaging with https://mui.zendesk.com/agent/tickets/25472.