### PR TITLE
[material-ui][LinearProgress][CircularProgress] Add variant overrides for module augumentation

### DIFF
--- a/packages/mui-material/src/CircularProgress/CircularProgress.d.ts
+++ b/packages/mui-material/src/CircularProgress/CircularProgress.d.ts
@@ -6,6 +6,7 @@ import { CircularProgressClasses } from './circularProgressClasses';
 
 export interface CircularProgressPropsColorOverrides {}
 
+export interface CircularProgressPropsVariantOverrides {}
 export interface CircularProgressProps
   extends StandardProps<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
   /**
@@ -55,7 +56,10 @@ export interface CircularProgressProps
    * Use indeterminate when there is no progress value.
    * @default 'indeterminate'
    */
-  variant?: 'determinate' | 'indeterminate';
+  variant?: OverridableStringUnion<
+    'determinate' | 'indeterminate',
+    CircularProgressPropsVariantOverrides
+  >;
 }
 
 /**

--- a/packages/mui-material/src/LinearProgress/LinearProgress.d.ts
+++ b/packages/mui-material/src/LinearProgress/LinearProgress.d.ts
@@ -6,6 +6,8 @@ import { LinearProgressClasses } from './linearProgressClasses';
 
 export interface LinearProgressPropsColorOverrides {}
 
+export interface LinearProgressPropsVariantOverrides {}
+
 export interface LinearProgressProps
   extends StandardProps<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
   /**
@@ -41,7 +43,10 @@ export interface LinearProgressProps
    * Use indeterminate or query when there is no progress value.
    * @default 'indeterminate'
    */
-  variant?: 'determinate' | 'indeterminate' | 'buffer' | 'query';
+  variant?: OverridableStringUnion<
+    'determinate' | 'indeterminate' | 'buffer' | 'query',
+    LinearProgressPropsVariantOverrides
+  >;
 }
 
 /**


### PR DESCRIPTION
fixes https://github.com/mui/material-ui/issues/45144

Adds LinearProgressPropsVariantOverrides to LinearProgress.d.ts and CircularProgressPropsVariantOverrides to CircularProgress.d.ts to enchance module augumentation



- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
