### PR TITLE
[material-ui] Fix wrong slotProps of DetailsHTMLAttributes types

### DIFF
--- a/packages/mui-material/src/Alert/Alert.d.ts
+++ b/packages/mui-material/src/Alert/Alert.d.ts
@@ -67,29 +67,17 @@ export type AlertSlotsAndSlotProps = CreateSlotsAndSlotProps<
      * Props forwarded to the icon slot.
      * By default, the avaible props are based on a div element.
      */
-    icon: SlotProps<
-      React.ElementType<React.DetailsHTMLAttributes<HTMLDivElement>>,
-      AlertIconSlotPropsOverrides,
-      AlertOwnerState
-    >;
+    icon: SlotProps<'div', AlertIconSlotPropsOverrides, AlertOwnerState>;
     /**
      * Props forwarded to the message slot.
      * By default, the avaible props are based on a div element.
      */
-    message: SlotProps<
-      React.ElementType<React.DetailsHTMLAttributes<HTMLDivElement>>,
-      AlertMessageSlotPropsOverrides,
-      AlertOwnerState
-    >;
+    message: SlotProps<'div', AlertMessageSlotPropsOverrides, AlertOwnerState>;
     /**
      * Props forwarded to the action slot.
      * By default, the avaible props are based on a div element.
      */
-    action: SlotProps<
-      React.ElementType<React.DetailsHTMLAttributes<HTMLDivElement>>,
-      AlertActionSlotPropsOverrides,
-      AlertOwnerState
-    >;
+    action: SlotProps<'div', AlertActionSlotPropsOverrides, AlertOwnerState>;
     /**
      * Props forwarded to the closeButton slot.
      * By default, the avaible props are based on the [IconButton](https://mui.com/material-ui/api/icon-button/#props) component.

--- a/packages/mui-material/src/CardHeader/CardHeader.d.ts
+++ b/packages/mui-material/src/CardHeader/CardHeader.d.ts
@@ -60,38 +60,22 @@ export type CardHeaderSlotsAndSlotProps = CreateSlotsAndSlotProps<
      * Props forwarded to the root slot.
      * By default, the avaible props are based on the div element.
      */
-    root: SlotProps<
-      React.ElementType<React.DetailsHTMLAttributes<HTMLDivElement>>,
-      CardHeaderRootSlotPropsOverrides,
-      CardHeaderOwnerState
-    >;
+    root: SlotProps<'div', CardHeaderRootSlotPropsOverrides, CardHeaderOwnerState>;
     /**
      * Props forwarded to the avatar slot.
      * By default, the avaible props are based on the div element.
      */
-    avatar: SlotProps<
-      React.ElementType<React.DetailsHTMLAttributes<HTMLDivElement>>,
-      CardHeaderAvatarSlotPropsOverrides,
-      CardHeaderOwnerState
-    >;
+    avatar: SlotProps<'div', CardHeaderAvatarSlotPropsOverrides, CardHeaderOwnerState>;
     /**
      * Props forwarded to the action slot.
      * By default, the avaible props are based on the div element.
      */
-    action: SlotProps<
-      React.ElementType<React.DetailsHTMLAttributes<HTMLDivElement>>,
-      CardHeaderActionSlotPropsOverrides,
-      CardHeaderOwnerState
-    >;
+    action: SlotProps<'div', CardHeaderActionSlotPropsOverrides, CardHeaderOwnerState>;
     /**
      * Props forwarded to the content slot.
      * By default, the avaible props are based on the div element.
      */
-    content: SlotProps<
-      React.ElementType<React.DetailsHTMLAttributes<HTMLDivElement>>,
-      CardHeaderContentSlotPropsOverrides,
-      CardHeaderOwnerState
-    >;
+    content: SlotProps<'div', CardHeaderContentSlotPropsOverrides, CardHeaderOwnerState>;
     /**
      * Props forwarded to the title slot (as long as disableTypography is not `true`).
      * By default, the avaible props are based on the [Typography](https://mui.com/material-ui/api/typography/#props) component.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

cherry pick from #45215

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
