### PR TITLE
[material-ui][utils] use correct iri-reference homepage format [NOTICKET]

### DIFF
--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/mui/material-ui/issues"
   },
-  "homepage": "private package",
+  "homepage": "https://github.com/mui/material-ui/tree/master/packages/mui-utils",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui-org"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I had the issue that generating an SBOM with https://github.com/CycloneDX/cyclonedx-node-npm#readme created invalid sboms since the homepage had an invalid iri-reference 

Do I need to create a PR for the 5.x and 6.x branches as well?