### PR TITLE
[material-ui][styles] Remove deprecated exports

### DIFF
--- a/docs/data/material/components/grid-legacy/ResponsiveGrid.js
+++ b/docs/data/material/components/grid-legacy/ResponsiveGrid.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Grid from '@mui/material/GridLegacy';

--- a/docs/data/material/components/grid-legacy/ResponsiveGrid.tsx
+++ b/docs/data/material/components/grid-legacy/ResponsiveGrid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Grid from '@mui/material/GridLegacy';

--- a/docs/data/material/components/grid/ResponsiveGrid.js
+++ b/docs/data/material/components/grid/ResponsiveGrid.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Grid from '@mui/material/Grid';

--- a/docs/data/material/components/grid/ResponsiveGrid.tsx
+++ b/docs/data/material/components/grid/ResponsiveGrid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Grid from '@mui/material/Grid';

--- a/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
+++ b/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
@@ -69,6 +69,26 @@ If you were using a Vite alias to force ESM imports for the icons package, you s
    },
 ```
 
+### createMuiTheme removed
+
+The deprecated `createMuiTheme` function has been removed.
+Use `createTheme` instead.
+
+```diff
+-import { createMuiTheme } from '@mui/material/styles';
++import { createTheme } from '@mui/material/styles';
+```
+
+### experimentalStyled removed
+
+The deprecated `experimentalStyled` function has been removed.
+Use `styled` instead.
+
+```diff
+-import { experimentalStyled as styled } from '@mui/material/styles';
++import { styled } from '@mui/material/styles';
+```
+
 ### Grid and Grid2 renamed
 
 The deprecated `Grid` component has been renamed to `GridLegacy`.
@@ -228,3 +248,13 @@ npx @mui/codemod@next v7.0.0/input-label-size-normal-medium <path/to/folder>
 ### Removal of `data-testid` prop from `SvgIcon`
 
 The default `data-testid` prop has been removed from the icons in `@mui/icons-material` in production bundles. This change ensures that the `data-testid` prop is only defined where needed, reducing the potential for naming clashes and removing unnecessary properties in production.
+
+### StyledEngineProvider deprecated import path removed
+
+Importing `StyledEngineProvider` from `'@mui/material'` was deprecated and now has been removed.
+Import it from `'@mui/material/styles'` instead:
+
+```diff
+-import { StyledEngineProvider } from '@mui/material';
++import { StyledEngineProvider } from '@mui/material/styles';
+```

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Button.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Button.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import MuiButton from '@mui/material/Button';
 
 const ButtonRoot = styled(MuiButton)(({ theme }) => ({

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Button.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Button.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { experimentalStyled as styled } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import MuiButton, { ButtonProps } from '@mui/material/Button';
 
 const ButtonRoot = styled(MuiButton)(({ theme }) => ({

--- a/docs/src/pages/premium-themes/onepirate/modules/form/FormFeedback.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/FormFeedback.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { experimentalStyled as styled } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 
 import Typography from '../components/Typography';
 

--- a/docs/src/pages/premium-themes/onepirate/modules/form/FormFeedback.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/FormFeedback.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { experimentalStyled as styled, Theme } from '@mui/material/styles';
+import { styled, Theme } from '@mui/material/styles';
 import { SxProps } from '@mui/system';
 import Typography from '../components/Typography';
 

--- a/packages/mui-material/src/StyledEngineProvider/index.d.ts
+++ b/packages/mui-material/src/StyledEngineProvider/index.d.ts
@@ -1,4 +1,0 @@
-/**
- * @deprecated will be removed in v5.beta, please use StyledEngineProvider from @mui/material/styles instead
- */
-export { StyledEngineProvider as default } from '@mui/system';

--- a/packages/mui-material/src/StyledEngineProvider/index.js
+++ b/packages/mui-material/src/StyledEngineProvider/index.js
@@ -1,1 +1,0 @@
-export { StyledEngineProvider as default } from '@mui/system';

--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -457,11 +457,6 @@ export * from './GlobalStyles';
 
 export * from './version';
 
-/**
- * @deprecated will be removed in v5.beta, please use StyledEngineProvider from @mui/material/styles instead
- */
-export { StyledEngineProvider } from './styles';
-
 export { unstable_composeClasses } from '@mui/utils';
 
 export { default as generateUtilityClass } from './generateUtilityClass';

--- a/packages/mui-material/src/styles/createTheme.ts
+++ b/packages/mui-material/src/styles/createTheme.ts
@@ -6,7 +6,6 @@ import createThemeWithVars, {
 } from './createThemeWithVars';
 import createThemeNoVars, { Theme, ThemeOptions } from './createThemeNoVars';
 
-export { createMuiTheme } from './createThemeNoVars';
 export type { ThemeOptions, Theme, CssThemeVariables } from './createThemeNoVars';
 
 // eslint-disable-next-line consistent-return

--- a/packages/mui-material/src/styles/createThemeNoVars.d.ts
+++ b/packages/mui-material/src/styles/createThemeNoVars.d.ts
@@ -87,12 +87,6 @@ export interface Theme extends BaseTheme, CssVarsProperties {
 }
 
 /**
- * @deprecated
- * Use `import { createTheme } from '@mui/material/styles'` instead.
- */
-export function createMuiTheme(options?: ThemeOptions, ...args: object[]): Theme;
-
-/**
  * Generate a theme base on the options received.
  * @param options Takes an incomplete theme object and adds the missing parts.
  * @param args Deep merge the arguments with the about to be returned theme.

--- a/packages/mui-material/src/styles/createThemeNoVars.js
+++ b/packages/mui-material/src/styles/createThemeNoVars.js
@@ -129,23 +129,4 @@ function createThemeNoVars(options = {}, ...args) {
   return muiTheme;
 }
 
-let warnedOnce = false;
-
-export function createMuiTheme(...args) {
-  if (process.env.NODE_ENV !== 'production') {
-    if (!warnedOnce) {
-      warnedOnce = true;
-      console.error(
-        [
-          'MUI: the createMuiTheme function was renamed to createTheme.',
-          '',
-          "You should use `import { createTheme } from '@mui/material/styles'`",
-        ].join('\n'),
-      );
-    }
-  }
-
-  return createThemeNoVars(...args);
-}
-
 export default createThemeNoVars;

--- a/packages/mui-material/src/styles/index.d.ts
+++ b/packages/mui-material/src/styles/index.d.ts
@@ -2,7 +2,6 @@ export { default as THEME_ID } from './identifier';
 export {
   default as createTheme,
   default as unstable_createMuiStrictModeTheme,
-  createMuiTheme,
   ThemeOptions,
   Theme,
   CssThemeVariables,
@@ -78,10 +77,6 @@ export { default as useTheme } from './useTheme';
 export { default as useThemeProps } from './useThemeProps';
 export * from './useThemeProps';
 export { default as styled } from './styled';
-/**
- * @deprecated will be removed in v5.beta, please use styled from @mui/material/styles instead
- */
-export { default as experimentalStyled } from './styled';
 export { default as ThemeProvider } from './ThemeProvider';
 export { ComponentsProps, ComponentsPropsList } from './props';
 export { ComponentsVariants } from './variants';

--- a/packages/mui-material/src/styles/index.js
+++ b/packages/mui-material/src/styles/index.js
@@ -24,7 +24,7 @@ export function experimental_sx() {
       'For more details, see https://github.com/mui/material-ui/pull/35150.',
   );
 }
-export { default as createTheme, createMuiTheme } from './createTheme';
+export { default as createTheme } from './createTheme';
 export { default as unstable_createMuiStrictModeTheme } from './createMuiStrictModeTheme';
 export { default as createStyles } from './createStyles';
 export { getUnit as unstable_getUnit, toUnitless as unstable_toUnitless } from './cssUtils';
@@ -34,7 +34,6 @@ export { default as createColorScheme } from './createColorScheme';
 export { default as useTheme } from './useTheme';
 export { default as useThemeProps } from './useThemeProps';
 export { default as styled } from './styled';
-export { default as experimentalStyled } from './styled';
 export { default as ThemeProvider } from './ThemeProvider';
 export { StyledEngineProvider } from '@mui/system';
 // The legacy utilities from @mui/styles


### PR DESCRIPTION
The following exports have been deprecated since v5:

- `createMuiTheme`
- `experimentalStyled`
- `StyledEngineProvider` from `@mui/material`

We can safely remove them, all have updated exports to replace them. The migration is manageable through search and replace, so I'm not currently adding a codemod. We can add one in the future if users report issues.