### PR TITLE
[core] Fix corepack and pnpm installation in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,11 @@ commands:
         default: false
         description: 'Set to true if you intend to any browser (for example with playwright).'
     steps:
+      - run:
+          name: Set npm registry public signing keys
+          command: |
+            echo "export COREPACK_INTEGRITY_KEYS='$(curl https://registry.npmjs.org/-/npm/v1/keys | jq -c '{npm: .keys}')'" >> $BASH_ENV
+
       - when:
           condition: << parameters.browsers >>
           steps:


### PR DESCRIPTION
Fixes failing CI pipelines, e.g. https://app.circleci.com/pipelines/github/mui/material-ui/147263/workflows/c200ca76-d4b0-48f4-896f-9717bbdfcec0

It was caused by an upstream issue with corepack: https://github.com/nodejs/corepack/issues/612

See https://github.com/mui/base-ui/pull/1405 for more details, it's the same fix ~

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
