### PR TITLE
[material-ui][Button] Apply id only if loading indicator is present

### DIFF
--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -600,7 +600,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
       focusVisibleClassName={clsx(classes.focusVisible, focusVisibleClassName)}
       ref={ref}
       type={type}
-      id={id}
+      id={loadingIndicator ? id : undefined}
       {...other}
       classes={classes}
     >

--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -578,11 +578,8 @@ const Button = React.forwardRef(function Button(inProps, ref) {
 
   const positionClassName = buttonGroupButtonContextPositionClassName || '';
 
-  let loader = null;
-  let computedId = idProp;
-
-  if (typeof loading === 'boolean') {
-    loader = (
+  const loader =
+    typeof loading === 'boolean' ? (
       // use plain HTML span to minimize the runtime overhead
       <span className={classes.loadingWrapper} style={{ display: 'contents' }}>
         {loading && (
@@ -591,10 +588,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
           </ButtonLoadingIndicator>
         )}
       </span>
-    );
-
-    computedId = loadingId;
-  }
+    ) : null;
 
   return (
     <ButtonRoot
@@ -606,7 +600,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
       focusVisibleClassName={clsx(classes.focusVisible, focusVisibleClassName)}
       ref={ref}
       type={type}
-      id={computedId}
+      id={loading ? loadingId : idProp}
       {...other}
       classes={classes}
     >

--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -531,9 +531,9 @@ const Button = React.forwardRef(function Button(inProps, ref) {
     ...other
   } = props;
 
-  const id = useId(idProp);
+  const loadingId = useId(idProp);
   const loadingIndicator = loadingIndicatorProp ?? (
-    <CircularProgress aria-labelledby={id} color="inherit" size={16} />
+    <CircularProgress aria-labelledby={loadingId} color="inherit" size={16} />
   );
 
   const ownerState = {
@@ -578,8 +578,11 @@ const Button = React.forwardRef(function Button(inProps, ref) {
 
   const positionClassName = buttonGroupButtonContextPositionClassName || '';
 
-  const loader =
-    typeof loading === 'boolean' ? (
+  let loader = null;
+  let computedId = idProp;
+
+  if (typeof loading === 'boolean') {
+    loader = (
       // use plain HTML span to minimize the runtime overhead
       <span className={classes.loadingWrapper} style={{ display: 'contents' }}>
         {loading && (
@@ -588,7 +591,10 @@ const Button = React.forwardRef(function Button(inProps, ref) {
           </ButtonLoadingIndicator>
         )}
       </span>
-    ) : null;
+    );
+
+    computedId = loadingId;
+  }
 
   return (
     <ButtonRoot
@@ -600,7 +606,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
       focusVisibleClassName={clsx(classes.focusVisible, focusVisibleClassName)}
       ref={ref}
       type={type}
-      id={loadingIndicator ? id : undefined}
+      id={computedId}
       {...other}
       classes={classes}
     >

--- a/packages/mui-material/src/Button/Button.test.js
+++ b/packages/mui-material/src/Button/Button.test.js
@@ -793,7 +793,7 @@ describe('<Button />', () => {
       expect(progressbar).toHaveAccessibleName('Submit');
     });
 
-    it('button has no id when `loading=false` and no `id` prop is present`', () => {
+    it('has no id when `loading=false` and no `id` prop is present`', () => {
       const id = 'some-id';
       render(
         <React.Fragment>

--- a/packages/mui-material/src/Button/Button.test.js
+++ b/packages/mui-material/src/Button/Button.test.js
@@ -792,6 +792,21 @@ describe('<Button />', () => {
       const progressbar = within(button).getByRole('progressbar');
       expect(progressbar).toHaveAccessibleName('Submit');
     });
+
+    it('button has no id when `loading=false` and no `id` prop is present`', () => {
+      const id = 'some-id';
+      render(
+        <React.Fragment>
+          <Button />
+          <Button id={id} />
+        </React.Fragment>,
+      );
+
+      const buttons = screen.getAllByRole('button');
+
+      expect(buttons[0]).not.to.have.attribute('id');
+      expect(buttons[1]).to.have.attribute('id', id);
+    });
   });
 
   describe('prop: loadingIndicator', () => {

--- a/packages/mui-material/src/IconButton/IconButton.js
+++ b/packages/mui-material/src/IconButton/IconButton.js
@@ -187,9 +187,9 @@ const IconButton = React.forwardRef(function IconButton(inProps, ref) {
     ...other
   } = props;
 
-  const id = useId(idProp);
+  const loadingId = useId(idProp);
   const loadingIndicator = loadingIndicatorProp ?? (
-    <CircularProgress aria-labelledby={id} color="inherit" size={16} />
+    <CircularProgress aria-labelledby={loadingId} color="inherit" size={16} />
   );
 
   const ownerState = {
@@ -207,7 +207,7 @@ const IconButton = React.forwardRef(function IconButton(inProps, ref) {
 
   return (
     <IconButtonRoot
-      id={id}
+      id={loading ? loadingId : idProp}
       className={clsx(classes.root, className)}
       centerRipple
       focusRipple={!disableFocusRipple}

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -192,6 +192,21 @@ describe('<IconButton />', () => {
       const progressbar = within(button).getByRole('progressbar');
       expect(progressbar).toHaveAccessibleName('Submit');
     });
+
+    it('has no id when `loading=false` and no `id` prop is present`', () => {
+      const id = 'some-id';
+      render(
+        <React.Fragment>
+          <IconButton />
+          <IconButton id={id} />
+        </React.Fragment>,
+      );
+
+      const buttons = screen.getAllByRole('button');
+
+      expect(buttons[0]).not.to.have.attribute('id');
+      expect(buttons[1]).to.have.attribute('id', id);
+    });
   });
 
   describe('prop: loadingIndicator', () => {


### PR DESCRIPTION
We introduced an `id` attribute in all buttons when we introduced the `loading` prop in the `Button` component (https://github.com/mui/material-ui/pull/44637). We've got a couple of reports that some tests were broken because of this: https://github.com/mui/material-ui/pull/44637#issuecomment-2631635116

This PR changes the logic so the `id` attribute is only added when the loading indicator is present. 