### PR TITLE
[docs-infra] Add `color-scheme` to document in iframe demos

### DIFF
--- a/docs/src/modules/components/DemoSandbox.js
+++ b/docs/src/modules/components/DemoSandbox.js
@@ -29,8 +29,11 @@ function FramedDemo(props) {
   const theme = useTheme();
   React.useEffect(() => {
     document.body.setAttribute('dir', theme.direction);
+  }, [document, theme.direction]);
+
+  React.useEffect(() => {
     document.documentElement.style.colorScheme = theme.palette.mode;
-  }, [document, theme.direction, theme.palette.mode]);
+  }, [document, theme.palette.mode]);
 
   const { jss, sheetsManager } = React.useMemo(() => {
     return {

--- a/docs/src/modules/components/DemoSandbox.js
+++ b/docs/src/modules/components/DemoSandbox.js
@@ -29,7 +29,8 @@ function FramedDemo(props) {
   const theme = useTheme();
   React.useEffect(() => {
     document.body.setAttribute('dir', theme.direction);
-  }, [document, theme.direction]);
+    document.documentElement.style.colorScheme = theme.palette.mode;
+  }, [document, theme.direction, theme.palette.mode]);
 
   const { jss, sheetsManager } = React.useMemo(() => {
     return {


### PR DESCRIPTION
### Problem

Originally reported [here](https://mui-org.slack.com/archives/C05SBSU8NPR/p1740007650950449).

When dark mode is enabled and we have scrollable demos displayed in an iframe, users see the following:

<img width="400" alt="Screenshot 2025-02-25 at 09 28 04" src="https://github.com/user-attachments/assets/2e1552e0-e1b8-4c87-b978-45b32642cd5a" />

### Solution

Adding the `color-scheme` to the document element:

<img width="400" alt="Screenshot 2025-02-25 at 09 28 22" src="https://github.com/user-attachments/assets/c24f06e4-e618-4d71-a236-7da3fe1722bb" />

---

Can be tested locally by making the following changes:

```diff
diff --git a/docs/data/material/components/buttons/BasicButtons.tsx b/docs/data/material/components/buttons/BasicButtons.tsx
index 60eb1dfe1e..253383b5b6 100644
--- a/docs/data/material/components/buttons/BasicButtons.tsx
+++ b/docs/data/material/components/buttons/BasicButtons.tsx
@@ -4,7 +4,13 @@ import Button from '@mui/material/Button';
 
 export default function BasicButtons() {
   return (
-    <Stack spacing={2} direction="row">
+    <Stack spacing={2} direction="column" sx={{ overflow: 'auto' }}>
+      <Button variant="text">Text</Button>
+      <Button variant="contained">Contained</Button>
+      <Button variant="outlined">Outlined</Button>
+      <Button variant="text">Text</Button>
+      <Button variant="contained">Contained</Button>
+      <Button variant="outlined">Outlined</Button>
       <Button variant="text">Text</Button>
       <Button variant="contained">Contained</Button>
       <Button variant="outlined">Outlined</Button>
diff --git a/docs/data/material/components/buttons/buttons.md b/docs/data/material/components/buttons/buttons.md
index 0b1b19fe71..2303128192 100644
--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -26,7 +26,7 @@ Buttons communicate actions that users can take. They are typically placed throu
 
 The `Button` comes with three variants: text (default), contained, and outlined.
 
-{{"demo": "BasicButtons.js"}}
+{{"demo": "BasicButtons.js","iframe": true}}
 
 ### Text button

 ```