### PR TITLE
[release] v5.16.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # [Versions](https://mui.com/versions/)
 
+## v5.16.15
+
+<!-- generated comparing v5.16.14..v5.x -->
+
+_Mar 14, 2025_
+
+### `@mui/material@5.16.15`
+
+- [TextareaAutosize] Temporarily disconnect ResizeObserver to avoid loop error (#44540) (#45238) @DiegoAndai
+
+### Core
+
+- Remove Suspense and clock mocking from regressions and e2e tests (#44935) (#45359) @DiegoAndai
+- Update pnpm (#45357) @DiegoAndai
+
+All contributors of this release in alphabetical order: @DiegoAndai
+
 ## v5.16.14
 
 <!-- generated comparing v5.16.13..v5.x -->

--- a/docs/package.json
+++ b/docs/package.json
@@ -42,7 +42,7 @@
     "@mui/styled-engine-sc": "workspace:^",
     "@mui/styles": "workspace:^",
     "@mui/system": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "@mui/x-charts": "6.19.5",
     "@mui/x-data-grid": "7.0.0-beta.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/monorepo",
-  "version": "5.16.14",
+  "version": "5.16.15",
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/base",
-  "version": "5.0.0-beta.40-0",
+  "version": "5.0.0-beta.40-1",
   "private": false,
   "author": "MUI Team",
   "description": "Base UI is a library of headless ('unstyled') React components and low-level hooks. You gain complete control over your app's CSS and accessibility features.",
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.9",
     "@floating-ui/react-dom": "^2.0.8",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "@popperjs/core": "^2.11.8",
     "clsx": "^2.1.0",
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@mui-internal/test-utils": "workspace:^",
     "@mui/internal-babel-macros": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/chai": "^4.3.12",

--- a/packages/mui-core-downloads-tracker/package.json
+++ b/packages/mui-core-downloads-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/core-downloads-tracker",
-  "version": "5.16.14",
+  "version": "5.16.15",
   "private": false,
   "author": "MUI Team",
   "description": "Internal package to track number of downloads of our design system libraries",

--- a/packages/mui-docs/package.json
+++ b/packages/mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/docs",
-  "version": "5.16.14",
+  "version": "5.16.15",
   "private": false,
   "author": "MUI Team",
   "description": "MUI Docs - Documentation building blocks.",

--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/icons-material",
-  "version": "5.16.14",
+  "version": "5.16.15",
   "private": false,
   "author": "MUI Team",
   "description": "Material Design icons distributed as SVG React components.",

--- a/packages/mui-joy/package.json
+++ b/packages/mui-joy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/joy",
-  "version": "5.0.0-beta.51",
+  "version": "5.0.0-beta.52",
   "private": false,
   "author": "MUI Team",
   "description": "Joy UI is an open-source React component library that implements MUI's own design principles. It's comprehensive and can be used in production out of the box.",
@@ -42,7 +42,7 @@
     "@mui/base": "workspace:*",
     "@mui/core-downloads-tracker": "workspace:^",
     "@mui/system": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "clsx": "^2.1.0",
     "prop-types": "^15.8.1"

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/lab",
-  "version": "5.0.0-alpha.175",
+  "version": "5.0.0-alpha.176",
   "private": false,
   "author": "MUI Team",
   "description": "Laboratory for new MUI modules.",
@@ -44,7 +44,7 @@
     "@babel/runtime": "^7.23.9",
     "@mui/base": "workspace:*",
     "@mui/system": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "clsx": "^2.1.0",
     "prop-types": "^15.8.1"

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/material",
-  "version": "5.16.14",
+  "version": "5.16.15",
   "private": false,
   "author": "MUI Team",
   "description": "Material UI is an open-source React component library that implements Google's Material Design. It's comprehensive and can be used in production out of the box.",
@@ -45,7 +45,7 @@
     "@babel/runtime": "^7.23.9",
     "@mui/core-downloads-tracker": "workspace:^",
     "@mui/system": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "@popperjs/core": "^2.11.8",
     "@types/react-transition-group": "^4.4.10",

--- a/packages/mui-private-theming/package.json
+++ b/packages/mui-private-theming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/private-theming",
-  "version": "5.16.14",
+  "version": "5.16.15",
   "private": false,
   "author": "MUI Team",
   "description": "Private - The React theme context to be shared between `@mui/styles` and `@mui/material`.",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@mui-internal/test-utils": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@types/chai": "^4.3.12",
     "@types/react": "^19.0.0",
     "chai": "^4.4.1",

--- a/packages/mui-styles/package.json
+++ b/packages/mui-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/styles",
-  "version": "5.16.14",
+  "version": "5.16.15",
   "private": false,
   "author": "MUI Team",
   "description": "MUI Styles - The legacy JSS-based styling solution of Material UI.",
@@ -41,7 +41,7 @@
     "@babel/runtime": "^7.23.9",
     "@emotion/hash": "^0.9.1",
     "@mui/private-theming": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "clsx": "^2.1.0",
     "csstype": "^3.1.3",

--- a/packages/mui-system/package.json
+++ b/packages/mui-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/system",
-  "version": "5.16.14",
+  "version": "5.16.15",
   "private": false,
   "author": "MUI Team",
   "description": "MUI System is a set of CSS utilities to help you build custom designs more efficiently. It makes it possible to rapidly lay out custom designs.",
@@ -43,7 +43,7 @@
     "@babel/runtime": "^7.23.9",
     "@mui/private-theming": "workspace:^",
     "@mui/styled-engine": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "clsx": "^2.1.0",
     "csstype": "^3.1.3",

--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/utils",
-  "version": "5.16.14",
+  "version": "5.16.15",
   "private": false,
   "author": "MUI Team",
   "description": "Utility functions for React components.",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.9",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@types/prop-types": "^15.7.12",
     "clsx": "^2.1.1",
     "prop-types": "^15.8.1",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@mui-internal/test-utils": "workspace:^",
     "@mui/internal-babel-macros": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@types/chai": "^4.3.12",
     "@types/mocha": "^10.0.6",
     "@types/node": "^18.19.48",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,7 +499,7 @@ importers:
         specifier: workspace:^
         version: link:../packages/mui-system/build
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../packages/mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1090,7 +1090,7 @@ importers:
         specifier: ^2.0.8
         version: 2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1361,7 +1361,7 @@ importers:
         specifier: workspace:^
         version: link:../mui-system/build
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1438,7 +1438,7 @@ importers:
         specifier: workspace:^
         version: link:../mui-system/build
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1500,7 +1500,7 @@ importers:
         specifier: workspace:^
         version: link:../mui-system/build
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1658,7 +1658,7 @@ importers:
         specifier: workspace:^
         version: link:../test-utils
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@types/chai':
         specifier: ^4.3.12
@@ -1768,7 +1768,7 @@ importers:
         specifier: workspace:^
         version: link:../mui-private-theming/build
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1854,7 +1854,7 @@ importers:
         specifier: workspace:^
         version: link:../mui-styled-engine/build
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1932,7 +1932,7 @@ importers:
         specifier: ^7.23.9
         version: 7.23.9
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@types/prop-types':
         specifier: ^15.7.12
@@ -4564,6 +4564,7 @@ packages:
   '@playwright/test@1.42.1':
     resolution: {integrity: sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==}
     engines: {node: '>=16'}
+    deprecated: Please update to the latest version of Playwright to test up-to-date browsers.
     hasBin: true
 
   '@polka/url@1.0.0-next.21':
@@ -7961,6 +7962,7 @@ packages:
   gm@1.25.0:
     resolution: {integrity: sha512-4kKdWXTtgQ4biIo7hZA396HT062nDVVHPjQcurNZ3o/voYN+o5FUC5kOwuORbpExp3XbTJ3SU7iRipiIhQtovw==}
     engines: {node: '>=14'}
+    deprecated: The gm module has been sunset. Please migrate to an alternative. https://github.com/aheckmann/gm?tab=readme-ov-file#2025-02-24-this-project-is-not-maintained
 
   goober@2.1.13:
     resolution: {integrity: sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==}

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -206,7 +206,7 @@ yargs(process.argv.slice(2))
         })
         .option('release', {
           // #default-branch-switch
-          default: 'master',
+          default: 'v5.x',
           describe: 'Ref which we want to release',
           type: 'string',
         })


### PR DESCRIPTION
Release v5.16.15

On hold: https://github.com/mui/material-ui/pull/45573

It contains a fix, and we also need to restrict `@mui/types` version.
