### PR TITLE
[docs-infra] Point to MUI X next docs

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -525,11 +525,11 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 ## MUI X
 ## Unlike the store that expect to be hosted under a subfolder,
 ## MUI X is configured to be hosted at the root.
-/static/x/* https://material-ui-x.netlify.app/static/x/:splat 200
-/x/_next/* https://material-ui-x.netlify.app/_next/:splat 200
-/x/* https://material-ui-x.netlify.app/x/:splat 200
-/r/x-* https://material-ui-x.netlify.app/r/x-:splat 200
-/:lang/x/* https://material-ui-x.netlify.app/:lang/x/:splat 200
+/static/x/* https://docs-next--material-ui-x.netlify.app/static/x/:splat 200
+/x/_next/* https://docs-next--material-ui-x.netlify.app/_next/:splat 200
+/x/* https://docs-next--material-ui-x.netlify.app/x/:splat 200
+/r/x-* https://docs-next--material-ui-x.netlify.app/r/x-:splat 200
+/:lang/x/* https://docs-next--material-ui-x.netlify.app/:lang/x/:splat 200
 
 ## Toolpad
 /toolpad/core/templates/nextjs-dashboard/_next/* https://toolpad-core-nextjs-themed.vercel.app/_next/:splat 200


### PR DESCRIPTION
Since the `master` branch of this repo is now deployed under `next.mui.com`, we need to point to MUI X next docs.
Currently, https://next.mui.com/x/react-data-grid/ points to https://material-ui-x.netlify.app/x/introduction/, while it should point to https://docs-next--material-ui-x.netlify.app/


Preview: https://deploy-preview-45207--material-ui.netlify.app/x/react-data-grid/