### PR TITLE
[release][core] Bump internal packages major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 <!-- generated comparing v6.4.1..master -->
 
-_Jan 29, 2025_
+_Jan 30, 2025_
 
 A big thanks to the 8 contributors who made this release possible.
 This is the first alpha release of Material UI v7 🎉.
@@ -31,6 +31,7 @@ This is the first alpha release of Material UI v7 🎉.
 - Fix MUI Base vale rule (#45140) @oliviertassinari
 - Fix missing store contributor renaming (b3d1be0) @oliviertassinari
 - Prepare libraries for first v7 alpha release (#45132) @DiegoAndai
+- Fix CHANGELOG vale failure (#45151) @DiegoAndai
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 <!-- generated comparing v6.4.1..master -->
 
-_Jan 30, 2025_
+_Jan 31, 2025_
 
-A big thanks to the 8 contributors who made this release possible.
+A big thanks to the 9 contributors who made this release possible.
 This is the first alpha release of Material UI v7 🎉.
 
 ### `@mui/material@7.0.0-alpha.0`
@@ -17,6 +17,7 @@ This is the first alpha release of Material UI v7 🎉.
 - [SwitchBase] Deprecate `inputProps` and complete slots, slotProps (#45076) @siriwatknp
 - [TextareaAutosize] Temporarily disconnect ResizeObserver to avoid loop error (#44540) @mj12albert
 - [Slider] Narrow onChange value type (#44777) @good-jinu
+- [Snackbar] Add Slots and SlotProps (#45103) @harry-whorlow
 
 ### `@mui/utils@7.0.0-alpha.0`
 
@@ -30,6 +31,7 @@ This is the first alpha release of Material UI v7 🎉.
 - [docs-infra] Move Ukraine banner to the bottom (#45135) @oliviertassinari
 - Fix MUI Base vale rule (#45140) @oliviertassinari
 - Fix missing store contributor renaming (b3d1be0) @oliviertassinari
+- Fix 404 errors (#45137) @oliviertassinari
 - Prepare libraries for first v7 alpha release (#45132) @DiegoAndai
 - Fix CHANGELOG vale failure (#45151) @DiegoAndai
 
@@ -38,7 +40,7 @@ This is the first alpha release of Material UI v7 🎉.
 - Fix `/base-ui` redirect and prune links (#45083) @mj12albert
 - Add v6 to v7 migration guide (#45143) @DiegoAndai
 
-All contributors of this release in alphabetical order: @DiegoAndai, @good-jinu, @Janpot, @joshkel, @mj12albert, @oliviertassinari, @siriwatknp, @ZeeshanTamboli
+All contributors of this release in alphabetical order: @DiegoAndai, @good-jinu, @harry-whorlow, @Janpot, @joshkel, @mj12albert, @oliviertassinari, @siriwatknp, @ZeeshanTamboli
 
 ## Older versions
 

--- a/packages-internal/babel-plugin-minify-errors/package.json
+++ b/packages-internal/babel-plugin-minify-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/internal-babel-plugin-minify-errors",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "author": "MUI Team",
   "description": "This is an internal package not meant for general use.",
   "repository": {

--- a/packages-internal/babel-plugin-resolve-imports/package.json
+++ b/packages-internal/babel-plugin-resolve-imports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/internal-babel-plugin-resolve-imports",
-  "version": "1.0.21",
+  "version": "2.0.0",
   "author": "MUI Team",
   "description": "babel plugin that resolves import specifiers to their actual output file.",
   "main": "./index.js",

--- a/packages-internal/docs-utils/package.json
+++ b/packages-internal/docs-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/internal-docs-utils",
-  "version": "1.0.16",
+  "version": "2.0.0",
   "author": "MUI Team",
   "description": "Utilities for MUI docs. This is an internal package not meant for general use.",
   "main": "./build/index.js",

--- a/packages-internal/scripts/package.json
+++ b/packages-internal/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/internal-scripts",
-  "version": "1.0.34",
+  "version": "2.0.0",
   "author": "MUI Team",
   "description": "Utilities supporting MUI libraries build and docs generation. This is an internal package not meant for general use.",
   "main": "build/index.js",

--- a/packages-internal/test-utils/package.json
+++ b/packages-internal/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/internal-test-utils",
-  "version": "1.0.27",
+  "version": "2.0.0",
   "author": "MUI Team",
   "description": "Utilities for MUI tests. This is an internal package not meant for general use.",
   "main": "./build/index.js",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/internal-markdown",
-  "version": "1.0.26",
+  "version": "2.0.0",
   "author": "MUI Team",
   "description": "MUI markdown parser. This is an internal package not meant for general use.",
   "main": "./index.mjs",


### PR DESCRIPTION
Bump the internal packages major so we can have them be released from either `master` or `v6.x`:

- If released from `master`, they would be `2.x`
- If released from `v6.x`, they would be `1.x`

This allows us to have breaking changes on `master` released under `2.x` without blocking non-breaking changes in `v6.x`, as those could be released under `1.x`. This is important as MUI X will be targeting v6.x for a while.