### PR TITLE
[material-ui] Allow nested theme creation with `vars`

### DIFF
--- a/docs/public/static/error-codes.json
+++ b/docs/public/static/error-codes.json
@@ -18,6 +18,6 @@
   "17": "MUI: Expected valid input target. Did you use a custom `slots.input` and forget to forward refs? See https://mui.com/r/input-component-ref-interface for more info.",
   "18": "MUI: The provided shorthand %s is invalid. The format should be `@<breakpoint | number>` or `@<breakpoint | number>/<container>`.\nFor example, `@sm` or `@600` or `@40rem/sidebar`.",
   "19": "MUI: The `experimental_sx` has been moved to `theme.unstable_sx`.For more details, see https://github.com/mui/material-ui/pull/35150.",
-  "20": "MUI: `vars` is a private field used for CSS variables support.\nPlease use another name.",
+  "20": "MUI: `vars` is a private field used for CSS variables support.\nPlease use another name or follow the [docs](https://mui.com/material-ui/customization/css-theme-variables/usage/) to enable the feature.",
   "21": "MUI: The `colorSchemes.%s` option is either missing or invalid."
 }

--- a/packages/mui-material/src/styles/createTheme.test.js
+++ b/packages/mui-material/src/styles/createTheme.test.js
@@ -535,9 +535,40 @@ describe('createTheme', () => {
     } catch (error) {
       expect(error.message).to.equal(
         'MUI: `vars` is a private field used for CSS variables support.\n' +
-          'Please use another name.',
+          'Please use another name or follow the [docs](https://mui.com/material-ui/customization/css-theme-variables/usage/) to enable the feature.',
       );
     }
+  });
+
+  it('should not throw for nested theme that includes `vars` node', () => {
+    const outerTheme = createTheme({
+      cssVariables: true,
+      palette: {
+        secondary: {
+          main: deepOrange[500],
+        },
+      },
+    });
+
+    expect(() =>
+      render(
+        <ThemeProvider theme={outerTheme}>
+          <ThemeProvider
+            theme={(theme) => {
+              return createTheme({
+                ...theme,
+                palette: {
+                  ...theme.palette,
+                  primary: {
+                    main: green[500],
+                  },
+                },
+              });
+            }}
+          />
+        </ThemeProvider>,
+      ),
+    ).not.to.throw();
   });
 
   it('should create a new object', () => {

--- a/packages/mui-material/src/styles/createThemeNoVars.js
+++ b/packages/mui-material/src/styles/createThemeNoVars.js
@@ -26,10 +26,13 @@ function createThemeNoVars(options = {}, ...args) {
 
   if (
     options.vars &&
-    options.generateThemeVars === undefined // check for `generateThemeVars` (created internally) to handle nested theme
+    // The error should throw only for the root theme creation because user is not allowed to use a custom node `vars`.
+    // `generateThemeVars` is the closest identifier for checking that the `options` is a result of `createTheme` with CSS variables so that user can create new theme for nested ThemeProvider.
+    options.generateThemeVars === undefined
   ) {
     throw /* minify-error */ new Error(
       'MUI: `vars` is a private field used for CSS variables support.\n' +
+        // #host-reference
         'Please use another name or follow the [docs](https://mui.com/material-ui/customization/css-theme-variables/usage/) to enable the feature.',
     );
   }

--- a/packages/mui-material/src/styles/createThemeNoVars.js
+++ b/packages/mui-material/src/styles/createThemeNoVars.js
@@ -24,10 +24,14 @@ function createThemeNoVars(options = {}, ...args) {
     ...other
   } = options;
 
-  if (options.vars) {
+  if (
+    options.vars &&
+    options.cssVariables === undefined &&
+    options.generateThemeVars === undefined
+  ) {
     throw /* minify-error */ new Error(
       'MUI: `vars` is a private field used for CSS variables support.\n' +
-        'Please use another name.',
+        'Please use another name or follow the [docs](https://mui.com/material-ui/customization/css-theme-variables/usage/) to enable the feature.',
     );
   }
 

--- a/packages/mui-material/src/styles/createThemeNoVars.js
+++ b/packages/mui-material/src/styles/createThemeNoVars.js
@@ -26,6 +26,7 @@ function createThemeNoVars(options = {}, ...args) {
 
   if (
     options.vars &&
+    // check for both `cssVariables` (user provided) and `generateThemeVars` (created internally) to handle nested theme
     options.cssVariables === undefined &&
     options.generateThemeVars === undefined
   ) {

--- a/packages/mui-material/src/styles/createThemeNoVars.js
+++ b/packages/mui-material/src/styles/createThemeNoVars.js
@@ -26,9 +26,7 @@ function createThemeNoVars(options = {}, ...args) {
 
   if (
     options.vars &&
-    // check for both `cssVariables` (user provided) and `generateThemeVars` (created internally) to handle nested theme
-    options.cssVariables === undefined &&
-    options.generateThemeVars === undefined
+    options.generateThemeVars === undefined // check for `generateThemeVars` (created internally) to handle nested theme
   ) {
     throw /* minify-error */ new Error(
       'MUI: `vars` is a private field used for CSS variables support.\n' +


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #44429
closes #34278

## Summary

If the theme is already created with CSS theme variables, don't throw the error.

Next step (separate PR), create a documentation for recommended approach of the nested theme with CSS variables.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
