### PR TITLE
[core] Fix publish dry run script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "release:build": "lerna run --concurrency 8 --no-private build --skip-nx-cache",
     "release:changelog": "node scripts/releaseChangelog.mjs",
     "release:publish": "pnpm publish --recursive --tag next",
-    "release:publish:dry-run": "pnpm publish --recursive --tag next --registry=\"http://localhost:4873/\"",
+    "release:publish:dry-run": "pnpm publish --dry-run --recursive --tag next",
     "release:tag": "node scripts/releaseTag.mjs",
     "release:pack": "tsx scripts/releasePack.mts",
     "docs:api": "rimraf --glob ./docs/pages/**/api-docs ./docs/pages/**/api && pnpm docs:api:build",


### PR DESCRIPTION
The `pnpm release:publish:dry-run` script doesn't work

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
