### PR TITLE
[docs][Autocomplete] Remove unnecessary renderTags prop from Sizes demo

### DIFF
--- a/docs/data/material/components/autocomplete/Sizes.js
+++ b/docs/data/material/components/autocomplete/Sizes.js
@@ -65,20 +65,6 @@ export default function Sizes() {
         options={top100Films}
         getOptionLabel={(option) => option.title}
         defaultValue={top100Films[13]}
-        renderTags={(value, getTagProps) =>
-          value.map((option, index) => {
-            const { key, ...tagProps } = getTagProps({ index });
-            return (
-              <Chip
-                key={key}
-                variant="outlined"
-                label={option.title}
-                size="small"
-                {...tagProps}
-              />
-            );
-          })
-        }
         renderInput={(params) => (
           <TextField
             {...params}

--- a/docs/data/material/components/autocomplete/Sizes.tsx
+++ b/docs/data/material/components/autocomplete/Sizes.tsx
@@ -65,20 +65,6 @@ export default function Sizes() {
         options={top100Films}
         getOptionLabel={(option) => option.title}
         defaultValue={top100Films[13]}
-        renderTags={(value, getTagProps) =>
-          value.map((option, index) => {
-            const { key, ...tagProps } = getTagProps({ index });
-            return (
-              <Chip
-                key={key}
-                variant="outlined"
-                label={option.title}
-                size="small"
-                {...tagProps}
-              />
-            );
-          })
-        }
         renderInput={(params) => (
           <TextField
             {...params}


### PR DESCRIPTION
If you're not using `multiple`, there's no need to pass the `renderTags` prop because it is only used when multiple selections are allowed.

Preview: https://deploy-preview-45401--material-ui.netlify.app/material-ui/react-autocomplete/#sizes