### PR TITLE
[website] Add banners and notification for 2025 Developer Survey

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -18,5 +18,10 @@
     "id": 85,
     "title": "MUI X v8 alpha",
     "text": "Check our plans for the upcoming stable in the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-v8-alpha-zero\" href=\"https://mui.com/blog/mui-x-v8-alpha-zero/\">announcement blog post</a>."
+  },
+  {
+    "id": 86,
+    "title": "Influence the roadmap for 2025",
+    "text": "Take a few minutes to share your feedback and expectations in the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-survey\" href=\"https://tally.so/r/mObbvk?source=docs-notification\">Developer Survey</a>."
   }
 ]

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -5,7 +5,7 @@ import FEATURE_TOGGLE from 'docs/src/featureToggle';
 import PageContext from 'docs/src/modules/components/PageContext';
 import { convertProductIdToName } from 'docs/src/modules/components/AppSearch';
 
-const showSurveyMessage = false;
+const showSurveyMessage = true;
 
 function isBlackFriday() {
   const today = Date.now();
@@ -38,8 +38,8 @@ export default function AppFrameBanner() {
   let href = '';
 
   if (showSurveyMessage) {
-    message = `Influence ${productName}'s 2024 roadmap! Participate in the latest Developer Survey`;
-    href = 'https://tally.so/r/3Ex4PN?source=website';
+    message = `🚀 Influence ${productName}'s 2025 roadmap! Participate in the latest Developer Survey`;
+    href = 'https://tally.so/r/mObbvk?source=website';
   } else if (mounted && isBlackFriday()) {
     message = `Black Friday is here! Don't miss out on the best offers of the year.`;
     href = 'https://mui.com/store/bundles/?deal=black-friday&from=docs';

--- a/docs/src/components/banner/AppHeaderBanner.tsx
+++ b/docs/src/components/banner/AppHeaderBanner.tsx
@@ -1,24 +1,34 @@
 import * as React from 'react';
 import Typography from '@mui/material/Typography';
+import { Theme } from '@mui/material/styles';
 import { Link } from '@mui/docs/Link';
 import ROUTES from 'docs/src/route';
 import FEATURE_TOGGLE from 'docs/src/featureToggle';
 
+const linkStyleOverrides = (theme: Theme) => ({
+  color: 'inherit',
+  textDecorationColor: 'currentColor',
+  '&:hover': {
+    color: (theme.vars || theme).palette.primary[200],
+  },
+  ...theme.applyDarkStyles({
+    color: 'inherit',
+    '&:hover': {
+      color: (theme.vars || theme).palette.primary[200],
+    },
+  }),
+});
+
 function getSurveyMessage() {
   return (
     <React.Fragment>
-      {`🚀 Influence MUI's 2024 roadmap! Participate in the latest`}
+      {`🚀 Influence MUI's 2025 roadmap! Participate in the latest`}
       &nbsp;
       <Link
-        href="https://tally.so/r/3Ex4PN?source=website"
+        href="https://tally.so/r/mObbvk?source=website"
         target="_blank"
         underline="always"
-        sx={{
-          color: 'inherit',
-          '&:hover': {
-            opacity: 0.9,
-          },
-        }}
+        sx={linkStyleOverrides}
       >
         Developer Survey →
       </Link>
@@ -36,12 +46,7 @@ function getDefaultHiringMessage() {
         href={ROUTES.careers}
         target="_blank"
         underline="always"
-        sx={{
-          color: 'inherit',
-          '&:hover': {
-            opacity: 0.9,
-          },
-        }}
+        sx={linkStyleOverrides}
       >
         Check the careers page →
       </Link>
@@ -50,7 +55,7 @@ function getDefaultHiringMessage() {
 }
 
 export default function AppHeaderBanner() {
-  const showSurveyMessage = false;
+  const showSurveyMessage = true;
   const bannerMessage = showSurveyMessage ? getSurveyMessage() : getDefaultHiringMessage();
 
   return FEATURE_TOGGLE.enable_website_banner ? (

--- a/docs/src/featureToggle.js
+++ b/docs/src/featureToggle.js
@@ -1,6 +1,6 @@
 // need to use commonjs export so that @mui/internal-markdown can use
 module.exports = {
-  enable_website_banner: false,
+  enable_website_banner: true,
   enable_docsnav_banner: true,
   enable_job_banner: false,
 };


### PR DESCRIPTION
Enable banners and notification for the 2025 Developer Survey. The notification won't show in the preview, but it will be available after merging this PR.

### Website banner
Preview: https://deploy-preview-45280--material-ui.netlify.app/
<img width="1271" alt="Screenshot 2025-02-10 at 16 26 46" src="https://github.com/user-attachments/assets/b3de84f2-23d8-41d1-b157-46155e67f503" />

### Docs banner
Preview: https://deploy-preview-45280--material-ui.netlify.app/material-ui/getting-started/
<img width="979" alt="Screenshot 2025-02-10 at 16 26 59" src="https://github.com/user-attachments/assets/418957c7-ee80-4afd-afa6-fd1752d10174" />
