### PR TITLE
[docs-infra] Fix block that can happen when type is not resolved

### DIFF
--- a/packages/api-docs-builder/utils/createDescribeableProp.ts
+++ b/packages/api-docs-builder/utils/createDescribeableProp.ts
@@ -5,7 +5,7 @@ export interface DescribeablePropDescriptor {
   annotation: doctrine.Annotation;
   defaultValue: string | null;
   required: boolean;
-  type: PropTypeDescriptor;
+  type?: PropTypeDescriptor;
 }
 
 export type CreateDescribeablePropSettings = {

--- a/packages/api-docs-builder/utils/generatePropDescription.ts
+++ b/packages/api-docs-builder/utils/generatePropDescription.ts
@@ -9,8 +9,8 @@ import {
 import { DescribeablePropDescriptor } from './createDescribeableProp';
 import { SeeMore } from '../types/utils.types';
 
-function resolveType(type: NonNullable<doctrine.Tag['type']>): string {
-  if (type.type === 'AllLiteral') {
+function resolveType(type: doctrine.Tag['type']): string {
+  if (!type || type.type === 'AllLiteral') {
     return 'any';
   }
 
@@ -88,7 +88,7 @@ export default function generatePropDescription(
   const type = prop.type;
   let deprecated = '';
 
-  if (type.name === 'custom') {
+  if (type?.name === 'custom') {
     const deprecatedInfo = getDeprecatedInfo(type);
     if (deprecatedInfo) {
       deprecated = `*Deprecated*. ${deprecatedInfo.explanation}<br><br>`;
@@ -123,7 +123,7 @@ export default function generatePropDescription(
   let signature;
   let signatureArgs;
   let signatureReturn;
-  if (type.name === 'func' && (parsedArgs.length > 0 || parsedReturns !== undefined)) {
+  if (type?.name === 'func' && (parsedArgs.length > 0 || parsedReturns !== undefined)) {
     parsedReturns = parsedReturns ?? { type: { type: 'VoidLiteral' } };
 
     // Remove new lines from tag descriptions to avoid markdown errors.

--- a/packages/api-docs-builder/utils/generatePropTypeDescription.ts
+++ b/packages/api-docs-builder/utils/generatePropTypeDescription.ts
@@ -2,7 +2,11 @@ import * as recast from 'recast';
 import { parse as docgenParse, PropTypeDescriptor } from 'react-docgen';
 import { escapeCell, escapeEntities, joinUnionTypes } from '../buildApi';
 
-function getDeprecatedInfo(type: PropTypeDescriptor) {
+function getDeprecatedInfo(type?: PropTypeDescriptor) {
+  if (!type) {
+    return false;
+  }
+
   const marker = /deprecatedPropType\((\r*\n)*\s*PropTypes\./g;
   const match = type.raw.match(marker);
   const startIndex = type.raw.search(marker);
@@ -18,7 +22,11 @@ function getDeprecatedInfo(type: PropTypeDescriptor) {
   return false;
 }
 
-export function getChained(type: PropTypeDescriptor) {
+export function getChained(type?: PropTypeDescriptor) {
+  if (!type) {
+    return false;
+  }
+
   if (type.raw) {
     const marker = 'chainPropTypes';
     const indexStart = type.raw.indexOf(marker);
@@ -48,24 +56,24 @@ export function getChained(type: PropTypeDescriptor) {
   return false;
 }
 
-export function isElementTypeAcceptingRefProp(type: PropTypeDescriptor): boolean {
-  return type.raw === 'elementTypeAcceptingRef';
+export function isElementTypeAcceptingRefProp(type?: PropTypeDescriptor): boolean {
+  return type?.raw === 'elementTypeAcceptingRef';
 }
 
-function isRefType(type: PropTypeDescriptor): boolean {
-  return type.raw === 'refType';
+function isRefType(type?: PropTypeDescriptor): boolean {
+  return type?.raw === 'refType';
 }
 
-function isIntegerType(type: PropTypeDescriptor): boolean {
-  return type.raw.startsWith('integerPropType');
+function isIntegerType(type?: PropTypeDescriptor): boolean {
+  return !!type && type.raw.startsWith('integerPropType');
 }
 
-export function isElementAcceptingRefProp(type: PropTypeDescriptor): boolean {
-  return /^elementAcceptingRef/.test(type.raw);
+export function isElementAcceptingRefProp(type?: PropTypeDescriptor): boolean {
+  return /^elementAcceptingRef/.test(type?.raw ?? '');
 }
 
-export default function generatePropTypeDescription(type: PropTypeDescriptor): string | undefined {
-  switch (type.name) {
+export default function generatePropTypeDescription(type?: PropTypeDescriptor): string | undefined {
+  switch (type?.name) {
     case 'custom': {
       if (isElementTypeAcceptingRefProp(type)) {
         return 'element type';
@@ -137,6 +145,6 @@ export default function generatePropTypeDescription(type: PropTypeDescriptor): s
     }
 
     default:
-      return type.name;
+      return type?.name;
   }
 }

--- a/packages/react-docgen-types/index.d.ts
+++ b/packages/react-docgen-types/index.d.ts
@@ -141,10 +141,7 @@ declare module 'react-docgen' {
     jsdocDefaultValue?: { computed?: boolean; value: string };
     description?: string;
     required?: boolean;
-    /**
-     * react-docgen has this as nullable but it was never treated as such
-     */
-    type: PropTypeDescriptor;
+    type?: PropTypeDescriptor;
   }
 
   export interface AllLiteralPropType {


### PR DESCRIPTION
The `type` descriptor can be `undefined` in some instances, when this script fails to detect the correct types. This would cause the script to crash and block progress. 