### PR TITLE
[material-ui] Fix negative input for CSS variables spacing array

### DIFF
--- a/packages/mui-material/src/styles/createTheme.test.js
+++ b/packages/mui-material/src/styles/createTheme.test.js
@@ -240,7 +240,31 @@ describe('createTheme', () => {
     describe('spacing', () => {
       it('should provide the default spacing', () => {
         const theme = createTheme({ cssVariables: true });
-        expect(theme.spacing(1)).to.equal(`calc(1 * var(--mui-spacing, 8px))`);
+        expect(theme.spacing(1)).to.equal(`var(--mui-spacing, 8px)`);
+        expect(theme.spacing(2)).to.equal(`calc(2 * var(--mui-spacing, 8px))`);
+      });
+    });
+
+    describe('spacing array', () => {
+      it('should create spacing vars array', () => {
+        const theme = createTheme({ cssVariables: true, spacing: [0, 4, 8] });
+        expect(theme.vars.spacing).to.deep.equal([
+          'var(--mui-spacing-0, 0px)',
+          'var(--mui-spacing-1, 4px)',
+          'var(--mui-spacing-2, 8px)',
+        ]);
+      });
+
+      it('should work with positive input', () => {
+        const theme = createTheme({ cssVariables: true, spacing: [0, 4, 8] });
+        expect(theme.spacing(1)).to.equal(`var(--mui-spacing-1, 4px)`);
+        expect(theme.spacing(2)).to.equal(`var(--mui-spacing-2, 8px)`);
+      });
+
+      it('should work with negative input', () => {
+        const theme = createTheme({ cssVariables: true, spacing: [0, 4, 8] });
+        expect(theme.spacing(-1)).to.equal(`calc(-1 * var(--mui-spacing-1, 4px))`);
+        expect(theme.spacing(-2)).to.equal(`calc(-1 * var(--mui-spacing-2, 8px))`);
       });
     });
   });

--- a/packages/mui-system/src/spacing/spacing.js
+++ b/packages/mui-system/src/spacing/spacing.js
@@ -110,6 +110,9 @@ export function createUnaryUnit(theme, themeKey, defaultValue, propName) {
       }
 
       if (typeof themeSpacing === 'string') {
+        if (themeSpacing.startsWith('var(') && val === 1) {
+          return themeSpacing;
+        }
         return `calc(${val} * ${themeSpacing})`;
       }
       return themeSpacing * val;
@@ -150,6 +153,10 @@ export function createUnaryUnit(theme, themeKey, defaultValue, propName) {
 
       if (typeof transformed === 'number') {
         return -transformed;
+      }
+
+      if (typeof transformed === 'string' && transformed.startsWith('var(')) {
+        return `calc(-1 * ${transformed})`;
       }
 
       return `-${transformed}`;

--- a/packages/mui-system/src/spacing/spacing.js
+++ b/packages/mui-system/src/spacing/spacing.js
@@ -110,6 +110,9 @@ export function createUnaryUnit(theme, themeKey, defaultValue, propName) {
       }
 
       if (typeof themeSpacing === 'string') {
+        if (themeSpacing.startsWith('var(') && val === 0) {
+          return 0;
+        }
         if (themeSpacing.startsWith('var(') && val === 1) {
           return themeSpacing;
         }

--- a/packages/mui-system/src/spacing/spacing.test.js
+++ b/packages/mui-system/src/spacing/spacing.test.js
@@ -167,6 +167,42 @@ describe('system spacing', () => {
       expect(output).to.deep.equal({ padding: 'var(--mui-spacing)' });
     });
 
+    it('should support CSS variables single value as decimal', () => {
+      const output = spacing({
+        theme: {
+          vars: {
+            spacing: 'var(--mui-spacing)',
+          },
+        },
+        p: 0.2,
+      });
+      expect(output).to.deep.equal({ padding: 'calc(0.2 * var(--mui-spacing))' });
+    });
+
+    it('should support CSS variables single value more than 1', () => {
+      const output = spacing({
+        theme: {
+          vars: {
+            spacing: 'var(--mui-spacing)',
+          },
+        },
+        p: 3,
+      });
+      expect(output).to.deep.equal({ padding: 'calc(3 * var(--mui-spacing))' });
+    });
+
+    it('should support CSS variables single value as zero', () => {
+      const output = spacing({
+        theme: {
+          vars: {
+            spacing: 'var(--mui-spacing)',
+          },
+        },
+        p: 0,
+      });
+      expect(output).to.deep.equal({ padding: 0 });
+    });
+
     it('should support CSS variables array', () => {
       const output = spacing({
         theme: {
@@ -183,6 +219,30 @@ describe('system spacing', () => {
         p: 2,
       });
       expect(output).to.deep.equal({ padding: 'var(--mui-spacing-2)' });
+    });
+
+    it('should support CSS variables array with negative value', () => {
+      const output = spacing({
+        theme: {
+          vars: {
+            spacing: ['var(--mui-spacing-0)', 'var(--mui-spacing-1)', 'var(--mui-spacing-2)'],
+          },
+        },
+        p: -2,
+      });
+      expect(output).to.deep.equal({ padding: 'calc(-1 * var(--mui-spacing-2))' });
+    });
+
+    it('should support CSS variables array with zero value', () => {
+      const output = spacing({
+        theme: {
+          vars: {
+            spacing: ['var(--mui-spacing-0)', 'var(--mui-spacing-1)', 'var(--mui-spacing-2)'],
+          },
+        },
+        p: 0,
+      });
+      expect(output).to.deep.equal({ padding: 'var(--mui-spacing-0)' });
     });
 
     it('should support breakpoints', () => {

--- a/packages/mui-system/src/spacing/spacing.test.js
+++ b/packages/mui-system/src/spacing/spacing.test.js
@@ -164,7 +164,7 @@ describe('system spacing', () => {
         },
         p: 1,
       });
-      expect(output).to.deep.equal({ padding: 'calc(1 * var(--mui-spacing))' });
+      expect(output).to.deep.equal({ padding: 'var(--mui-spacing)' });
     });
 
     it('should support CSS variables array', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #45500 

## Issue

Using negative spacing input does not work

```js
const theme =createTheme({ cssVariables: true, spacing: [0, 4, 8] });

theme.spacing(-2) // ❌ does not work, it should produce `calc(-1 * var(--mui-spacing-2))`
```

## Root cause

The logic does not handle the negative input, e.g. `theme.spacing(-2)` when the spacing input is an array and CSS variables enabled.

Please see the tests.

## Improvements

This PR also include improvements for input value as `0` and `1` to save some bytes.

**Before**:

```js
theme.spacing(0); // calc(0 * var(--mui-spacing))
theme.spacing(1); // calc(1 * var(--mui-spacing))
```

**After**:

```js
theme.spacing(0); // 0
theme.spacing(1); // var(--mui-spacing)
```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
