### PR TITLE
[core] Rename some `@mui/material/styles/createTypography` exports

### DIFF
--- a/packages/mui-material/src/Typography/Typography.d.ts
+++ b/packages/mui-material/src/Typography/Typography.d.ts
@@ -3,7 +3,7 @@ import { OverridableStringUnion } from '@mui/types';
 import { SxProps, SystemProps } from '@mui/system';
 import { Theme, TypeText } from '../styles';
 import { OverrideProps, OverridableComponent } from '../OverridableComponent';
-import { Variant } from '../styles/createTypography';
+import { TypographyVariant } from '../styles/createTypography';
 import { TypographyClasses } from './typographyClasses';
 
 export interface TypographyPropsVariantOverrides {}
@@ -68,7 +68,7 @@ export interface TypographyOwnProps extends Omit<SystemProps<Theme>, 'color'> {
    * Applies the theme typography styles.
    * @default 'body1'
    */
-  variant?: OverridableStringUnion<Variant | 'inherit', TypographyPropsVariantOverrides>;
+  variant?: OverridableStringUnion<TypographyVariant | 'inherit', TypographyPropsVariantOverrides>;
   /**
    * The component maps the variant prop to a range of different HTML element types.
    * For instance, subtitle1 to `<h6>`.
@@ -89,7 +89,10 @@ export interface TypographyOwnProps extends Omit<SystemProps<Theme>, 'color'> {
    * }
    */
   variantMapping?: Partial<
-    Record<OverridableStringUnion<Variant | 'inherit', TypographyPropsVariantOverrides>, string>
+    Record<
+      OverridableStringUnion<TypographyVariant | 'inherit', TypographyPropsVariantOverrides>,
+      string
+    >
   >;
 }
 

--- a/packages/mui-material/src/styles/adaptV4Theme.d.ts
+++ b/packages/mui-material/src/styles/adaptV4Theme.d.ts
@@ -1,7 +1,7 @@
 import { BreakpointsOptions, ShapeOptions, SpacingOptions } from '@mui/system';
 import { MixinsOptions } from './createMixins';
 import { Palette, PaletteOptions } from './createPalette';
-import { TypographyOptions } from './createTypography';
+import { TypographyVariantsOptions } from './createTypography';
 import { Shadows } from './shadows';
 import { TransitionsOptions } from './createTransitions';
 import { ZIndexOptions } from './zIndex';
