### PR TITLE
[codemod] Fix codemods not found

### DIFF
--- a/packages/mui-codemod/codemod.js
+++ b/packages/mui-codemod/codemod.js
@@ -17,8 +17,8 @@ async function runJscodeshiftTransform(transform, files, flags, codemodFlags) {
   const paths = [
     path.resolve(__dirname, './src', `${transform}/index.js`),
     path.resolve(__dirname, './src', `${transform}.js`),
-    path.resolve(__dirname, './node', `${transform}/index.js`),
-    path.resolve(__dirname, './node', `${transform}.js`),
+    path.resolve(__dirname, './', `${transform}/index.js`),
+    path.resolve(__dirname, './', `${transform}.js`),
   ];
 
   let transformerPath;
@@ -107,7 +107,7 @@ async function runPostcssTransform(transform, files) {
   // local postcss plugins are loaded through config files https://github.com/postcss/postcss-load-config/issues/17#issuecomment-253125559
   const paths = [
     path.resolve(__dirname, './src', `${transform}/postcss.config.js`),
-    path.resolve(__dirname, './node', `${transform}/postcss.config.js`),
+    path.resolve(__dirname, './', `${transform}/postcss.config.js`),
   ];
 
   let configPath;


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/45445

After https://github.com/mui/material-ui/pull/43264, the codemod package no longer packages the codemods inside the `./node` folder, but in the root (`./`). We have to update the codemod script to search in `./` instead of `./node`.

Layout before: https://unpkg.com/browse/@mui/codemod@6.4.6/
Layout after: https://unpkg.com/browse/@mui/codemod@7.0.0-beta.1/

