### PR TITLE
correct ChipLabel lineHeight

### DIFF
--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -132,6 +132,7 @@ const ChipLabel = styled('span', {
   order: 1,
   minInlineSize: 0,
   flexGrow: 1,
+  lineHeight: 'normal',
   ...(ownerState.clickable && {
     zIndex: 1,
     pointerEvents: 'none',

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -132,7 +132,6 @@ const ChipLabel = styled('span', {
   order: 1,
   minInlineSize: 0,
   flexGrow: 1,
-  lineHeight: 'normal',
   ...(ownerState.clickable && {
     zIndex: 1,
     pointerEvents: 'none',

--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -348,6 +348,7 @@ const ChipLabel = styled('span', {
   paddingLeft: 12,
   paddingRight: 12,
   whiteSpace: 'nowrap',
+  lineHeight: 'normal',
   variants: [
     {
       props: { variant: 'outlined' },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

closes #45097

Changed line-height of label component, that it shown correctly 

before:
<img width="326" alt="image" src="https://github.com/user-attachments/assets/41cb5211-f925-46b8-bf10-e13c65a606e5" />
after:
<img width="230" alt="image" src="https://github.com/user-attachments/assets/973a20cb-231e-422d-a05e-7436598d89f3" />
