### PR TITLE
[core] Update branch switch tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
             - run:
                 name: '`pnpm dedupe` was run?'
                 command: |
-                  # #default-branch-switch
+                  # #target-branch-reference
                   if [[ $(git diff --name-status master | grep -E 'pnpm-workspace\.yaml|pnpm-lock.yaml|package\.json') == "" ]];
                   then
                       echo "No changes to dependencies detected. Skipping..."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -926,9 +926,10 @@ workflows:
           filters:
             branches:
               only:
+                # #target-branch-reference
                 - master
-                - next
                 - v5.x
+                - v6.x
     jobs:
       - test_unit:
           <<: *default-context
@@ -976,8 +977,9 @@ workflows:
           filters:
             branches:
               only:
+                # #target-branch-reference
                 - master
-                - next
+                - v6.x
     jobs:
       - test_unit:
           <<: *default-context
@@ -1003,8 +1005,9 @@ workflows:
           filters:
             branches:
               only:
+                # #target-branch-reference
                 - master
-                - next
+                - v6.x
     jobs:
       - test_types_next:
           <<: *default-context

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -4,15 +4,17 @@ on:
   # So that PRs touching the same files as the push are updated
   push:
     branches:
+      # #target-branch-reference
       - master
-      - next
+      - v6.x
   # So that the `dirtyLabel` is removed if conflicts are resolved
   # Could put too much strain on rate limit
   # If we hit the rate limit too often remove this event
   pull_request_target:
     branches:
+      # #target-branch-reference
       - master
