### PR TITLE
[material-ui][ListItemText] Add missing `root` slot

### DIFF
--- a/docs/pages/material-ui/api/list-item-text.json
+++ b/docs/pages/material-ui/api/list-item-text.json
@@ -19,14 +19,14 @@
     "slotProps": {
       "type": {
         "name": "shape",
-        "description": "{ primary?: func<br>&#124;&nbsp;object, secondary?: func<br>&#124;&nbsp;object }"
+        "description": "{ primary?: func<br>&#124;&nbsp;object, root?: func<br>&#124;&nbsp;object, secondary?: func<br>&#124;&nbsp;object }"
       },
       "default": "{}"
     },
     "slots": {
       "type": {
         "name": "shape",
-        "description": "{ primary?: elementType, secondary?: elementType }"
+        "description": "{ primary?: elementType, root?: elementType, secondary?: elementType }"
       },
       "default": "{}"
     },
@@ -44,6 +44,12 @@
     "import { ListItemText } from '@mui/material';"
   ],
   "slots": [
+    {
+      "name": "root",
+      "description": "The component that renders the root slot.",
+      "default": "'div'",
+      "class": "MuiListItemText-root"
+    },
     {
       "name": "primary",
       "description": "The component that renders the primary slot.",
@@ -74,12 +80,6 @@
       "key": "multiline",
       "className": "MuiListItemText-multiline",
       "description": "Styles applied to the Typography component if primary and secondary are set.",
-      "isGlobal": false
-    },
-    {
-      "key": "root",
-      "className": "MuiListItemText-root",
-      "description": "Styles applied to the root element.",
       "isGlobal": false
     }
   ],

--- a/docs/translations/api-docs/list-item-text/list-item-text.json
+++ b/docs/translations/api-docs/list-item-text/list-item-text.json
@@ -38,11 +38,11 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the Typography component",
       "conditions": "primary and secondary are set"
-    },
-    "root": { "description": "Styles applied to the root element." }
+    }
   },
   "slotDescriptions": {
     "primary": "The component that renders the primary slot.",
+    "root": "The component that renders the root slot.",
     "secondary": "The component that renders the secondary slot."
   }
 }

--- a/packages/mui-material/src/ListItemText/ListItemText.d.ts
+++ b/packages/mui-material/src/ListItemText/ListItemText.d.ts
@@ -7,6 +7,11 @@ import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
 
 export interface ListItemTextSlots {
   /**
+   * The component that renders the root slot.
+   * @default 'div'
+   */
+  root?: React.ElementType;
+  /**
    * The component that renders the primary slot.
    * @default Typography
    */
@@ -21,6 +26,11 @@ export interface ListItemTextSlots {
 export type ListItemTextSlotsAndSlotProps = CreateSlotsAndSlotProps<
   ListItemTextSlots,
   {
+    /**
+     * Props forwared to the root slot.
+     * By default, the available props are based on `div` element.
+     */
+    root: SlotProps<'div', {}, ListItemTextOwnerState>;
     /**
      * Props forwared to the primary slot (as long as disableTypography is not `true`)
      * By default, the available props are based on the [Typography](https://mui.com/material-ui/api/typography/#props) component

--- a/packages/mui-material/src/ListItemText/ListItemText.js
+++ b/packages/mui-material/src/ListItemText/ListItemText.js
@@ -105,6 +105,17 @@ const ListItemText = React.forwardRef(function ListItemText(inProps, ref) {
     },
   };
 
+  const [RootSlot, rootSlotProps] = useSlot('root', {
+    className: clsx(classes.root, className),
+    elementType: ListItemTextRoot,
+    externalForwardedProps: {
+      ...externalForwardedProps,
+      ...other,
+    },
+    ownerState,
+    ref,
+  });
+
   const [PrimarySlot, primarySlotProps] = useSlot('primary', {
     className: classes.primary,
     elementType: Typography,
@@ -139,15 +150,10 @@ const ListItemText = React.forwardRef(function ListItemText(inProps, ref) {
   }
 
   return (
-    <ListItemTextRoot
-      className={clsx(classes.root, className)}
-      ownerState={ownerState}
-      ref={ref}
-      {...other}
-    >
+    <RootSlot {...rootSlotProps}>
       {primary}
       {secondary}
-    </ListItemTextRoot>
+    </RootSlot>
   );
 });
 

--- a/packages/mui-material/src/ListItemText/ListItemText.js
+++ b/packages/mui-material/src/ListItemText/ListItemText.js
@@ -214,6 +214,7 @@ ListItemText.propTypes /* remove-proptypes */ = {
    */
   slotProps: PropTypes.shape({
     primary: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     secondary: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   }),
   /**
@@ -222,6 +223,7 @@ ListItemText.propTypes /* remove-proptypes */ = {
    */
   slots: PropTypes.shape({
     primary: PropTypes.elementType,
+    root: PropTypes.elementType,
     secondary: PropTypes.elementType,
   }),
   /**

--- a/packages/mui-material/src/ListItemText/ListItemText.test.js
+++ b/packages/mui-material/src/ListItemText/ListItemText.test.js
@@ -22,6 +22,9 @@ describe('<ListItemText />', () => {
       secondary: {
         expectedClassName: classes.secondary,
       },
+      root: {
+        expectedClassName: classes.root,
+      },
     },
     skip: ['componentProp', 'componentsProp'],
   }));


### PR DESCRIPTION
This PR #44571 missed adding root slot, I've added it to make it consistent across components