### PR TITLE
[material-ui][Tabs] Fix Alt+Arrow from being consumed by tab navigation

### DIFF
--- a/packages/mui-material/src/Tab/Tab.js
+++ b/packages/mui-material/src/Tab/Tab.js
@@ -254,6 +254,12 @@ const Tab = React.forwardRef(function Tab(inProps, ref) {
     }
   };
 
+  const handleKeyDown = (event) => {
+    if (event.altKey && (event.key === 'ArrowLeft' || event.key === 'ArrowRight')) {
+      event.stopPropagation();
+    }
+  };
+
   return (
     <TabRoot
       focusRipple={!disableFocusRipple}
@@ -264,6 +270,7 @@ const Tab = React.forwardRef(function Tab(inProps, ref) {
       disabled={disabled}
       onClick={handleClick}
       onFocus={handleFocus}
+      onKeyDown={handleKeyDown}
       ownerState={ownerState}
       tabIndex={selected ? 0 : -1}
       {...other}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