-      - next
+      - v6.x
     types: [synchronize]
 
 permissions: {}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ cd material-ui
 git remote add upstream https://github.com/mui/material-ui.git
 ```
 
-<!-- #default-branch-switch -->
+<!-- #target-branch-reference -->
 
 3. Synchronize your local `master` branch with the upstream one:
 
@@ -144,7 +144,7 @@ If any of these checks fail, refer to [Checks and how to fix them](#checks-and-h
 
 Make sure the following is true:
 
-<!-- #default-branch-switch -->
+<!-- #target-branch-reference -->
 
 - The branch is targeted at `master` for ongoing development. All tests are passing. Code that lands in `master` must be compatible with the latest stable release. It may contain additional features but no breaking changes. We should be able to release a new minor version from the tip of `master` at any time.
 - If a feature is being added:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 <!-- markdownlint-disable-next-line -->
 <p align="center">
   <a href="https://next.mui.com/core/" rel="noopener" target="_blank"><img width="150" height="133" src="https://mui.com/static/logo.svg" alt="Material UI logo"></a>

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ For how-to questions that don't involve making changes to the code base, please 
 
 ## Examples
 
+<!-- #repo-reference -->
+
 Our documentation features [a collection of example projects](https://github.com/mui/material-ui/tree/master/examples).
 
 ## Premium templates

--- a/docs/data/material/components/about-the-lab/about-the-lab.md
+++ b/docs/data/material/components/about-the-lab/about-the-lab.md
@@ -19,7 +19,7 @@ For a component to be ready to move to the core, the following criteria are cons
 
 To install and save in your `package.json` dependencies, run one of the following commands:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 <codeblock storageKey="package-manager">
 

--- a/docs/data/material/components/icons/icons.md
+++ b/docs/data/material/components/icons/icons.md
@@ -26,7 +26,7 @@ You can [search the full list of these icons](/material-ui/material-icons/).
 
 Run one of the following commands to install it and save it to your `package.json` dependencies:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 <codeblock storageKey="package-manager">
 ```bash npm

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -18,7 +18,7 @@ includes the 2,100+ official [Material Icons](https://fonts.google.com/icons?ico
 It depends on `@mui/material`, which requires Emotion packages.
 Use one of the following commands to install it:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 <codeblock storageKey="package-manager">
 

--- a/docs/data/material/customization/dark-mode/dark-mode.md
+++ b/docs/data/material/customization/dark-mode/dark-mode.md
@@ -175,6 +175,8 @@ Use the `theme.applyStyles()` utility to apply styles for a specific mode.
 
 We recommend using this function over checking `theme.palette.mode` to switch between styles as it has more benefits:
 
+<!-- #repo-reference -->
+
 - It can be used with [Pigment CSS](https://github.com/mui/material-ui/tree/master/packages/pigment-css-react), our in-house zero-runtime CSS-in-JS solution.
 - It is generally more readable and maintainable.
 - It is slightly more performant as it doesn't require to do style recalculation but the bundle size of SSR generated styles is larger.

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -149,6 +149,8 @@ const theme = createTheme({
 
 {{"demo": "ManuallyProvideCustomColor.js", "defaultCodeOpen": false}}
 
+<!-- #repo-reference -->
+
 If you need to manipulate colors, `@mui/material/styles` provides [a set of utilities](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/index.d.ts#L52-L67) to help with this.
 The following example uses the `alpha()` and `getContrastRatio()` utilities to define tokens using opacity:
 

--- a/docs/data/material/getting-started/example-projects/example-projects.md
+++ b/docs/data/material/getting-started/example-projects/example-projects.md
@@ -4,6 +4,8 @@
 
 ## Official integrations
 
+<!-- #repo-reference -->
+
 The following integration examples are available in the [`/examples`](https://github.com/mui/material-ui/tree/master/examples) folder of the Material UI GitHub repository.
 These examples feature Material UI paired with other popular React libraries and frameworks, so you can skip the initial setup steps and jump straight into building.
 

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -156,7 +156,7 @@ For instance, via Google Web Fonts:
 
 You can start using Material UI right away with minimal front-end infrastructure by installing it via CDN, which is a great option for rapid prototyping.
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 Follow [this CDN example](https://github.com/mui/material-ui/tree/master/examples/material-ui-via-cdn) to get started.
 

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -6,7 +6,7 @@
 
 Run one of the following commands to add Material UI to your project:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 <codeblock storageKey="package-manager">
 

--- a/docs/data/material/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/data/material/getting-started/supported-platforms/supported-platforms.md
@@ -13,7 +13,7 @@ You don't need to provide any JavaScript polyfill as it manages unsupported brow
 | :----- | :------ | :----- | :------------- | :----------- |
 | >= 121 | >= 115  | >= 109 | >= 15.4        | >= 15.4      |
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 An extensive list can be found in our [.browserlistrc](https://github.com/mui/material-ui/blob/-/.browserslistrc#L12-L27) (check the `stable` entry).
 

--- a/docs/data/material/getting-started/templates/blog/README.md
+++ b/docs/data/material/getting-started/templates/blog/README.md
@@ -10,6 +10,6 @@
 
 ## Demo
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 View the demo at https://next.mui.com/material-ui/getting-started/templates/blog/.

--- a/docs/data/material/getting-started/templates/blog/README.md
+++ b/docs/data/material/getting-started/templates/blog/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 1. Copy these folders (`blog` and `shared-theme`) into your project, or one of the [example projects](https://github.com/mui/material-ui/tree/master/examples).
 2. Make sure your project has the required dependencies: @mui/material, @mui/icons-material, @emotion/styled, @emotion/react, markdown-to-jsx.

--- a/docs/data/material/getting-started/templates/checkout/README.md
+++ b/docs/data/material/getting-started/templates/checkout/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 1. Copy these folders (`checkout` and `shared-theme`) into your project, or one of the [example projects](https://github.com/mui/material-ui/tree/master/examples).
 2. Make sure your project has the required dependencies: @mui/material, @emotion/styled, @emotion/react.

--- a/docs/data/material/getting-started/templates/checkout/README.md
+++ b/docs/data/material/getting-started/templates/checkout/README.md
@@ -10,6 +10,6 @@
 
 ## Demo
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 View the demo at https://next.mui.com/material-ui/getting-started/templates/checkout/.

--- a/docs/data/material/getting-started/templates/dashboard/README.md
+++ b/docs/data/material/getting-started/templates/dashboard/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 1. Copy these folders (`dashboard` and `shared-theme`) into your project, or one of the [example projects](https://github.com/mui/material-ui/tree/master/examples).
 2. Make sure your project has the required dependencies: @mui/material, @mui/icons-material, @emotion/styled, @emotion/react, @mui/x-charts, @mui/x-date-pickers, @mui/x-data-grid, @mui/x-tree-view, dayjs

--- a/docs/data/material/getting-started/templates/dashboard/README.md
+++ b/docs/data/material/getting-started/templates/dashboard/README.md
@@ -10,6 +10,6 @@
 
 ## Demo
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 View the demo at https://next.mui.com/material-ui/getting-started/templates/dashboard/.

--- a/docs/data/material/getting-started/templates/marketing-page/README.md
+++ b/docs/data/material/getting-started/templates/marketing-page/README.md
@@ -10,6 +10,6 @@
 
 ## Demo
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 View the demo at https://next.mui.com/material-ui/getting-started/templates/marketing-page/.

--- a/docs/data/material/getting-started/templates/marketing-page/README.md
+++ b/docs/data/material/getting-started/templates/marketing-page/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 1. Copy these folders (`marketing-page` and `shared-theme`) into your project, or one of the [example projects](https://github.com/mui/material-ui/tree/master/examples).
 2. Make sure your project has the required dependencies: @mui/material, @mui/icons-material, @emotion/styled, @emotion/react.

--- a/docs/data/material/getting-started/templates/sign-in-side/README.md
+++ b/docs/data/material/getting-started/templates/sign-in-side/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 1. Copy these folders (`sign-in-side` and `shared-theme`) into your project, or one of the [example projects](https://github.com/mui/material-ui/tree/master/examples).
 2. Make sure your project has the required dependencies: @mui/material, @mui/icons-material, @emotion/styled, @emotion/react.

--- a/docs/data/material/getting-started/templates/sign-in-side/README.md
+++ b/docs/data/material/getting-started/templates/sign-in-side/README.md
@@ -10,6 +10,6 @@
 
 ## Demo
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 View the demo at https://next.mui.com/material-ui/getting-started/templates/sign-in-side/.

--- a/docs/data/material/getting-started/templates/sign-in/README.md
+++ b/docs/data/material/getting-started/templates/sign-in/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 1. Copy these folders (`sign-in` and `shared-theme`) into your project, or one of the [example projects](https://github.com/mui/material-ui/tree/master/examples).
 2. Make sure your project has the required dependencies: @mui/material, @mui/icons-material, @emotion/styled, @emotion/react.

--- a/docs/data/material/getting-started/templates/sign-in/README.md
+++ b/docs/data/material/getting-started/templates/sign-in/README.md
@@ -10,6 +10,6 @@
 
 ## Demo
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 View the demo at https://next.mui.com/material-ui/getting-started/templates/sign-in/.

--- a/docs/data/material/getting-started/templates/sign-up/README.md
+++ b/docs/data/material/getting-started/templates/sign-up/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 1. Copy these folders (`sign-up` and `shared-theme`) into your project, or one of the [example projects](https://github.com/mui/material-ui/tree/master/examples).
 2. Make sure your project has the required dependencies: @mui/material, @mui/icons-material, @emotion/styled, @emotion/react.

--- a/docs/data/material/getting-started/templates/sign-up/README.md
+++ b/docs/data/material/getting-started/templates/sign-up/README.md
@@ -10,6 +10,6 @@
 
 ## Demo
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 View the demo at https://next.mui.com/material-ui/getting-started/templates/sign-up/.

--- a/docs/data/material/guides/localization/localization.md
+++ b/docs/data/material/guides/localization/localization.md
@@ -96,7 +96,7 @@ The [Data Grid and Data Grid Pro](/x/react-data-grid/) components have their own
 | Urdu (Pakistan)         | ur-PK               | `urPK`      |
 | Vietnamese              | vi-VN               | `viVN`      |
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 You can [find the source](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/locale/index.ts) in the GitHub repository.
 

--- a/docs/data/material/guides/typescript/typescript.md
+++ b/docs/data/material/guides/typescript/typescript.md
@@ -4,7 +4,7 @@
 
 ## Minimum configuration
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 Material UI requires a minimum version of TypeScript 4.7. Have a look at the [Create React App with TypeScript](https://github.com/mui/material-ui/tree/master/examples/material-ui-cra-ts) example.
 

--- a/docs/data/material/integrations/interoperability/interoperability.md
+++ b/docs/data/material/integrations/interoperability/interoperability.md
@@ -272,7 +272,7 @@ export default function GlobalCssSliderDeep() {
 By default, Material UI components come with Emotion as their style engine.
 If, however, you would like to use styled-components, you can configure your app by following the [styled-components guide](/material-ui/integrations/styled-components/) or starting with one of the example projects:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 - [Create React App with styled-components](https://github.com/mui/material-ui/tree/master/examples/material-ui-cra-styled-components)
 - [Create React App with styled-components and TypeScript](https://github.com/mui/material-ui/tree/master/examples/material-ui-cra-styled-components-ts)

--- a/docs/data/material/integrations/interoperability/interoperability.md
+++ b/docs/data/material/integrations/interoperability/interoperability.md
@@ -580,6 +580,8 @@ It works exactly like styled components. You can [use the same guide](/material-
 
 ### Setup
 
+<!-- #repo-reference -->
+
 If you are used to Tailwind CSS and want to use it together with the Material UI components, you can start by cloning the [Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/material-ui-cra-tailwind-ts) example project.
 If you use a different framework, or already have set up your project, follow these steps:
 

--- a/docs/data/material/integrations/styled-components/styled-components.md
+++ b/docs/data/material/integrations/styled-components/styled-components.md
@@ -30,7 +30,7 @@ To use styled-components, you need to configure your bundler to replace it with 
 
 If you're using yarn, you can configure it using a package resolution:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```diff title="package.json"
  {

--- a/docs/data/material/integrations/styled-components/styled-components.md
+++ b/docs/data/material/integrations/styled-components/styled-components.md
@@ -100,7 +100,7 @@ For TypeScript, you must also update the `tsconfig.json` as shown here:
 
 We provide boilerplate examples of Create React App with Material UI and styled-components in both JavaScript and TypeScript:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 - [Material UI + CRA + styled-components (JavaScript)](https://github.com/mui/material-ui/tree/master/examples/material-ui-cra-styled-components)
 - [Material UI + CRA + styled-components (TypeScript)](https://github.com/mui/material-ui/tree/master/examples/material-ui-cra-styled-components-ts)

--- a/docs/data/styles/basics/basics.md
+++ b/docs/data/styles/basics/basics.md
@@ -16,7 +16,7 @@ See the [v5 migration docs](/material-ui/migration/migrating-from-jss/) for deta
 
 To install and save in your `package.json` dependencies, run:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npm install @mui/styles@next

--- a/docs/data/system/experimental-api/css-theme-variables/css-theme-variables.md
+++ b/docs/data/system/experimental-api/css-theme-variables/css-theme-variables.md
@@ -189,6 +189,8 @@ Now, the Button's `backgroundColor`, `borderColor` and text `color` values will 
 For framework- or language-specific setup instructions, see [CSS theme variables—Usage—Server-side rendering](/material-ui/customization/css-theme-variables/usage/).
 For framework or language specific setup, see [this](/material-ui/customization/css-theme-variables/usage/)
 
+<!-- #repo-reference -->
+
 See the complete usage of `createCssVarsProvider` in [Material UI](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/ThemeProviderWithVars.tsx) and [Joy UI](https://github.com/mui/material-ui/blob/master/packages/mui-joy/src/styles/CssVarsProvider.tsx).
 
 ## API

--- a/docs/data/system/getting-started/installation/installation.md
+++ b/docs/data/system/getting-started/installation/installation.md
@@ -39,7 +39,7 @@ Please note that [react](https://www.npmjs.com/package/react) is a peer dependen
 MUI System uses [Emotion](https://emotion.sh/docs/introduction) as its default styling engine.
 If you want to use [styled-components](https://styled-components.com/) instead, run one of the following commands:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 <codeblock storageKey="package-manager">
 

--- a/docs/data/system/getting-started/usage/usage.md
+++ b/docs/data/system/getting-started/usage/usage.md
@@ -156,7 +156,7 @@ Runtime performance takes a hit.
 | c. Render 1,000 styled components | `<StyledDiv>`         |           181ms |
 | d. Render 1,000 Box               | `<Box sx={…}>`        |           296ms |
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 Visit the [benchmark folder](https://github.com/mui/material-ui/tree/master/benchmark/browser) for a reproduction of the metrics above.
 

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -189,7 +189,7 @@ export default withDocsInfra({
     // docs-infra
     LIB_VERSION: pkg.version,
     SOURCE_CODE_REPO: 'https://github.com/mui/material-ui',
-    SOURCE_GITHUB_BRANCH: 'master', // #default-branch-switch
+    SOURCE_GITHUB_BRANCH: 'master', // #target-branch-reference
     GITHUB_TEMPLATE_DOCS_FEEDBACK: '4.docs-feedback.yml',
     BUILD_ONLY_ENGLISH_LOCALE: String(buildOnlyEnglishLocale),
     // MUI Core related

--- a/docs/scripts/reportBrokenLinks.js
+++ b/docs/scripts/reportBrokenLinks.js
@@ -45,7 +45,7 @@ Object.keys(usedLinks)
   .sort()
   .forEach((linkKey) => {
     //
-    // <!-- #default-branch-switch -->
+    // <!-- #host-reference -->
     //
     write(`- https://next.mui.com${linkKey}`);
     console.log(`https://next.mui.com${linkKey}`);

--- a/docs/src/modules/components/Head.tsx
+++ b/docs/src/modules/components/Head.tsx
@@ -5,7 +5,7 @@ import { LANGUAGES_SSR } from 'docs/config';
 import { useUserLanguage, useTranslate } from '@mui/docs/i18n';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 
-// #default-branch-switch
+// #host-reference
 const HOST = process.env.PULL_REQUEST_ID
   ? `https://deploy-preview-${process.env.PULL_REQUEST_ID}--${process.env.NETLIFY_SITE_NAME}.netlify.app`
   : 'https://next.mui.com';
@@ -56,7 +56,7 @@ export default function Head(props: HeadProps) {
       <meta property="og:ttl" content="604800" />
       {/* Algolia */}
       <meta name="docsearch:language" content={userLanguage} />
-      {/* #default-branch-switch */}
+      {/* #host-reference */}
       <meta name="docsearch:version" content="master" />
       {disableAlternateLocale
         ? null

--- a/docs/src/modules/components/MaterialUIExampleCollection.js
+++ b/docs/src/modules/components/MaterialUIExampleCollection.js
@@ -8,7 +8,7 @@ import Link from '@mui/material/Link';
 import ChevronRightRoundedIcon from '@mui/icons-material/ChevronRightRounded';
 import CloudRoundedIcon from '@mui/icons-material/CloudRounded';
 
-// #default-branch-switch
+// #repo-reference
 const examples = [
   {
     name: 'Next.js App Router',

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -21,6 +21,7 @@ async function fetchNotifications() {
     const items = (await import('../../../notifications.json')).default;
     return items;
   }
+  // #repo-reference
   const response = await fetch(
     'https://raw.githubusercontent.com/mui/material-ui/master/docs/notifications.json',
   );

--- a/docs/src/modules/sandbox/CodeSandbox.test.js
+++ b/docs/src/modules/sandbox/CodeSandbox.test.js
@@ -33,6 +33,7 @@ describe('CodeSandbox', () => {
             'https://github.com/mui/material-ui/blob/v5.7.0/docs/data/material/components/buttons/BasicButtons.js',
           dependencies: {
             react: 'latest',
+            // #npm-tag-reference
             '@mui/material': 'next',
             'react-dom': 'latest',
             '@emotion/react': 'latest',
@@ -123,6 +124,7 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
             'https://github.com/mui/material-ui/blob/v5.7.0/docs/data/material/components/buttons/BasicButtons.tsx',
           dependencies: {
             react: 'latest',
+            // #npm-tag-reference
             '@mui/material': 'next',
             'react-dom': 'latest',
             '@emotion/react': 'latest',
@@ -230,6 +232,7 @@ ReactDOM.createRoot(document.querySelector("#root")!).render(
     expect(result.dependencies).to.deep.equal({
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
+      // #npm-tag-reference
       '@mui/material': 'next',
       '@types/react': 'latest',
       '@types/react-dom': 'latest',

--- a/docs/src/modules/sandbox/Dependencies.test.js
+++ b/docs/src/modules/sandbox/Dependencies.test.js
@@ -40,6 +40,7 @@ const styles = theme => ({
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
       '@foo-bar/bip': 'latest',
+      // #npm-tag-reference
       '@mui/material': 'next',
       '@mui/base': 'latest',
       'prop-types': 'latest',
@@ -71,6 +72,7 @@ const suggestions = [
       'react-dom': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
+      // #npm-tag-reference
       '@mui/material': 'next',
       '@unexisting/thing': 'latest',
       'autosuggest-highlight': 'latest',
@@ -100,6 +102,7 @@ import { LocalizationProvider as MuiPickersLocalizationProvider, KeyboardTimePic
       'prop-types': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
+      // #npm-tag-reference
       '@mui/material': 'next',
       '@mui/lab': 'next',
     });
@@ -127,6 +130,7 @@ import 'exceljs';
       'prop-types': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
+      // #npm-tag-reference
       '@mui/material': 'next',
       '@mui/lab': 'next',
       exceljs: 'latest',
@@ -146,6 +150,7 @@ import 'exceljs';
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
       '@foo-bar/bip': 'latest',
+      // #npm-tag-reference
       '@mui/material': 'next',
       '@mui/base': 'latest',
       '@types/foo-bar__bip': 'latest',
@@ -167,6 +172,7 @@ import 'exceljs';
       'react-dom': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
+      // #npm-tag-reference
       '@mui/material': 'next',
       '@types/react-dom': 'latest',
       '@types/react': 'latest',
@@ -195,6 +201,7 @@ import {
       'react-dom': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
+      // #npm-tag-reference
       '@mui/material': 'next',
       '@mui/lab': 'next',
     });
@@ -215,6 +222,7 @@ import lab from '@mui/lab';
       'react-dom': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
+      // #npm-tag-reference
       '@mui/material': 'next',
       '@mui/lab': 'next',
     });

--- a/docs/src/modules/sandbox/Dependencies.ts
+++ b/docs/src/modules/sandbox/Dependencies.ts
@@ -54,7 +54,7 @@ export default function SandboxDependencies(demo: Demo, options?: { commitRef?: 
       if (['joy', 'base'].includes(packageName)) {
         return 'latest';
       }
-      // #default-branch-switch
+      // #npm-tag-reference
       return 'next';
     }
     const shortSha = commitRef.slice(0, 8);

--- a/docs/src/modules/sandbox/StackBlitz.test.js
+++ b/docs/src/modules/sandbox/StackBlitz.test.js
@@ -83,6 +83,7 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
       },
       dependencies: {
         react: 'latest',
+        // #npm-tag-reference
         '@mui/material': 'next',
         'react-dom': 'latest',
         '@emotion/react': 'latest',
@@ -186,6 +187,7 @@ ReactDOM.createRoot(document.querySelector("#root")!).render(
       },
       dependencies: {
         react: 'latest',
+        // #npm-tag-reference
         '@mui/material': 'next',
         'react-dom': 'latest',
         '@emotion/react': 'latest',

--- a/examples/base-ui-cra-ts/README.md
+++ b/examples/base-ui-cra-ts/README.md
@@ -8,7 +8,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/base-ui-cra-ts
@@ -24,7 +24,7 @@ npm start
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/base-ui-cra-ts)
 

--- a/examples/base-ui-cra/README.md
+++ b/examples/base-ui-cra/README.md
@@ -8,7 +8,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/base-ui-cra
@@ -24,7 +24,7 @@ npm start
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/base-ui-cra)
 

--- a/examples/base-ui-nextjs-tailwind-ts/README.md
+++ b/examples/base-ui-nextjs-tailwind-ts/README.md
@@ -6,7 +6,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped using [`create-nex
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/base-ui-nextjs-tailwind-ts
@@ -22,7 +22,7 @@ npm run dev
 
 or
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/base-ui-nextjs-tailwind-ts)
 

--- a/examples/base-ui-vite-tailwind-ts/README.md
+++ b/examples/base-ui-vite-tailwind-ts/README.md
@@ -24,7 +24,7 @@ npm start
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/base-ui-vite-tailwind-ts)
 

--- a/examples/base-ui-vite-tailwind/README.md
+++ b/examples/base-ui-vite-tailwind/README.md
@@ -24,7 +24,7 @@ npm start
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/base-ui-vite-tailwind)
 

--- a/examples/joy-ui-cra-ts/README.md
+++ b/examples/joy-ui-cra-ts/README.md
@@ -6,7 +6,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/joy-ui-cra-ts
@@ -22,7 +22,7 @@ npm start
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/joy-ui-cra-ts)
 

--- a/examples/joy-ui-cra-ts/README.md
+++ b/examples/joy-ui-cra-ts/README.md
@@ -30,7 +30,7 @@ or:
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://mui.com/joy-ui/getting-started/templates/) section.

--- a/examples/joy-ui-nextjs-ts/README.md
+++ b/examples/joy-ui-nextjs-ts/README.md
@@ -6,7 +6,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/joy-ui-nextjs-ts
@@ -24,7 +24,7 @@ Open [http://localhost:3000](http://localhost:3000) with your web browser to see
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/joy-ui-nextjs-ts)
 

--- a/examples/joy-ui-nextjs-ts/README.md
+++ b/examples/joy-ui-nextjs-ts/README.md
@@ -39,7 +39,7 @@ To learn more about this example:
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://mui.com/joy-ui/getting-started/templates/) section.

--- a/examples/joy-ui-vite-ts/README.md
+++ b/examples/joy-ui-vite-ts/README.md
@@ -8,7 +8,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/joy-ui-vite-ts
@@ -24,7 +24,7 @@ npm run dev
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/joy-ui-vite-ts)
 

--- a/examples/joy-ui-vite-ts/README.md
+++ b/examples/joy-ui-vite-ts/README.md
@@ -37,7 +37,7 @@ It includes `@mui/joy` and it's peer dependencies.
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://mui.com/joy-ui/getting-started/templates/) section.

--- a/examples/material-ui-cra-styled-components-ts/README.md
+++ b/examples/material-ui-cra-styled-components-ts/README.md
@@ -20,7 +20,7 @@ Alternatively, to skip this configuration, you can set `skipLibCheck: true` in y
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/material-ui-cra-styled-components-ts
@@ -36,7 +36,7 @@ npm start
 
 ## CodeSandbox
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/p/sandbox/github/mui/material-ui/tree/master/examples/material-ui-cra-styled-components-ts).
 

--- a/examples/material-ui-cra-styled-components-ts/README.md
+++ b/examples/material-ui-cra-styled-components-ts/README.md
@@ -40,6 +40,8 @@ npm start
 
 Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/p/sandbox/github/mui/material-ui/tree/master/examples/material-ui-cra-styled-components-ts).
 
+<!-- #host-reference -->
+
 The following link leverages this demo: https://next.mui.com/material-ui/integrations/interoperability/#change-the-default-styled-engine with Parcel's alias feature within the `package.json`.
 
 [![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/styled-components-interoperability-w9z9d)
@@ -54,7 +56,7 @@ Note, the version 5 of `@mui/styled-engine-sc` is compatible with version 5 of `
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-cra-styled-components/README.md
+++ b/examples/material-ui-cra-styled-components/README.md
@@ -24,6 +24,8 @@ npm start
 
 Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/p/sandbox/github/mui/material-ui/tree/master/examples/material-ui-cra-styled-components).
 
+<!-- #host-reference -->
+
 The following link leverages this demo: https://next.mui.com/material-ui/integrations/interoperability/#change-the-default-styled-engine with Parcel's alias feature within the `package.json`.
 
 [![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/styled-components-interoperability-w9z9d)
@@ -38,7 +40,7 @@ Note, the version 5 of `@mui/styled-engine-sc` is compatible with version 5 of `
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-cra-styled-components/README.md
+++ b/examples/material-ui-cra-styled-components/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/material-ui-cra-styled-components
@@ -20,7 +20,7 @@ npm start
 
 ## CodeSandbox
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 Note that CodeSandbox is not supporting react-app-rewired, yet you can [still see the code](https://codesandbox.io/p/sandbox/github/mui/material-ui/tree/master/examples/material-ui-cra-styled-components).
 

--- a/examples/material-ui-cra-tailwind-ts/README.md
+++ b/examples/material-ui-cra-tailwind-ts/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/material-ui-cra-tailwind-ts
@@ -20,7 +20,7 @@ npm start
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-ui-cra-tailwind-ts)
 

--- a/examples/material-ui-cra-tailwind-ts/README.md
+++ b/examples/material-ui-cra-tailwind-ts/README.md
@@ -31,7 +31,7 @@ It includes `@mui/material` and its peer dependencies, including [Emotion](https
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-cra-ts/README.md
+++ b/examples/material-ui-cra-ts/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/material-ui-cra-ts
@@ -20,7 +20,7 @@ npm start
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/mui/material-ui/tree/master/examples/material-ui-cra-ts)
 

--- a/examples/material-ui-cra-ts/README.md
+++ b/examples/material-ui-cra-ts/README.md
@@ -28,7 +28,7 @@ or:
 
 ## The idea behind the example
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 This example demonstrates how you can use Material UI with [Create React App](https://github.com/facebookincubator/create-react-app) in [TypeScript](https://github.com/Microsoft/TypeScript).
 It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
@@ -36,7 +36,7 @@ If you prefer, you can [use styled-components instead](https://next.mui.com/mate
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-cra/README.md
+++ b/examples/material-ui-cra/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/material-ui-cra
@@ -20,7 +20,7 @@ npm start
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/mui/material-ui/tree/master/examples/material-ui-cra)
 

--- a/examples/material-ui-cra/README.md
+++ b/examples/material-ui-cra/README.md
@@ -28,7 +28,7 @@ or:
 
 ## The idea behind the example
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 This example demonstrates how you can use [Create React App](https://github.com/facebookincubator/create-react-app) with Material UI.
 It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
@@ -36,7 +36,7 @@ If you prefer, you can [use styled-components instead](https://next.mui.com/mate
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-express-ssr/README.md
+++ b/examples/material-ui-express-ssr/README.md
@@ -28,7 +28,7 @@ or:
 
 ## The idea behind the example
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 This is the reference implementation of the [Server Rendering tutorial](https://next.mui.com/material-ui/guides/server-rendering/).
 
@@ -37,7 +37,7 @@ If you prefer, you can [use styled-components instead](https://next.mui.com/mate
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-express-ssr/README.md
+++ b/examples/material-ui-express-ssr/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/material-ui-express-ssr
@@ -20,7 +20,7 @@ npm run start
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-ui-express-ssr)
 

--- a/examples/material-ui-gatsby/README.md
+++ b/examples/material-ui-gatsby/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/material-ui-gatsby

--- a/examples/material-ui-gatsby/README.md
+++ b/examples/material-ui-gatsby/README.md
@@ -20,7 +20,7 @@ npm run develop
 
 ## The idea behind the example
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 The project uses [Gatsby](https://github.com/gatsbyjs/gatsby), which is a static site generator for React.
 It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
@@ -28,7 +28,7 @@ If you prefer, you can [use styled-components instead](https://next.mui.com/mate
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-nextjs-pages-router-ts/README.md
+++ b/examples/material-ui-nextjs-pages-router-ts/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/material-ui-nextjs-pages-router-ts
@@ -20,7 +20,7 @@ npm run dev
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-ui-nextjs-pages-router-ts)
 
@@ -40,7 +40,7 @@ If you prefer, you can [use styled-components instead](https://next.mui.com/mate
 
 ## The link component
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 <!-- #host-reference -->
 
 The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/material-ui-nextjs-pages-router-ts) provides an adapter for the use of [Next.js's Link component](https://nextjs.org/docs/pages/api-reference/components/link) with Material UI.

--- a/examples/material-ui-nextjs-pages-router-ts/README.md
+++ b/examples/material-ui-nextjs-pages-router-ts/README.md
@@ -32,7 +32,7 @@ or:
 As of Next.js 13.4, the newer App Router pattern is stable.
 We recommend starting new projects with the [Material UI with Next.js (App Router) example](https://github.com/mui/material-ui/tree/master/examples/material-ui-nextjs-ts) unless you need (or prefer) the Pages Router.
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 The project uses [Next.js](https://github.com/vercel/next.js), which is a framework for server-rendered React apps.
 It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
@@ -41,13 +41,14 @@ If you prefer, you can [use styled-components instead](https://next.mui.com/mate
 ## The link component
 
 <!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/material-ui-nextjs-pages-router-ts) provides an adapter for the use of [Next.js's Link component](https://nextjs.org/docs/pages/api-reference/components/link) with Material UI.
 More information [in the documentation](https://next.mui.com/material-ui/integrations/routing/#next-js-pages-router).
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-nextjs-pages-router/README.md
+++ b/examples/material-ui-nextjs-pages-router/README.md
@@ -32,7 +32,7 @@ or:
 As of Next.js 13.4, the newer App Router pattern is stable.
 We recommend starting new projects with the [Material UI with Next.js (App Router) example](https://github.com/mui/material-ui/tree/master/examples/material-ui-nextjs) unless you need (or prefer) the Pages Router.
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 The project uses [Next.js](https://github.com/vercel/next.js), which is a framework for server-rendered React apps.
 It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
@@ -41,13 +41,14 @@ If you prefer, you can [use styled-components instead](https://next.mui.com/mate
 ## The Link component
 
 <!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/material-ui-nextjs-pages-router) provides an adapter for the use of [Next.js's Link component](https://nextjs.org/docs/pages/api-reference/components/link) with Material UI.
 More information [in the documentation](https://next.mui.com/material-ui/integrations/routing/#next-js-pages-router).
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-nextjs-pages-router/README.md
+++ b/examples/material-ui-nextjs-pages-router/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/material-ui-nextjs-pages-router
@@ -20,7 +20,7 @@ npm run dev
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-ui-nextjs-pages-router)
 
@@ -40,7 +40,7 @@ If you prefer, you can [use styled-components instead](https://next.mui.com/mate
 
 ## The Link component
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 <!-- #host-reference -->
 
 The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/material-ui-nextjs-pages-router) provides an adapter for the use of [Next.js's Link component](https://nextjs.org/docs/pages/api-reference/components/link) with Material UI.

--- a/examples/material-ui-nextjs-ts-v4-v5-migration/README.md
+++ b/examples/material-ui-nextjs-ts-v4-v5-migration/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/material-ui-nextjs-ts-v4-v5-migration
@@ -20,7 +20,7 @@ npm run dev
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-ui-nextjs-ts-v4-v5-migration)
 

--- a/examples/material-ui-nextjs-ts/README.md
+++ b/examples/material-ui-nextjs-ts/README.md
@@ -6,7 +6,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped using [`create-nex
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/material-ui-nextjs-ts
@@ -24,7 +24,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-ui-nextjs-ts)
 

--- a/examples/material-ui-nextjs-ts/README.md
+++ b/examples/material-ui-nextjs-ts/README.md
@@ -34,14 +34,14 @@ or:
 
 To learn more about this example:
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 - [Next.js documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Customizing Material UI](https://next.mui.com/material-ui/customization/how-to-customize/) - approaches to customizing Material UI.
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-nextjs/README.md
+++ b/examples/material-ui-nextjs/README.md
@@ -34,14 +34,14 @@ or:
 
 To learn more about this example:
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 - [Next.js documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Customizing Material UI](https://next.mui.com/material-ui/customization/how-to-customize/) - approaches to customizing Material UI.
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-nextjs/README.md
+++ b/examples/material-ui-nextjs/README.md
@@ -6,7 +6,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped using [`create-nex
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/material-ui-nextjs
@@ -24,7 +24,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-ui-nextjs)
 

--- a/examples/material-ui-pigment-css-nextjs-ts/README.md
+++ b/examples/material-ui-pigment-css-nextjs-ts/README.md
@@ -34,14 +34,14 @@ or:
 
 To learn more about this example:
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 - [Next.js documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Customizing Material UI](https://next.mui.com/material-ui/customization/how-to-customize/) - approaches to customizing Material UI.
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-pigment-css-nextjs-ts/README.md
+++ b/examples/material-ui-pigment-css-nextjs-ts/README.md
@@ -6,7 +6,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped using [`create-nex
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/material-ui-pigment-css-nextjs-ts
@@ -24,7 +24,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-ui-pigment-css-nextjs-ts)
 

--- a/examples/material-ui-pigment-css-vite-ts/README.md
+++ b/examples/material-ui-pigment-css-vite-ts/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/material-ui-pigment-css-vite-ts
@@ -20,7 +20,7 @@ npm run dev
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-ui-pigment-css-vite-ts)
 

--- a/examples/material-ui-pigment-css-vite-ts/README.md
+++ b/examples/material-ui-pigment-css-vite-ts/README.md
@@ -33,7 +33,7 @@ It includes `@mui/material` and [Pigment CSS](https://github.com/mui/pigment-cs
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-preact/README.md
+++ b/examples/material-ui-preact/README.md
@@ -26,13 +26,13 @@ This example uses CRA with `react-app-rewired` for adding webpack aliases for Pr
 
 It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 If you prefer, you can [use styled-components instead](https://next.mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-preact/README.md
+++ b/examples/material-ui-preact/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/material-ui-preact

--- a/examples/material-ui-remix-ts/README.md
+++ b/examples/material-ui-remix-ts/README.md
@@ -28,7 +28,7 @@ or:
 
 ## The idea behind the example
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 The project uses [Remix](https://remix.run/), which is a full-stack web framework.
 It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
@@ -36,7 +36,7 @@ If you prefer, you can [use styled-components instead](https://next.mui.com/mate
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-remix-ts/README.md
+++ b/examples/material-ui-remix-ts/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/material-ui-remix-ts
@@ -20,7 +20,7 @@ npm run dev
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-ui-remix-ts)
 

--- a/examples/material-ui-via-cdn/README.md
+++ b/examples/material-ui-via-cdn/README.md
@@ -24,7 +24,7 @@ You can start using Material UI with minimal front-end infrastructure, which is
 We discourage using this approach in production, though.
 The client has to download the entire library, regardless of which components are used, affecting performance and bandwidth usage.
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [The live preview.](https://raw.githack.com/mui/material-ui/master/examples/material-ui-via-cdn/index.html)
 

--- a/examples/material-ui-via-cdn/README.md
+++ b/examples/material-ui-via-cdn/README.md
@@ -30,7 +30,7 @@ The client has to download the entire library, regardless of which components ar
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-via-cdn/README.md
+++ b/examples/material-ui-via-cdn/README.md
@@ -4,6 +4,8 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
+<!-- #repo-reference -->
+
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/material-ui-via-cdn
 cd material-ui-via-cdn

--- a/examples/material-ui-vite-ts/README.md
+++ b/examples/material-ui-vite-ts/README.md
@@ -33,7 +33,7 @@ It includes `@mui/material` and its peer dependencies, including [Emotion](https
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/examples/material-ui-vite-ts/README.md
+++ b/examples/material-ui-vite-ts/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/material-ui-vite-ts
@@ -20,7 +20,7 @@ npm run dev
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-ui-vite-ts)
 

--- a/examples/material-ui-vite/README.md
+++ b/examples/material-ui-vite/README.md
@@ -4,7 +4,7 @@
 
 Download the example [or clone the repo](https://github.com/mui/material-ui):
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 ```bash
 curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2 material-ui-master/examples/material-ui-vite
@@ -20,7 +20,7 @@ npm run dev
 
 or:
 
-<!-- #default-branch-switch -->
+<!-- #repo-reference -->
 
 [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-ui-vite)
 

--- a/examples/material-ui-vite/README.md
+++ b/examples/material-ui-vite/README.md
@@ -33,7 +33,7 @@ It includes `@mui/material` and its peer dependencies, including [Emotion](https
 
 ## What's next?
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://next.mui.com/material-ui/getting-started/templates/) section.

--- a/packages/api-docs-builder-core/baseUi/projectSettings.ts
+++ b/packages/api-docs-builder-core/baseUi/projectSettings.ts
@@ -46,6 +46,6 @@ export const projectSettings: ProjectSettings = {
   translationPagesDirectory: 'docs/translations/api-docs-base',
   generateClassName: generateUtilityClass,
   isGlobalClassName: isGlobalState,
-  // #default-branch-switch
+  // #host-reference
   baseApiUrl: 'https://mui.com',
 };

--- a/packages/api-docs-builder-core/materialUi/projectSettings.ts
+++ b/packages/api-docs-builder-core/materialUi/projectSettings.ts
@@ -52,6 +52,6 @@ export const projectSettings: ProjectSettings = {
   translationPagesDirectory: 'docs/translations/api-docs',
   generateClassName,
   isGlobalClassName: isGlobalState,
-  // #default-branch-switch
+  // #host-reference
   baseApiUrl: 'https://next.mui.com',
 };

--- a/packages/mui-base/README.md
+++ b/packages/mui-base/README.md
@@ -17,7 +17,7 @@ npm install @mui/base
 
 ## Documentation
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 Visit [https://mui.com/base-ui/](https://mui.com/base-ui/) to view the full documentation.
 

--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -11,10 +11,10 @@ Some of the codemods also run [postcss](https://github.com/postcss/postcss) plug
 
 ## Setup & run
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
-npx @mui/codemod@latest <codemod> <paths...>
+npx @mui/codemod@next <codemod> <paths...>
 
 Applies a `@mui/codemod` to the specified paths
 
@@ -2441,7 +2441,7 @@ Renames `Autocomplete`'s `closeIcon` prop to `clearIcon`.
 +<Autocomplete clearIcon={defaultClearIcon} />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/autocomplete-rename-closeicon  <path>
@@ -2460,7 +2460,7 @@ Renames `Autocomplete`'s `getOptionSelected` to `isOptionEqualToValue`.
  />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/autocomplete-rename-option  <path>
@@ -2479,7 +2479,7 @@ Updates the `Avatar`'s `variant` value and `classes` key from 'circle' to 'circu
 +<Avatar classes={{ circular: 'className' }} />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/avatar-circle-circular <path>
@@ -2514,7 +2514,7 @@ Renames the badge's props.
  }}>
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/badge-overlap-value <path>
@@ -2538,7 +2538,7 @@ This change only affects Base UI components.
  />;
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/base-rename-components-to-slots <path>
@@ -2557,7 +2557,7 @@ Updates the Box API from separate system props to `sx`.
 +<Box borderRadius="16px">
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/box-borderradius-values <path>
@@ -2593,7 +2593,7 @@ Renames the Box `grid*Gap` props.
 +<Box rowGap={4}>Item 5</Box>
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/box-rename-gap <path>
@@ -2610,7 +2610,7 @@ Removes the outdated `color` prop values.
 +<Button>
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/button-color-prop <path>
@@ -2627,7 +2627,7 @@ Removes the Chip `variant` prop if the value is `"default"`.
 +<Chip>
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/chip-variant-prop <path>
@@ -2644,7 +2644,7 @@ Renames the CircularProgress `static` variant to `determinate`.
 +<CircularProgress variant="determinate" classes={{ determinate: 'className' }} />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/circularprogress-variant <path>
@@ -2663,7 +2663,7 @@ Renames `Collapse`'s `collapsedHeight` prop to `collapsedSize`.
 +<Collapse classes={{ root: 'collapse' }} />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/collapse-rename-collapsedheight <path>
@@ -2682,7 +2682,7 @@ A generic codemod to rename any component prop.
 +<Component newProp />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/component-rename-prop <path> -- --component=Grid --from=prop --to=newProp
@@ -2794,7 +2794,7 @@ Renames the `fade` style utility import and calls to `alpha()`.
 +const foo = alpha('#aaa');
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/fade-rename-alpha <path>
@@ -2811,7 +2811,7 @@ Renames `Grid`'s `justify` prop to `justifyContent`.
 +<Grid item justifyContent="left">Item</Grid>
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/grid-justify-justifycontent <path>
@@ -3095,7 +3095,7 @@ or
 +import { SpeedDial } from '@material-ui/core';
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/moved-lab-modules <path>
@@ -3139,7 +3139,7 @@ Fix private import paths.
 +import { createTheme } from '@material-ui/core/styles';
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/optimal-imports <path>
@@ -3268,7 +3268,7 @@ Updates breakpoint values to match new logic. ⚠️ This mod is not idempotent,
 +theme.breakpoints.between('sm', 'lg')
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/theme-breakpoints <path>
@@ -3342,7 +3342,7 @@ Removes the 'px' suffix from some template strings.
 +`${theme.spacing(2)} ${theme.spacing(4)}`
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/theme-spacing <path>
@@ -3375,7 +3375,7 @@ Converts all `@mui/material` submodule imports to the root module:
 +import { List, Grid } from '@mui/material';
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/top-level-imports <path>
@@ -3427,7 +3427,7 @@ Updates Dialog, Menu, Popover, and Snackbar to use the `TransitionProps` prop to
  />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/use-transitionprops <path>
@@ -3457,7 +3457,7 @@ The diff should look like this:
 +<FormControl value="Standard" variant="standard" />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v5.0.0/variant-prop <path>
@@ -3568,7 +3568,7 @@ The diff should look like this:
 +const spacing = theme.spacing(1);
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v4.0.0/theme-spacing-api <path>
@@ -3595,7 +3595,7 @@ Converts all `@material-ui/core` imports more than 1 level deep to the optimal f
 +import { withStyles, createTheme } from '@material-ui/core/styles';
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v4.0.0/optimal-imports <path>
@@ -3613,7 +3613,7 @@ Converts all `@material-ui/core` submodule imports to the root module:
 +import { List, withStyles } from '@material-ui/core';
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v4.0.0/top-level-imports <path>
@@ -3634,7 +3634,7 @@ The diff should look like this:
 +import MenuItem from '@material-ui/core/MenuItem';
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v1.0.0/import-path <path>
@@ -3661,7 +3661,7 @@ The diff should look like this:
 +const teal500 = teal['500'];
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v1.0.0/color-imports <path>
@@ -3669,7 +3669,7 @@ npx @mui/codemod@latest v1.0.0/color-imports <path>
 
 **additional options**
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v1.0.0/color-imports <path> -- --importPath='mui/styles/colors' --targetPath='mui/colors'
@@ -3687,7 +3687,7 @@ The diff should look like this:
 +import ThreeDRotation from '@material-ui/icons/ThreeDRotation';
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v1.0.0/svg-icon-imports <path>
@@ -3705,7 +3705,7 @@ The diff should look like this:
 +<MenuItem>{"Profile" + "!"}</MenuItem>
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v1.0.0/menu-item-primary-text <path>
@@ -3729,7 +3729,7 @@ The diff should look like this:
 +import RaisedButton from 'material-ui/RaisedButton';
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/codemod@latest v0.15.0/import-path <path>

--- a/packages/mui-docs/README.md
+++ b/packages/mui-docs/README.md
@@ -6,7 +6,7 @@ This package hosts the documentation building blocks.
 
 Install the package in your project directory with:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npm install @mui/docs@next
@@ -15,7 +15,7 @@ npm install @mui/docs@next
 The docs has a peer dependency on the core components.
 If you are not already using Material UI in your project, you can add it with:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npm install @mui/material@next

--- a/packages/mui-icons-material/README.md
+++ b/packages/mui-icons-material/README.md
@@ -10,7 +10,7 @@ This package contains Google's [Material Icons](https://fonts.google.com/icons?i
 
 The Material Icons package depends on Material UI—install both with the following command:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npm install @mui/icons-material@next @mui/material@next @emotion/styled @emotion/react

--- a/packages/mui-icons-material/README.md
+++ b/packages/mui-icons-material/README.md
@@ -1,6 +1,6 @@
 # @mui/icons-material
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 This package contains Google's [Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) converted to Material UI [SVG Icon](https://next.mui.com/material-ui/icons/#svgicon) components.
 
@@ -18,7 +18,7 @@ npm install @mui/icons-material@next @mui/material@next @emotion/styled @emotion
 
 ## Documentation
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 - Learn more about Material UI's [SVG Icon component](https://next.mui.com/material-ui/icons/#svgicon).
 - Browse the available icons on the [Material Icons page](https://next.mui.com/material-ui/material-icons/).

--- a/packages/mui-lab/README.md
+++ b/packages/mui-lab/README.md
@@ -23,6 +23,6 @@ npm install @mui/material@next @emotion/react @emotion/styled
 
 ## Documentation
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 Visit [https://next.mui.com/material-ui/about-the-lab/](https://next.mui.com/material-ui/about-the-lab/) to view the full documentation.

--- a/packages/mui-lab/README.md
+++ b/packages/mui-lab/README.md
@@ -6,7 +6,7 @@ This package hosts the incubator components that are not yet ready to move to `c
 
 Install the package in your project directory with:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npm install @mui/lab@next
@@ -15,7 +15,7 @@ npm install @mui/lab@next
 The lab has peer dependencies on the Material Design components and on the Emotion library.
 If you are not already using them in your project, you can install with:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npm install @mui/material@next @emotion/react @emotion/styled

--- a/packages/mui-material/README.md
+++ b/packages/mui-material/README.md
@@ -1,4 +1,4 @@
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 <!-- markdownlint-disable-next-line -->
 <p align="center">
   <a href="https://next.mui.com/material-ui/" rel="noopener" target="_blank"><img width="150" height="133" src="https://mui.com/static/logo.svg" alt="Material UI logo"></a>

--- a/packages/mui-material/README.md
+++ b/packages/mui-material/README.md
@@ -12,7 +12,7 @@ Material UI is an open-source React component library that implements Google's 
 
 Install the package in your project directory with:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npm install @mui/material@next @emotion/react @emotion/styled

--- a/packages/mui-styled-engine-sc/README.md
+++ b/packages/mui-styled-engine-sc/README.md
@@ -5,6 +5,6 @@ It's designed for developers who would like to use `styled-components` as the ma
 
 ## Documentation
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 Visit [https://next.mui.com/material-ui/integrations/styled-components/](https://next.mui.com/material-ui/integrations/styled-components/) to view the full documentation.

--- a/packages/mui-styled-engine/README.md
+++ b/packages/mui-styled-engine/README.md
@@ -6,6 +6,6 @@ It is used internally in the `@mui/system` package.
 
 ## Documentation
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 Visit [https://next.mui.com/material-ui/integrations/styled-components/](https://next.mui.com/material-ui/integrations/styled-components/) to view the full documentation.

--- a/packages/mui-system/README.md
+++ b/packages/mui-system/README.md
@@ -6,7 +6,7 @@ MUI System is a set of CSS utilities to help you build custom designs more effi
 
 Install the package in your project directory with:
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npm install @mui/system@next @emotion/react @emotion/styled

--- a/packages/mui-system/README.md
+++ b/packages/mui-system/README.md
@@ -14,6 +14,6 @@ npm install @mui/system@next @emotion/react @emotion/styled
 
 ## Documentation
 
-<!-- #default-branch-switch -->
+<!-- #host-reference -->
 
 Visit [https://next.mui.com/system/getting-started/](https://next.mui.com/system/getting-started/) to view the full documentation.

--- a/packages/mui-system/src/createBreakpoints/createBreakpoints.d.ts
+++ b/packages/mui-system/src/createBreakpoints/createBreakpoints.d.ts
@@ -9,7 +9,7 @@ export type Breakpoint = OverridableStringUnion<
 export const keys: Breakpoint[];
 
 // Keep in sync with docs/src/pages/customization/breakpoints/breakpoints.md
-// #default-branch-switch
+// #host-reference
 export interface Breakpoints {
   keys: Breakpoint[];
   /**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -57,6 +57,12 @@ deploying all the changes that have been merged into the main branch
 since the previous release (for example publishing a blog post or releasing
 urgent docs updates).
 
+**Note:** The instructions below are for deploying to the `latest` branch of the `material-ui-docs` repository, which points to `https://mui.com/`. If you need to deploy to a different subdomain, replace `latest` with the appropriate branch name:
+
+- `latest`: `https://mui.com/`
+- `next`: `https://next.mui.com/`
+- `v*.x`: `https://v*.mui.com/`
+
 To do so, follow these steps:
 
 1. Add the `material-ui-docs` remote if you haven't done this already:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -94,7 +94,7 @@ To do so, follow these steps:
    In case of conflicts you will need to resolve them and commit the changes manually.
 
    If this command fails with the message 'bad revision', it means that the commit doesn't exist on your local repository.
-   The commit might have been created on a remote branch, probably when merging into `master` or `next`.
+   The commit might have been created on a remote branch, probably when merging into `master` or `v*.x`.
    In this case, you'll have to fetch the latest changes of the corresponding remote branch and then try again.
 
 5. Push the changes to the `material-ui-docs` remote:

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -214,7 +214,7 @@ yargs(process.argv.slice(2))
           type: 'string',
         })
         .option('release', {
-          // #default-branch-switch
+          // #target-branch-reference
           default: 'master',
           describe: 'Ref which we want to release',
           type: 'string',


### PR DESCRIPTION
Following up on https://github.com/mui/material-ui/pull/45132#issuecomment-2616632648:

We're using `#default-branch-switch` to mark where changes are required, but with the new protocol, some of these changes happen on `master` branch and others on `v*.x` branch, so the comment becomes confusing. There are 4 types of changes that are encompassed under this tag:

- Changes to the npm version tag (`latest` -> `next`) in `master` (e.g.,  [#45132](https://github.com/mui/material-ui/pull/45132))
- Changes to the host (`mui.com` -> `next.mui.com`) in `master` (e.g.,  [#45132](https://github.com/mui/material-ui/pull/45132))
- Changes to repository links (`https://github.com/mui/material-ui/tree/master` -> `github.com/mui/material-ui/tree/v*.x`) in `v*.x` (e.g., [#45133](https://github.com/mui/material-ui/pull/45133)) 
- Changes to target branches for CI checks/builds (`master` -> `v*.x`) in `v*.x` (e.g., [#45133](https://github.com/mui/material-ui/pull/45133))

This PR splits these into 4 different tags:

- `#npm-tag-reference`
- `#host-reference`
- `#repo-reference`
- `#target-branch-reference`

By splitting them, it will be easier to follow the branch split protocol and understand what each one refers to.

I used `reference` instead of `switch` as I think it's more descriptive and reads better: "Here's is a **reference** of the npm tag/host/repo/target branch"
