### PR TITLE
[release] v7.0.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ This release contains bug fixes 🐛 and improvements to the new package layout 
 - [code-infra] Convert a few docs modules to ts (#45548) @Janpot
 - [code-infra] Remove more CJS modules from the docs (#45557) @Janpot
 - [code-infra] Remove nested imports from theme augmentation (#45514) @Janpot
-- [docs-infra] Add @ts-ignore to avoid type checking for MUI X (#45555) @siriwatknp
+- [docs-infra] Add @ts-ignore to avoid type checking for MUI X (#45555) @siriwatknp
 - [blog] Fix author end-of-year updates (#45533) @oliviertassinari
 
 All contributors of this release in alphabetical order: @dahiro, @DiegoAndai, @Janpot, @Jtaks, @mj12albert, @oliviertassinari, @sai6855, @siriwatknp, @vipierozan99, @yermartee

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 <!-- generated comparing v7.0.0-beta.3..master -->
 
-_Mar 12, 2025_
+_Mar 13, 2025_
 
 A big thanks to the 10 contributors who made this release possible.
 This release contains bug fixes 🐛 and improvements to the new package layout 🏗️.
@@ -43,7 +43,7 @@ This release contains bug fixes 🐛 and improvements to the new package layout 
 ### `@mui/utils@7.0.0-beta.4`
 
 - Fix package layout inconsistencies (#45491) @DiegoAndai
-- use correct iri-reference homepage format (#45472) @dahiro
+- Use correct iri-reference homepage format (#45472) @dahiro
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,65 @@
 # [Versions](https://mui.com/versions/)
 
+## 7.0.0-beta.4
+
+<!-- generated comparing v7.0.0-beta.3..master -->
+
+_Mar 12, 2025_
+
+A big thanks to the 10 contributors who made this release possible.
+This release contains bug fixes 🐛 and improvements to the new package layout 🏗️.
+
+### `@mui/material@7.0.0-beta.4`
+
+- [Accordion] Add missing `root` slot (#45532) @sai6855
+- [AccordionSummary] Add slots and slotProps (#45559) @sai6855
+- [ListItemText] Add missing `root` slot (#45540) @sai6855
+- [SpeedDial] Add missing `root` slot (#45541) @sai6855
+- [Tooltip] Allow auto placement on tooltip (#45399) @Jtaks
+- [useScrollTrigger] Do nothing if target is null (#45441) @vipierozan99
+- [TextareaAutosize] Fix ResizeObserver causing infinite `selectionchange` loop (#45351) @mj12albert
+- Fix negative input for CSS variables spacing array (#45550) @siriwatknp
+- Add missing deprecations in deprecations-all file (#45505) @sai6855
+- Rename some `@mui/material/styles/createTypography` exports (#45558) @Janpot
+
+### `@mui/icons-material@7.0.0-beta.4`
+
+- Remove unused icon names from the download script (#45453) @yermartee
+
+### `@mui/system@7.0.0-beta.4`
+
+- Prevent nested non-vars theme inheritance (#45545) @siriwatknp
+- Disable theme recalculation as default behavior (#45405) @siriwatknp
+- Fix package layout inconsistencies (#45491) @DiegoAndai
+
+### `@mui/styled-engine@7.0.0-beta.4`
+
+- Add `enableCssLayer` prop to StyledEngineProvider (#45428) @siriwatknp
+
+### `@mui/types@7.3.0`
+
+- [code-infra] Fix type resolution for @mui/types (#45513) @Janpot
+
+### `@mui/utils@7.0.0-beta.4`
+
+- Fix package layout inconsistencies (#45491) @DiegoAndai
+- use correct iri-reference homepage format (#45472) @dahiro
+
+### Docs
+
+- [Backdrop] Fix component name in migration guide (#45506) @sai6855
+- [TextField] Add HTML input section to TextField page (#45439) @siriwatknp
+
+### Core
+
+- [code-infra] Convert a few docs modules to ts (#45548) @Janpot
+- [code-infra] Remove more CJS modules from the docs (#45557) @Janpot
+- [code-infra] Remove nested imports from theme augmentation (#45514) @Janpot
+- [docs-infra] Add @ts-ignore to avoid type checking for MUI X (#45555) @siriwatknp
+- [blog] Fix author end-of-year updates (#45533) @oliviertassinari
+
+All contributors of this release in alphabetical order: @dahiro, @DiegoAndai, @Janpot, @Jtaks, @mj12albert, @oliviertassinari, @sai6855, @siriwatknp, @vipierozan99, @yermartee
+
 ## 7.0.0-beta.3
 
 <!-- generated comparing v7.0.0-beta.2..master -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/monorepo",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/packages-internal/scripts/package.json
+++ b/packages-internal/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/internal-scripts",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": "MUI Team",
   "description": "Utilities supporting MUI libraries build and docs generation. This is an internal package not meant for general use.",
   "main": "build/index.js",

--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/base",
-  "version": "5.0.0-beta.69",
+  "version": "7.0.0-beta.4",
   "private": false,
   "author": "MUI Team",
   "description": "MUI Base is a library of headless ('unstyled') React components and low-level hooks. You gain complete control over your app's CSS and accessibility features.",

--- a/packages/mui-codemod/package.json
+++ b/packages/mui-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/codemod",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "bin": "./codemod.js",
   "private": false,
   "author": "MUI Team",

--- a/packages/mui-core-downloads-tracker/package.json
+++ b/packages/mui-core-downloads-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/core-downloads-tracker",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "private": false,
   "author": "MUI Team",
   "description": "Internal package to track number of downloads of our design system libraries",

--- a/packages/mui-docs/package.json
+++ b/packages/mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/docs",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "private": false,
   "author": "MUI Team",
   "description": "MUI Docs - Documentation building blocks.",

--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/icons-material",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "private": false,
   "author": "MUI Team",
   "description": "Material Design icons distributed as SVG React components.",

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/lab",
-  "version": "7.0.0-beta.6",
+  "version": "7.0.0-beta.7",
   "private": false,
   "author": "MUI Team",
   "description": "Laboratory for new MUI modules.",

--- a/packages/mui-material-nextjs/package.json
+++ b/packages/mui-material-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/material-nextjs",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "private": false,
   "author": "MUI Team",
   "description": "Collection of utilities for integration between Material UI and Next.js.",

--- a/packages/mui-material-pigment-css/package.json
+++ b/packages/mui-material-pigment-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/material-pigment-css",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "author": "MUI Team",
   "description": "A wrapper over Pigment CSS that provides the same styled and theming APIs as Material UI.",
   "main": "./src/index.ts",

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/material",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "private": false,
   "author": "MUI Team",
   "description": "Material UI is an open-source React component library that implements Google's Material Design. It's comprehensive and can be used in production out of the box.",

--- a/packages/mui-private-theming/package.json
+++ b/packages/mui-private-theming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/private-theming",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "private": false,
   "author": "MUI Team",
   "description": "Private - The React theme context to be shared between `@mui/styles` and `@mui/material`.",

--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/styled-engine",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "private": false,
   "author": "MUI Team",
   "description": "styled() API wrapper package for emotion.",

--- a/packages/mui-styles/package.json
+++ b/packages/mui-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/styles",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "private": false,
   "author": "MUI Team",
   "description": "MUI Styles - The legacy JSS-based styling solution of Material UI.",

--- a/packages/mui-system/package.json
+++ b/packages/mui-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/system",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "private": false,
   "author": "MUI Team",
   "description": "MUI System is a set of CSS utilities to help you build custom designs more efficiently. It makes it possible to rapidly lay out custom designs.",

--- a/packages/mui-types/package.json
+++ b/packages/mui-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/types",
-  "version": "7.2.23",
+  "version": "7.3.0",
   "private": false,
   "author": "MUI Team",
   "description": "Utility types for MUI.",

--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/utils",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "private": false,
   "author": "MUI Team",
   "description": "Utility functions for React components.",


### PR DESCRIPTION
Release v7.0.0-beta.4.

- We’ll include `@mui/base` in this release, as we need a version with the package layout updates because `@mui/lab` depends on it
- We will release two versions of `@mui/types`: `7.3.0` for v7 and `7.2.24` for v5 and v6. This PR includes `7.3.0`. The `7.2.24` release will be made from the `v6.x` branch.