### PR TITLE
[test] Remove unnecessary renderTags prop from SizeSmallValueOverflow regression test and remove key warning

### DIFF
--- a/test/regressions/fixtures/Autocomplete/SizeSmallValueOverflow.js
+++ b/test/regressions/fixtures/Autocomplete/SizeSmallValueOverflow.js
@@ -80,16 +80,6 @@ export default function Sizes() {
         getOptionLabel={(option) => option.title}
         defaultValue={movies[0]}
         disableClearable
-        renderTags={(value, getTagProps) =>
-          value.map((option, index) => (
-            <Chip
-              variant="outlined"
-              label={option.title}
-              size="small"
-              {...getTagProps({ index })}
-            />
-          ))
-        }
         renderInput={(params) => (
           <TextField {...params} variant="filled" label="Movies" placeholder="Favorites" />
         )}
@@ -103,14 +93,12 @@ export default function Sizes() {
         defaultValue={[movies[0]]}
         disableClearable
         renderTags={(value, getTagProps) =>
-          value.map((option, index) => (
-            <Chip
-              variant="outlined"
-              label={option.title}
-              size="small"
-              {...getTagProps({ index })}
-            />
-          ))
+          value.map((option, index) => {
+            const { key, ...other } = getTagProps({ index });
+            return (
+              <Chip key={key} variant="outlined" label={option.title} size="small" {...other} />
+            );
+          })
         }
         renderInput={(params) => (
           <TextField {...params} variant="filled" label="Movies" placeholder="Favorites" />


### PR DESCRIPTION
Same as #45401 to remove unnecessary renderTags prop. 

Also fix the following `key` warning:

![Screenshot (45)](https://github.com/user-attachments/assets/a5d98759-7d60-433e-a667-7f1737c6b331)
