### PR TITLE
[code-infra] Make `getVersionEnvVariables` reusable for other repos

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,5 +1,4 @@
 import childProcess from 'child_process';
-import glob from 'fast-glob';
 import path from 'path';
 import { promisify } from 'util';
 import yargs from 'yargs';
@@ -67,7 +66,7 @@ async function run(argv) {
     MUI_BUILD_VERBOSE: verbose,
     MUI_BABEL_RUNTIME_VERSION: babelRuntimeVersion,
     MUI_OUT_FILE_EXTENSION: outFileExtension,
-    ...(await getVersionEnvVariables()),
+    ...(await getVersionEnvVariables(packageJson)),
   };
 
   const babelArgs = [

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,6 +1,5 @@
 import path from 'path';
 import url from 'url';
-import fs from 'fs/promises';
 
 /**
  * Returns the full path of the root directory of this repository.
@@ -15,12 +14,10 @@ export function getWorkspaceRoot() {
 /**
  * Returns the version and destructured values of the version as env variables to be replaced.
  */
-export async function getVersionEnvVariables() {
-  const packageJsonData = await fs.readFile(path.resolve('./package.json'), 'utf8');
-  const { version = null } = JSON.parse(packageJsonData);
-
+export function getVersionEnvVariables(pkgJson) {
+  const version = pkgJson.version;
   if (!version) {
-    throw new Error('Could not find the version in the package.json');
+    throw new Error('No version found in package.json');
   }
 
   const [versionNumber, prerelease] = version.split('-');


### PR DESCRIPTION
For https://github.com/mui/mui-x/pull/16931
Also to avoid hitting the filesystem twice to read package.json