### PR TITLE
[material-ui][SwipeableDrawer] Safe access of ref value in SwipeableDrawer

### DIFF
--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -497,8 +497,8 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
     // At least one element clogs the drawer interaction zone.
     if (
       open &&
-      (hideBackdrop || !backdropRef.current.contains(nativeEvent.target)) &&
-      !paperRef.current.contains(nativeEvent.target)
+      (hideBackdrop || !backdropRef?.current?.contains(nativeEvent.target)) &&
+      !paperRef?.current?.contains(nativeEvent.target)
     ) {
       return;
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In the company I work for we're using **MUI** as the base for the designs system, and we started receiving a Sentry issue affecting a non-trivial amount of users. Mostly happening on our capacitor app on iOS devices.

<img width="310" alt="image" src="https://github.com/user-attachments/assets/0e7ae295-4560-40f0-bf30-30955df6511d" />

<img width="445" alt="image" src="https://github.com/user-attachments/assets/629dea65-2790-40d8-934e-c59f51e38c8d" />


After some investigation, it seems clear the error is surfacing from the mui code. Here's a screenshot of the minified code from the capacitor bundled file that Sentry mentioned.

<img width="356" alt="image" src="https://github.com/user-attachments/assets/e791f2d4-cc12-4279-baca-964a0b8ffe1b" />


Looking in the **material-ui** codebase for a similar line of code that could cause the issue, I stumbled upon the `SwipeableDrawer`, where I found a condition that looks _really_ similar to the minified code that's throwing the error. Indeed, it looks like the ref is not accessed safely in the if condition.

This simple fix I'm submitting here should solve the issue.
