### PR TITLE
Remove unused icon names from the download script

### DIFF
--- a/packages/mui-icons-material/scripts/download.mjs
+++ b/packages/mui-icons-material/scripts/download.mjs
@@ -18,33 +18,16 @@ const ignoredIconNames = new Set([
   '123',
   '6_ft_apart',
   'add_chart', // Leads to inconsistent casing with `Addchart`
-  'compost',
-  'cruelty_free',
-  'data_exploration',
-  'disabled_visible',
-  'drive_file_move_rtl',
   'exposure_neg_1', // Google product
   'exposure_neg_2', // Google product
   'exposure_plus_1', // Google product
   'exposure_plus_2', // Google product
   'exposure_zero', // Google product
-  'free_cancellation',
-  'front_hand',
-  'generating_tokens',
-  'group_off',
   'horizontal_distribute', // Advanced text editor
-  'hotel_class',
-  'incomplete_circle',
   'motion_photos_on', // Google product
   'motion_photos_pause', // Google product
   'motion_photos_paused', // Google product
-  'new_label',
-  'personal_injury',
-  'pin_end',
-  'pin_invoke',
   'polymer', // Legacy brand
-  'private_connectivity',
-  'real_estate_agent',
   'vertical_distribute', // Advanced text editor
 ]);
 


### PR DESCRIPTION
Remove unused icon names from the download script

Fixes: https://github.com/mui/material-ui/issues/45189

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