@@ -23,7 +23,7 @@ export interface DeprecatedThemeOptions {
   shadows?: Shadows;
   spacing?: SpacingOptions;
   transitions?: TransitionsOptions;
-  typography?: TypographyOptions | ((palette: Palette) => TypographyOptions);
+  typography?: TypographyVariantsOptions | ((palette: Palette) => TypographyVariantsOptions);
   variants?: ComponentsVariants;
   zIndex?: ZIndexOptions;
   unstable_strictMode?: boolean;

--- a/packages/mui-material/src/styles/createThemeNoVars.d.ts
+++ b/packages/mui-material/src/styles/createThemeNoVars.d.ts
@@ -7,7 +7,7 @@ import {
 } from '@mui/system';
 import { Mixins, MixinsOptions } from './createMixins';
 import { Palette, PaletteOptions } from './createPalette';
-import { Typography, TypographyOptions } from './createTypography';
+import { TypographyVariants, TypographyVariantsOptions } from './createTypography';
 import { Shadows } from './shadows';
 import { Transitions, TransitionsOptions } from './createTransitions';
 import { ZIndex, ZIndexOptions } from './zIndex';
@@ -38,7 +38,7 @@ export interface ThemeOptions extends Omit<SystemThemeOptions, 'zIndex'>, CssVar
   palette?: PaletteOptions;
   shadows?: Shadows;
   transitions?: TransitionsOptions;
-  typography?: TypographyOptions | ((palette: Palette) => TypographyOptions);
+  typography?: TypographyVariantsOptions | ((palette: Palette) => TypographyVariantsOptions);
   zIndex?: ZIndexOptions;
   unstable_strictMode?: boolean;
   unstable_sxConfig?: SxConfig;
@@ -49,7 +49,7 @@ export interface BaseTheme extends SystemTheme {
   palette: Palette & (CssThemeVariables extends { enabled: true } ? CssVarsPalette : {});
   shadows: Shadows;
   transitions: Transitions;
-  typography: Typography;
+  typography: TypographyVariants;
   zIndex: ZIndex;
   unstable_strictMode?: boolean;
 }

--- a/packages/mui-material/src/styles/createTypography.d.ts
+++ b/packages/mui-material/src/styles/createTypography.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as CSS from 'csstype';
 import { Palette } from './createPalette';
 
-export type Variant =
+export type TypographyVariant =
   | 'h1'
   | 'h2'
   | 'h3'
@@ -63,12 +63,15 @@ export interface TypographyUtils {
   pxToRem: (px: number) => string;
 }
 
-export interface Typography extends Record<Variant, TypographyStyle>, FontStyle, TypographyUtils {}
+export interface TypographyVariants
+  extends Record<TypographyVariant, TypographyStyle>,
+    FontStyle,
+    TypographyUtils {}
 
-export interface TypographyOptions
-  extends Partial<Record<Variant, TypographyStyleOptions> & FontStyleOptions> {}
+export interface TypographyVariantsOptions
+  extends Partial<Record<TypographyVariant, TypographyStyleOptions> & FontStyleOptions> {}
 
 export default function createTypography(
   palette: Palette,
-  typography: TypographyOptions | ((palette: Palette) => TypographyOptions),
-): Typography;
+  typography: TypographyVariantsOptions | ((palette: Palette) => TypographyVariantsOptions),
+): TypographyVariants;

--- a/packages/mui-material/src/styles/index.d.ts
+++ b/packages/mui-material/src/styles/index.d.ts
@@ -25,10 +25,10 @@ export {
 export { default as createColorScheme } from './createColorScheme';
 export { default as createStyles } from './createStyles';
 export {
-  Typography as TypographyVariants,
-  TypographyOptions as TypographyVariantsOptions,
+  TypographyVariants,
+  TypographyVariantsOptions,
   TypographyStyle,
-  Variant as TypographyVariant,
+  TypographyVariant,
 } from './createTypography';
 export { default as responsiveFontSizes } from './responsiveFontSizes';
 export {

--- a/packages/mui-material/src/styles/responsiveFontSizes.d.ts
+++ b/packages/mui-material/src/styles/responsiveFontSizes.d.ts
@@ -1,14 +1,14 @@
 import { Breakpoint } from '@mui/system';
-import { Typography } from './createTypography';
+import { TypographyVariants } from './createTypography';
 
 export interface ResponsiveFontSizesOptions {
   breakpoints?: Breakpoint[];
   disableAlign?: boolean;
   factor?: number;
-  variants?: Array<keyof Typography>;
+  variants?: Array<keyof TypographyVariants>;
 }
 
-export default function responsiveFontSizes<T extends { typography: Typography }>(
+export default function responsiveFontSizes<T extends { typography: TypographyVariants }>(
   theme: T,
   options?: ResponsiveFontSizesOptions,
 ): T;


### PR DESCRIPTION
Rename some interfaces to match the publicly exported ones. `@mui/material/styles/createTypography` is not exported and these are aliased and publicly exported in `@mui/material/styles`. this way we can remove the alias, there is no need to have an internal name that is different from the public one.

https://github.com/mui/material-ui/blob/9ab5dcf63fabfd70243a4ac1486f659793b79e7f/packages/mui-material/src/styles/index.d.ts#L27-L32

=>

https://github.com/mui/material-ui/blob/a867bfcbd3136820b69ad09a6284d24fdc978c0c/packages/mui-material/src/styles/index.d.ts#L27-L32

This is not a breaking change if you're importing from `@mui/material/styles`, if you're importing from `@mui/material/styles/createTheme` then it will already break due to the subpath not being exported.