### PR TITLE
[docs] Update nextjs font optimization guide

### DIFF
--- a/docs/data/material/integrations/nextjs/nextjs.md
+++ b/docs/data/material/integrations/nextjs/nextjs.md
@@ -104,7 +104,7 @@ Finally, in `src/app/layout.tsx`, pass the theme to the `ThemeProvider`:
    const { children } = props;
    return (
 +    <html lang="en" className={roboto.variable}>
-+      <body>
+       <body>
           <AppRouterCacheProvider>
 +           <ThemeProvider theme={theme}>
               {children}

--- a/docs/data/material/integrations/nextjs/nextjs.md
+++ b/docs/data/material/integrations/nextjs/nextjs.md
@@ -103,8 +103,8 @@ Finally, in `src/app/layout.tsx`, pass the theme to the `ThemeProvider`:
  export default function RootLayout(props) {
    const { children } = props;
    return (
-     <html lang="en">
-+      <body className={roboto.variable}>
++    <html lang="en" className={roboto.variable}>
++      <body>
           <AppRouterCacheProvider>
 +           <ThemeProvider theme={theme}>
               {children}


### PR DESCRIPTION
Updated line 106 and 107 as per https://github.com/mui/material-ui/issues/45537#issuecomment-2727831866

Fixes the issue of --font-[variant] CSS custom property not computing the value correctly when next js font is applied to `<body>` instead of `<html/>`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

