### PR TITLE
[docs][icons] Fix typo in material-icons.md

### DIFF
--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -40,6 +40,7 @@ See the [Installation](/material-ui/getting-started/installation/) page for addi
 
 :::info
 Google also offers [Material Symbols](https://fonts.google.com/icons?icon.set=Material+Symbols) as the successor of Material Icons. `@mui/icons-material` only covers Icons at this time, there are no support for Symbols yet.
+Google offers [Material Symbols](https://fonts.google.com/icons?icon.set=Material+Symbols) as the successor to Material Icons. However, `@mui/icons-material` currently supports only Icons, with no support for Symbols yet.
 :::
 
 <hr/>

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -39,7 +39,6 @@ yarn add @mui/icons-material@next @mui/material@next @emotion/styled @emotion/re
 See the [Installation](/material-ui/getting-started/installation/) page for additional docs about how to make sure everything is set up correctly.
 
 :::info
-Google also offers [Material Symbols](https://fonts.google.com/icons?icon.set=Material+Symbols) as the successor of Material Icons. `@mui/icons-material` only covers Icons at this time, there are no support for Symbols yet.
 Google offers [Material Symbols](https://fonts.google.com/icons?icon.set=Material+Symbols) as the successor to Material Icons. However, `@mui/icons-material` currently supports only Icons, with no support for Symbols yet.
 :::
 


### PR DESCRIPTION
Should be 'is no support' rather than 'are no support'.

This PR replaces https://github.com/mui/material-ui/pull/45310 as it was not specified correctly.