### PR TITLE
[docs] Disable babel for the docs

### DIFF
--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -1,7 +1,4 @@
-const path = require('path');
 const fse = require('fs-extra');
-
-const errorCodesPath = path.resolve(__dirname, './public/static/error-codes.json');
 
 const { version: transformRuntimeVersion } = fse.readJSONSync(
   require.resolve('@babel/runtime-corejs2/package.json'),
@@ -22,17 +19,7 @@ module.exports = {
       },
     ],
   ],
-  plugins: [
-    [
-      'babel-plugin-macros',
-      {
-        muiError: {
-          errorCodesPath,
-        },
-      },
-    ],
-    'babel-plugin-optimize-clsx',
-  ],
+  plugins: ['babel-plugin-optimize-clsx'],
   ignore: [/@babel[\\|/]runtime/], // Fix a Windows issue.
   env: {
     production: {

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -25,7 +25,7 @@ module.exports = {
     production: {
       plugins: [
         '@babel/plugin-transform-react-constant-elements',
-        ['babel-plugin-react-remove-properties', { properties: ['data-mui-test'] }],
+        ['babel-plugin-react-remove-properties', { properties: ['data-testid'] }],
         ['babel-plugin-transform-react-remove-prop-types', { mode: 'remove' }],
       ],
     },

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -29,6 +29,9 @@ export default withDocsInfra({
   experimental: {
     forceSwcTransforms: true,
   },
+  compiler: {
+    reactRemoveProperties: true,
+  },
   webpack: (config: NextConfig, options): NextConfig => {
     const plugins = config.plugins.slice();
 

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -26,6 +26,9 @@ const pkgContent = fs.readFileSync(path.resolve(workspaceRoot, 'package.json'), 
 const pkg = JSON.parse(pkgContent);
 
 export default withDocsInfra({
+  experimental: {
+    forceSwcTransforms: true,
+  },
   webpack: (config: NextConfig, options): NextConfig => {
     const plugins = config.plugins.slice();
 

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Script from 'next/script';
-import { documentGetInitialProps } from '@mui/material-nextjs/v13-pagesRouter';
+import { documentGetInitialProps } from '@mui/material-nextjs/v15-pagesRouter';
 import { ServerStyleSheets as JSSServerStyleSheets } from '@mui/styles';
 import { ServerStyleSheet } from 'styled-components';
 import Document, { Html, Head, Main, NextScript } from 'next/document';

--- a/packages/markdown/parseMarkdown.mjs
+++ b/packages/markdown/parseMarkdown.mjs
@@ -468,7 +468,7 @@ function createRender(context) {
 
             return `<aside class="MuiCallout-root MuiCallout-${token.severity}">${[
               '<div class="MuiCallout-icon-container">',
-              '<svg focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="ContentCopyRoundedIcon">',
+              '<svg>',
               `<use class="MuiCode-copied-icon" xlink:href="#${token.severity}-icon" />`,
               '</svg>',
               '</div>',


### PR DESCRIPTION
locally this seems to cut `docs:build` time in half. Let's see what this does to the bundles for https://github.com/mui/material-ui/issues/42385.

* Running page speed insights is super variable, the scores range from 45 to 82 on different runs. How is this remotely useful?
* local lighthouse scores on performance seem to be identical
* Did notice in their tree map that js size went down from 2.1MB to 1.9MB 

blockers (?):
- [ ] `babel-plugin-transform-react-remove-prop-types` See https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/issues/201
    _Since react 19 doesn't do proptypes checking, we may simple just remove them from our sources and get rid of the babel plugin_
- [ ] `@babel/plugin-transform-react-constant-elements`
    _React compiler wil memoize those._
- [ ] `babel-plugin-optimize-clsx`
    _There is no 1 to 1 replacement yet, but React compiler will emmoize these and reduce the amount of allocations._
- [x] `babel-plugin-react-remove-properties (data-mui-test)` https://github.com/vercel/next.js/pull/31606
    there now is [`compiler.reactRemoveProperties`](https://nextjs.org/docs/architecture/nextjs-compiler#remove-react-properties). It doesn't seem to work though. It doesn't look like currently all `data-testid` are removed neither. i.e. on mui.com:
    ![Screenshot 2025-02-05 at 11 18 56](https://github.com/user-attachments/assets/37a2c7e0-4744-45ff-b2ad-d13ca19f66e5)
