### PR TITLE
[icons] Remove default data-testid

### DIFF
--- a/docs/data/material/components/icons/icons.md
+++ b/docs/data/material/components/icons/icons.md
@@ -81,20 +81,6 @@ The Material Design guidelines name the icons using "snake_case" naming (for exa
 
 {{"demo": "SvgMaterialIcons.js"}}
 
-### Testing
-
-For testing purposes, each icon exposed from `@mui/icons-material` has a `data-testid` attribute with the name of the icon. For instance:
-
-```jsx
-import DeleteIcon from '@mui/icons-material/Delete';
-```
-
-has the following attribute once mounted:
-
-```html
-<svg data-testid="DeleteIcon"></svg>
-```
-
 ## SvgIcon
 
 If you need a custom SVG icon (not available in the [Material Icons](/material-ui/material-icons/)) you can use the `SvgIcon` wrapper.

--- a/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
+++ b/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
@@ -158,3 +158,25 @@ Use this codemod to automatically update the `size` value:
 ```bash
 npx @mui/codemod@next v7.0.0/input-label-size-normal-medium <path/to/folder>
 ```
+
+### Removal of `data-testid` prop from `SvgIcon`
+
+The default `data-testid` prop has been removed from the `SvgIcon` component, and therefore also from all icons in `@mui/icons-material`. If you need to use `data-testid` for testing purposes, you can manually add it to your `SvgIcon` components.
+
+For example, if you were using:
+
+```jsx
+import HomeIcon from '@mui/icons-material/Home';
+
+<HomeIcon />;
+```
+
+You should update it to:
+
+```jsx
+import HomeIcon from '@mui/icons-material/Home';
+
+<HomeIcon data-testid="HomeIcon" />;
+```
+
+This change ensures that the `data-testid` prop is only defined where needed, reducing the potential for naming clashes and removing unnecessary properties in production.

--- a/docs/src/components/productBaseUI/MuiBaseDeprecation.tsx
+++ b/docs/src/components/productBaseUI/MuiBaseDeprecation.tsx
@@ -37,12 +37,7 @@ export default function MuiBaseDeprecation(props: {
 function Icon() {
   return (
     <Box className="MuiCallout-icon-container">
-      <svg
-        focusable="false"
-        aria-hidden="true"
-        viewBox="0 0 24 24"
-        data-testid="ContentCopyRoundedIcon"
-      >
+      <svg focusable="false" aria-hidden="true" viewBox="0 0 24 24">
         <use className="MuiCode-copied-icon" xlinkHref="#error-icon" />
       </svg>
     </Box>

--- a/packages/mui-material/src/utils/createSvgIcon.d.ts
+++ b/packages/mui-material/src/utils/createSvgIcon.d.ts
@@ -1,3 +1,3 @@
-import SvgIcon from '@mui/material/SvgIcon';
+import SvgIcon from '../SvgIcon';
 
 export default function createSvgIcon(path: React.ReactNode, displayName: string): typeof SvgIcon;

--- a/packages/mui-material/src/utils/createSvgIcon.js
+++ b/packages/mui-material/src/utils/createSvgIcon.js
@@ -8,7 +8,11 @@ import SvgIcon from '../SvgIcon';
 export default function createSvgIcon(path, displayName) {
   function Component(props, ref) {
     return (
-      <SvgIcon data-testid={`${displayName}Icon`} ref={ref} {...props}>
+      <SvgIcon
+        data-testid={process.env.NODE_ENV !== 'production' ? `${displayName}Icon` : undefined}
+        ref={ref}
+        {...props}
+      >
         {path}
       </SvgIcon>
     );

--- a/packages/mui-material/src/utils/createSvgIcon.js
+++ b/packages/mui-material/src/utils/createSvgIcon.js
@@ -8,11 +8,7 @@ import SvgIcon from '../SvgIcon';
 export default function createSvgIcon(path, displayName) {
   function Component(props, ref) {
     return (
-      <SvgIcon
-        data-testid={process.env.NODE_ENV !== 'production' ? `${displayName}Icon` : undefined}
-        ref={ref}
-        {...props}
-      >
+      <SvgIcon ref={ref} {...props}>
         {path}
       </SvgIcon>
     );


### PR DESCRIPTION
Breaking change

Removes the default `data-testid` prop in favor for users defining this themselves. Adds a section to the migration guide and remove the docs that describe this behavior.