### PR TITLE
[docs] Add v6 to v7 migration guide

### DIFF
--- a/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
+++ b/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
@@ -11,7 +11,7 @@ In the `package.json` file, change the package version from `latest` to `next`.
 +"@mui/material": "next",
 ```
 
-Using `next` ensures your project always uses the latest v7 release.
+Using `next` ensures your project always uses the latest v7 pre-releases.
 Alternatively, you can also target and fix it to a specific version, for example, `7.0.0-alpha.0`.
 
 ## Breaking changes
@@ -21,5 +21,5 @@ The steps you need to take to migrate from Material UI v6 to v7 are described 
 
 :::info
 This list is a work in progress.
-It will be updated as new breaking changes are introduced.
+Expect updates as new breaking changes are introduced.
 :::

--- a/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
+++ b/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
@@ -1,0 +1,25 @@
+# Upgrade to v7
+
+<p class="description">This guide explains how to upgrade from Material UI v6 to v7.</p>
+
+## Start using the alpha release
+
+In the `package.json` file, change the package version from `latest` to `next`.
+
+```diff title="package.json"
+-"@mui/material": "latest",
++"@mui/material": "next",
+```
+
+Using `next` ensures your project always uses the latest v7 release.
+Alternatively, you can also target and fix it to a specific version, for example, `7.0.0-alpha.0`.
+
+## Breaking changes
+
+Since v7 is a new major release, it contains some changes that affect the public API.
+The steps you need to take to migrate from Material UI v6 to v7 are described below.
+
+:::info
+This list is a work in progress.
+It will be updated as new breaking changes are introduced.
+:::

--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -298,6 +298,16 @@ const pages: MuiPage[] = [
         title: 'Migration from @material-ui/pickers',
       },
       {
+        pathname: '/material-ui/migration/v7',
+        subheader: 'Upgrade to v7',
+        children: [
+          {
+            pathname: '/material-ui/migration/upgrade-to-v7',
+            title: 'Upgrade to v7: getting started',
+          },
+        ],
+      },
+      {
         pathname: '/material-ui/migration/v6',
         subheader: 'Upgrade to v6',
         children: [

--- a/docs/data/system/migration/upgrade-to-v7/upgrade-to-v7.md
+++ b/docs/data/system/migration/upgrade-to-v7/upgrade-to-v7.md
@@ -1,0 +1,25 @@
+# Upgrade to v7
+
+<p class="description">This guide explains how to upgrade from MUI System v6 to v7.</p>
+
+## Start using the alpha release
+
+In the `package.json` file, change the package version from `latest` to `next`.
+
+```diff title="package.json"
+-"@mui/system": "latest",
++"@mui/system": "next",
+```
+
+Using `next` ensures your project always uses the latest v7 release.
+Alternatively, you can also target and fix it to a specific version, for example, `7.0.0-alpha.0`.
+
+## Breaking changes
+
+Since v7 is a new major release, it contains some changes that affect the public API.
+The steps you need to take to migrate from MUI System v6 to v7 are described below.
+
+:::info
+This list is a work in progress.
+It will be updated as new breaking changes are introduced.
+:::

--- a/docs/data/system/migration/upgrade-to-v7/upgrade-to-v7.md
+++ b/docs/data/system/migration/upgrade-to-v7/upgrade-to-v7.md
@@ -1,6 +1,6 @@
 # Upgrade to v7
 
-<p class="description">This guide explains how to upgrade from MUI System v6 to v7.</p>
+<p class="description">This guide explains how to upgrade from MUI System v6 to v7.</p>
 
 ## Start using the alpha release
 
@@ -11,15 +11,15 @@ In the `package.json` file, change the package version from `latest` to `next`.
 +"@mui/system": "next",
 ```
 
-Using `next` ensures your project always uses the latest v7 release.
+Using `next` ensures your project always uses the latest v7 pre-releases.
 Alternatively, you can also target and fix it to a specific version, for example, `7.0.0-alpha.0`.
 
 ## Breaking changes
 
 Since v7 is a new major release, it contains some changes that affect the public API.
-The steps you need to take to migrate from MUI System v6 to v7 are described below.
+The steps you need to take to migrate from MUI System v6 to v7 are described below.
 
 :::info
 This list is a work in progress.
-It will be updated as new breaking changes are introduced.
+Expect updates as new breaking changes are introduced.
 :::

--- a/docs/data/system/pages.ts
+++ b/docs/data/system/pages.ts
@@ -47,6 +47,10 @@ const pages: readonly MuiPage[] = [
     title: 'Migration',
     children: [
       {
+        pathname: '/system/migration/upgrade-to-v7',
+        title: 'Upgrade to v7',
+      },
+      {
         pathname: '/system/migration/migrating-to-v6',
         title: 'Migrating to v6',
       },

--- a/docs/pages/material-ui/migration/upgrade-to-v7.js
+++ b/docs/pages/material-ui/migration/upgrade-to-v7.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md?muiMarkdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}

--- a/docs/pages/system/migration/upgrade-to-v7.js
+++ b/docs/pages/system/migration/upgrade-to-v7.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docs/data/system/migration/upgrade-to-v7/upgrade-to-v7.md?muiMarkdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -27,6 +27,7 @@
     "/system/react-grid": "Grid",
     "/system/react-stack": "Stack",
     "/system/migration": "Migration",
+    "/system/migration/upgrade-to-v7": "Upgrade to v7",
     "/system/migration/migrating-to-v6": "Migrating to v6",
     "/system/experimental-api": "Experimental APIs",
     "/system/experimental-api/configure-the-sx-prop": "Configure the sx prop",

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -262,6 +262,8 @@
     "/material-ui/migration": "Migration",
     "/material-ui/migration/migration-grid-v2": "Migrating to Grid v2",
     "/material-ui/migration/pickers-migration": "Migration from @material-ui/pickers",
+    "Upgrade to v7": "Upgrade to v7",
+    "/material-ui/migration/upgrade-to-v7": "Upgrade to v7: getting started",
     "Upgrade to v6": "Upgrade to v6",
     "/material-ui/migration/upgrade-to-v6": "Upgrade to v6: getting started",
     "/material-ui/migration/migrating-from-deprecated-apis": "Migrating from deprecated APIs",


### PR DESCRIPTION
Add migration guide from v6 to v7 for Material UI and MUI System. They're empty now, but adding them allows everyone to add breaking changes on each PR.

Preview: https://deploy-preview-45143--material-ui.netlify.app/material-ui/migration/upgrade-to-v7/