### PR TITLE
[Radio] Fix `inputProps` not forwarded

### DIFF
--- a/packages/mui-material/src/Radio/Radio.js
+++ b/packages/mui-material/src/Radio/Radio.js
@@ -127,6 +127,7 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
     disableRipple = false,
     slots = {},
     slotProps = {},
+    inputProps,
     ...other
   } = props;
 
@@ -166,6 +167,8 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
     }
   }
 
+  const externalInputProps = slotProps.input ?? inputProps;
+
   const [RootSlot, rootSlotProps] = useSlot('root', {
     ref,
     elementType: RadioRoot,
@@ -197,7 +200,9 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
       slotProps: {
         // Do not forward `slotProps.root` again because it's already handled by the `RootSlot` in this file.
         input:
-          typeof slotProps.input === 'function' ? slotProps.input(ownerState) : slotProps.input,
+          typeof externalInputProps === 'function'
+            ? externalInputProps(ownerState)
+            : externalInputProps,
       },
     },
   });

--- a/packages/mui-material/src/Radio/Radio.test.js
+++ b/packages/mui-material/src/Radio/Radio.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer } from '@mui/internal-test-utils';
+import { createRenderer, screen } from '@mui/internal-test-utils';
 import Radio, { radioClasses as classes } from '@mui/material/Radio';
 import FormControl from '@mui/material/FormControl';
 import ButtonBase from '@mui/material/ButtonBase';
@@ -141,5 +141,11 @@ describe('<Radio />', () => {
         paddingRight: '2px',
       });
     });
+  });
+
+  it('deprecated `inputProps` should work', () => {
+    render(<Radio inputProps={{ 'aria-label': 'A' }} />);
+
+    expect(screen.queryByRole('radio', { name: 'A' })).not.to.equal(null);
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #45447

## Root cause

The `slotProps.input` is explicitly passed to SwitchBase which always override `inputProps`.

## Fix

Did the same as the Checkbox by fallback the `slotProps.input` to `inputProps`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
