### PR TITLE
[v5.x][core] Remove Suspense and clock mocking from regressions and e2e tests (#44935)

### DIFF
--- a/test/e2e/TestViewer.js
+++ b/test/e2e/TestViewer.js
@@ -13,11 +13,9 @@ function TestViewer(props) {
   }, []);
 
   return (
-    <React.Suspense fallback={<div aria-busy />}>
-      <div aria-busy={!ready} data-testid="testcase">
-        {children}
-      </div>
-    </React.Suspense>
+    <div aria-busy={!ready} data-testid="testcase">
+      {children}
+    </div>
   );
 }
 

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { useFakeTimers } from 'sinon';
 import Box from '@mui/material/Box';
 import GlobalStyles from '@mui/material/GlobalStyles';
 import JoyBox from '@mui/joy/Box';
@@ -29,12 +28,6 @@ function TestViewer(props) {
     document.fonts.addEventListener('loading', handleFontsEvent);
     document.fonts.addEventListener('loadingdone', handleFontsEvent);
 
-    // Use a "real timestamp" so that we see a useful date instead of "00:00"
-    // eslint-disable-next-line react-hooks/rules-of-hooks -- not a React hook
-    const clock = useFakeTimers({
-      now: new Date('Mon Aug 18 14:11:54 2014 -0500'),
-      toFake: ['Date'],
-    });
     // In case the child triggered font fetching we're not ready yet.
     // The fonts event handler will mark the test as ready on `loadingdone`
     if (document.fonts.status === 'loaded') {
@@ -44,7 +37,6 @@ function TestViewer(props) {
     return () => {
       document.fonts.removeEventListener('loading', handleFontsEvent);
       document.fonts.removeEventListener('loadingdone', handleFontsEvent);
-      clock.restore();
     };
   }, []);
 
@@ -70,27 +62,25 @@ function TestViewer(props) {
           },
         }}
       />
-      <React.Suspense fallback={<div aria-busy />}>
-        {window.location.pathname.startsWith('/docs-joy') ? (
-          <CssVarsProvider>
-            <JoyBox
-              aria-busy={!ready}
-              data-testid="testcase"
-              sx={{ bgcolor: 'background.body', display: 'inline-block', p: 1 }}
-            >
-              {children}
-            </JoyBox>
-          </CssVarsProvider>
-        ) : (
-          <Box
+      {window.location.pathname.startsWith('/docs-joy') ? (
+        <CssVarsProvider>
+          <JoyBox
             aria-busy={!ready}
             data-testid="testcase"
-            sx={{ bgcolor: 'background.default', display: 'inline-block', p: 1 }}
+            sx={{ bgcolor: 'background.body', display: 'inline-block', p: 1 }}
           >
             {children}
-          </Box>
-        )}
-      </React.Suspense>
+          </JoyBox>
+        </CssVarsProvider>
+      ) : (
+        <Box
+          aria-busy={!ready}
+          data-testid="testcase"
+          sx={{ bgcolor: 'background.default', display: 'inline-block', p: 1 }}
+        >
+          {children}
+        </Box>
+      )}
     </React.Fragment>
   );
 }


### PR DESCRIPTION
Cherry-pick #44935

We need to cherry-pick it to avoid the increased regression-test times in the `v5.x` branch.