### PR TITLE
[docs] Fix `element.ref` accessing warning on docs

### DIFF
--- a/examples/material-ui-nextjs-pages-router-ts/src/Link.tsx
+++ b/examples/material-ui-nextjs-pages-router-ts/src/Link.tsx
@@ -3,10 +3,6 @@ import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import NextLink, { LinkProps as NextLinkProps } from 'next/link';
 import MuiLink, { LinkProps as MuiLinkProps } from '@mui/material/Link';
-import { styled } from '@mui/material/styles';
-
-// Add support for the sx prop for consistency with the other branches.
-const Anchor = styled('a')({});
 
 interface NextLinkComposedProps
   extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
@@ -17,17 +13,7 @@ interface NextLinkComposedProps
 
 export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
   function NextLinkComposed(props, ref) {
-    const {
-      to,
-      linkAs,
-      replace,
-      scroll,
-      shallow,
-      prefetch,
-      legacyBehavior = true,
-      locale,
-      ...other
-    } = props;
+    const { to, linkAs, replace, scroll, shallow, prefetch, locale, ...other } = props;
 
     return (
       <NextLink
@@ -39,10 +25,9 @@ export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComp
         shallow={shallow}
         passHref
         locale={locale}
-        legacyBehavior={legacyBehavior}
-      >
-        <Anchor ref={ref} {...other} />
-      </NextLink>
+        ref={ref}
+        {...other}
+      />
     );
   },
 );
@@ -64,7 +49,6 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props,
     as,
     className: classNameProps,
     href,
-    legacyBehavior,
     linkAs: linkAsProp,
     locale,
     noLinkStyle,
@@ -90,7 +74,6 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props,
     scroll,
     shallow,
     prefetch,
-    legacyBehavior,
     locale,
   };
 

--- a/examples/material-ui-nextjs-pages-router/src/Link.js
+++ b/examples/material-ui-nextjs-pages-router/src/Link.js
@@ -3,23 +3,9 @@ import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import NextLink from 'next/link';
 import MuiLink from '@mui/material/Link';
-import { styled } from '@mui/material/styles';
-
-// Add support for the sx prop for consistency with the other branches.
-const Anchor = styled('a')({});
 
 export const NextLinkComposed = React.forwardRef(function NextLinkComposed(props, ref) {
-  const {
-    to,
-    linkAs,
-    replace,
-    scroll,
-    shallow,
-    prefetch,
-    legacyBehavior = true,
-    locale,
-    ...other
-  } = props;
+  const { to, linkAs, replace, scroll, shallow, prefetch, locale, ...other } = props;
 
   return (
     <NextLink
@@ -30,11 +16,10 @@ export const NextLinkComposed = React.forwardRef(function NextLinkComposed(props
       scroll={scroll}
       shallow={shallow}
       passHref
-      legacyBehavior={legacyBehavior}
       locale={locale}
-    >
-      <Anchor ref={ref} {...other} />
-    </NextLink>
+      ref={ref}
+      {...other}
+    />
   );
 });
 
@@ -46,7 +31,6 @@ const Link = React.forwardRef(function Link(props, ref) {
     as,
     className: classNameProps,
     href,
-    legacyBehavior,
     linkAs: linkAsProp,
     locale,
     noLinkStyle,
@@ -72,7 +56,6 @@ const Link = React.forwardRef(function Link(props, ref) {
     scroll,
     shallow,
     prefetch,
-    legacyBehavior,
     locale,
   };
 

--- a/packages/mui-docs/src/Link/Link.tsx
+++ b/packages/mui-docs/src/Link/Link.tsx
@@ -3,20 +3,15 @@ import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import NextLink, { LinkProps as NextLinkProps } from 'next/link';
 import MuiLink, { LinkProps as MuiLinkProps } from '@mui/material/Link';
-import { styled } from '@mui/material/styles';
 import { useUserLanguage } from '../i18n';
 import { useDocsConfig } from '../DocsProvider';
 
 /**
  * File to keep in sync with:
  *
- * - /docs/src/modules/components/Link.tsx
  * - /examples/material-ui-nextjs-pages-router/src/Link.js
  * - /examples/material-ui-nextjs-pages-router-ts/src/Link.tsx
  */
-
-// Add support for the sx prop for consistency with the other branches.
-const Anchor = styled('a')({});
 
 interface NextLinkComposedProps
   extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
@@ -27,17 +22,7 @@ interface NextLinkComposedProps
 
 const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
   function NextLinkComposed(props, ref) {
-    const {
-      to,
-      linkAs,
-      replace,
-      scroll,
-      shallow,
-      prefetch,
-      legacyBehavior = true,
-      locale,
-      ...other
-    } = props;
+    const { to, linkAs, replace, scroll, shallow, prefetch, locale, ...other } = props;
 
     return (
       <NextLink
@@ -49,10 +34,10 @@ const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedPro
         shallow={shallow}
         passHref
         locale={locale}
-        legacyBehavior={legacyBehavior}
-      >
-        <Anchor data-no-markdown-link="true" ref={ref} {...other} />
-      </NextLink>
+        data-no-markdown-link="true"
+        ref={ref}
+        {...other}
+      />
     );
   },
 );
@@ -74,7 +59,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link
     as,
     className: classNameProps,
     href,
-    legacyBehavior,
     linkAs: linkAsProp,
     locale,
     noLinkStyle,
@@ -116,7 +100,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link
     replace,
     scroll,
     shallow,
-    legacyBehavior,
     prefetch,
     locale,
   };


### PR DESCRIPTION
### Problem

Fix this warning (only visible on local):

<img width="700" alt="Screenshot 2025-01-30 at 16 26 04" src="https://github.com/user-attachments/assets/54d9ad0f-757b-4e20-a3b0-27d4bdb073c1" />

To repro, simply checkout master, run docs and visit the homepage.

### Solution

Remove the usage of `legacyBehavior` on the docs' `Link` component ([source](https://github.com/mui/material-ui/blob/master/packages/mui-docs/src/Link/Link.tsx#L52)). This legacy behavior relies on accessing the child ref, causing the warning:

https://github.com/vercel/next.js/blob/38a6d0177eced9b56dfcc58f83662a659195af15/packages/next/src/client/link.tsx#L461

Here's the guide on removing this prop: https://github.com/vercel/next.js/commit/489e65ed98544e69b0afd7e0cfc3f9f6c2b803b7.

I think we can remove it as the only thing we're doing on `NextLinkComposed` is adding an empty styled anchor, which Next's `Link` now does by default:

https://github.com/vercel/next.js/blob/38a6d0177eced9b56dfcc58f83662a659195af15/packages/next/src/client/link.tsx#L621-L623

So:

- For usages with `legacyBehavior = true`, the result is the same
- There shouldn't be any usages with `legacyBehavior = false`, as that would result in a nested anchor which is not valid HTML. I searched confirmed this in [this repo](https://github.com/search?q=repo%3Amui%2Fmaterial-ui+legacyBehavior&type=code), [MUI X's](https://github.com/search?q=repo%3Amui%2Fmui-x%20legacyBehavior&type=code), and [Toolpad's](https://github.com/search?q=repo%3Amui%2Ftoolpad%20legacyBehavior&type=code).

**Note:** I updated the pages router examples accordingly.
