### PR TITLE
[code-infra] Fix build:types script omitting folders with a dot in their name

### DIFF
--- a/scripts/buildTypes.mts
+++ b/scripts/buildTypes.mts
@@ -4,7 +4,6 @@ import path from 'path';
 import yargs from 'yargs';
 import { $ } from 'execa';
 import * as babel from '@babel/core';
-import { typescriptCopy } from './copyFilesUtils.mjs';
 
 const $$ = $({ stdio: 'inherit' });
 
@@ -49,7 +48,7 @@ async function copyDeclarations(sourceDirectory: string, destinationDirectory: s
     recursive: true,
     filter: (src) => {
       // include directories and .d.ts files
-      return !src.includes('.') || src.endsWith('.d.ts');
+      return src.endsWith('.d.ts');
     },
   });
 }
@@ -66,7 +65,7 @@ async function main(argv: HandlerArgv) {
   const esmFolder = path.join(buildFolder, 'esm');
   const modernFolder = path.join(buildFolder, 'modern');
 
-  await typescriptCopy({ from: srcPath, to: esmFolder });
+  await copyDeclarations(srcPath, esmFolder);
 
   if (!argv.skipTsc) {
     const tsconfigPath = path.join(packageRoot, 'tsconfig.build.json');

--- a/scripts/buildTypes.mts
+++ b/scripts/buildTypes.mts
@@ -4,7 +4,6 @@ import path from 'path';
 import yargs from 'yargs';
 import { $ } from 'execa';
 import * as babel from '@babel/core';
-import { stat } from 'fs';
 
 const $$ = $({ stdio: 'inherit' });
 

--- a/scripts/buildTypes.mts
+++ b/scripts/buildTypes.mts
@@ -4,6 +4,7 @@ import path from 'path';
 import yargs from 'yargs';
 import { $ } from 'execa';
 import * as babel from '@babel/core';
+import { stat } from 'fs';
 
 const $$ = $({ stdio: 'inherit' });
 
@@ -46,9 +47,16 @@ async function copyDeclarations(sourceDirectory: string, destinationDirectory: s
 
   await fs.cp(fullSourceDirectory, fullDestinationDirectory, {
     recursive: true,
-    filter: (src) => {
-      // include directories and .d.ts files, exclude dotfiles
-      return !src.startsWith('.') && src.endsWith('.d.ts');
+    filter: async (src) => {
+      if (src.startsWith('.')) {
+        // ignore dotfiles
+        return false;
+      }
+      const stats = await fs.stat(src);
+      if (stats.isDirectory()) {
+        return true;
+      }
+      return src.endsWith('.d.ts');
     },
   });
 }

--- a/scripts/buildTypes.mts
+++ b/scripts/buildTypes.mts
@@ -47,8 +47,8 @@ async function copyDeclarations(sourceDirectory: string, destinationDirectory: s
   await fs.cp(fullSourceDirectory, fullDestinationDirectory, {
     recursive: true,
     filter: (src) => {
-      // include directories and .d.ts files
-      return src.endsWith('.d.ts');
+      // include directories and .d.ts files, exclude dotfiles
+      return !src.startsWith('.') || src.endsWith('.d.ts');
     },
   });
 }

--- a/scripts/buildTypes.mts
+++ b/scripts/buildTypes.mts
@@ -48,7 +48,7 @@ async function copyDeclarations(sourceDirectory: string, destinationDirectory: s
     recursive: true,
     filter: (src) => {
       // include directories and .d.ts files, exclude dotfiles
-      return !src.startsWith('.') || src.endsWith('.d.ts');
+      return !src.startsWith('.') && src.endsWith('.d.ts');
     },
   });
 }


### PR DESCRIPTION
Uncovered when someone tried to publish from a project folder named `material-ui.git`
This function was copied from the base ui codebase. Checking for non-existence of a dot is a poor way of detecting folders. We can't build this without actually checking whether `src` is a folder.