### PR TITLE
[StepButton] Remove StepIconButton type

### DIFF
--- a/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
+++ b/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
@@ -228,3 +228,15 @@ npx @mui/codemod@next v7.0.0/input-label-size-normal-medium <path/to/folder>
 ### Removal of `data-testid` prop from `SvgIcon`
 
 The default `data-testid` prop has been removed from the icons in `@mui/icons-material` in production bundles. This change ensures that the `data-testid` prop is only defined where needed, reducing the potential for naming clashes and removing unnecessary properties in production.
+
+### StepButtonIcon type removed
+
+The deprecated `StepButtonIcon` type has been removed. Use `StepButtonProps['icon']` instead.
+
+```diff
+- import { StepButtonIcon } from '@mui/material/StepButton';
++ import { StepButtonProps } from '@mui/material/StepButton';
+
+-StepButtonIcon
++StepButtonProps['icon']
+```

--- a/packages/mui-material/src/StepButton/StepButton.d.ts
+++ b/packages/mui-material/src/StepButton/StepButton.d.ts
@@ -5,11 +5,6 @@ import { OverrideProps } from '../OverridableComponent';
 import { Theme } from '../styles';
 import { StepButtonClasses } from './stepButtonClasses';
 
-/**
- * @deprecated use `StepButtonProps['icon']` instead.
- */
-export type StepButtonIcon = React.ReactNode;
-
 export interface StepButtonOwnProps {
   /**
    * Can be a `StepLabel` or a node to place inside `StepLabel` as children.


### PR DESCRIPTION
This type has been deprecated since https://github.com/mui/material-ui/pull/20342.

The migration is manageable through search and replace, so I'm not currently adding a codemod. We can add one in the future if users report issues.
