### PR TITLE
[material-ui] Support nested theme when upper theme is CSS vars theme

### DIFF
--- a/packages/mui-material/src/styles/ThemeProvider.js
+++ b/packages/mui-material/src/styles/ThemeProvider.js
@@ -10,8 +10,7 @@ export default function ThemeProvider({ theme: themeInput, ...props }) {
   if (typeof themeInput !== 'function') {
     if (scopedTheme && !scopedTheme.vars) {
       finalTheme = { ...scopedTheme, vars: null };
-    }
-    if (themeInput && !themeInput.vars) {
+    } else if (themeInput && !themeInput.vars) {
       finalTheme = { ...themeInput, vars: null };
     }
   }

--- a/packages/mui-material/src/styles/ThemeProvider.js
+++ b/packages/mui-material/src/styles/ThemeProvider.js
@@ -6,11 +6,20 @@ import THEME_ID from './identifier';
 
 export default function ThemeProvider({ theme: themeInput, ...props }) {
   const scopedTheme = themeInput[THEME_ID];
+  let finalTheme = scopedTheme || themeInput;
+  if (typeof themeInput !== 'function') {
+    if (scopedTheme && !scopedTheme.vars) {
+      finalTheme = { ...scopedTheme, vars: null };
+    }
+    if (themeInput && !themeInput.vars) {
+      finalTheme = { ...themeInput, vars: null };
+    }
+  }
   return (
     <SystemThemeProvider
       {...props}
       themeId={scopedTheme ? THEME_ID : undefined}
-      theme={scopedTheme || themeInput}
+      theme={finalTheme}
     />
   );
 }

--- a/packages/mui-material/src/styles/ThemeProvider.test.tsx
+++ b/packages/mui-material/src/styles/ThemeProvider.test.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer } from '@mui-internal/test-utils';
-import { ThemeProvider } from '@mui/material/styles';
+import {
+  ThemeProvider,
+  createTheme,
+  useTheme,
+  experimental_extendTheme as extendTheme,
+} from '@mui/material/styles';
+import Button from '@mui/material/Button';
 
 describe('ThemeProvider', () => {
   const { render } = createRenderer();
@@ -14,5 +20,34 @@ describe('ThemeProvider', () => {
         </ThemeProvider>,
       ),
     ).not.toWarnDev();
+  });
+
+  it('should have `vars` as null for nested non-vars theme', () => {
+    const upperTheme = extendTheme();
+    const nestedTheme = createTheme({
+      palette: {
+        // @ts-ignore
+        ochre: {
+          main: '#E3D026',
+          light: '#E9DB5D',
+          dark: '#A29415',
+          contrastText: '#242105',
+        },
+      },
+    });
+    let theme: any;
+    function Component() {
+      theme = useTheme();
+      return <Button>Button</Button>;
+    }
+    render(
+      <ThemeProvider theme={upperTheme}>
+        <ThemeProvider theme={nestedTheme}>
+          <Component />
+        </ThemeProvider>
+      </ThemeProvider>,
+    );
+
+    expect(theme.vars).to.equal(null);
   });
 });

--- a/packages/mui-material/src/styles/createTheme.js
+++ b/packages/mui-material/src/styles/createTheme.js
@@ -24,7 +24,12 @@ function createTheme(options = {}, ...args) {
     ...other
   } = options;
 
-  if (options.vars) {
+  if (
+    options.vars &&
+    // The error should throw only for the root theme creation because user is not allowed to use a custom node `vars`.
+    // `generateCssVars` is the closest identifier for checking that the `options` is a result of `extendTheme` with CSS variables so that user can create new theme for nested ThemeProvider.
+    options.generateCssVars === undefined
+  ) {
     throw new MuiError(
       'MUI: `vars` is a private field used for CSS variables support.\n' +
         'Please use another name.',

--- a/packages/mui-material/src/styles/createTheme.test.js
+++ b/packages/mui-material/src/styles/createTheme.test.js
@@ -3,7 +3,12 @@ import { expect } from 'chai';
 import { createRenderer } from '@mui-internal/test-utils';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
-import { ThemeProvider, createTheme, styled } from '@mui/material/styles';
+import {
+  ThemeProvider,
+  createTheme,
+  styled,
+  experimental_extendTheme as extendTheme,
+} from '@mui/material/styles';
 import { deepOrange, green } from '@mui/material/colors';
 
 describe('createTheme', () => {
@@ -310,5 +315,39 @@ describe('createTheme', () => {
           'Please use another name.',
       );
     }
+  });
+
+  it('should not throw for nested theme that includes `vars` node', () => {
+    const outerTheme = extendTheme({
+      colorSchemes: {
+        light: {
+          palette: {
+            secondary: {
+              main: deepOrange[500],
+            },
+          },
+        },
+      },
+    });
+
+    expect(() =>
+      render(
+        <ThemeProvider theme={outerTheme}>
+          <ThemeProvider
+            theme={(theme) => {
+              return createTheme({
+                ...theme,
+                palette: {
+                  ...theme.palette,
+                  primary: {
+                    main: green[500],
+                  },
+                },
+              });
+            }}
+          />
+        </ThemeProvider>,
+      ),
+    ).not.to.throw();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1200,7 +1200,7 @@ importers:
         version: 7.23.9
       '@mui/base':
         specifier: '*'
-        version: 5.0.0-beta.69(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 5.0.0-beta.70(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mui/system':
         specifier: ^5.0.0
         version: 5.15.12(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@types/react@19.0.1)(react@19.0.0))(@types/react@19.0.1)(react@19.0.0)
@@ -3906,6 +3906,17 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/base@5.0.0-beta.70':
+    resolution: {integrity: sha512-Tb/BIhJzb0pa5zv/wu7OdokY9ZKEDqcu1BDFnohyvGCoHuSXbEr90rPq1qeNW3XvTBIbNWHEF7gqge+xpUo6tQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@mui/core-downloads-tracker@5.15.8':
     resolution: {integrity: sha512-W6R1dZJgbYfLmQKf7Es2WUw0pkDkEVUf2jA22DYu0JOa9M3pjvOqoC9HgOPGNNJTu6SCWLSWh3euv1Jn2NmeQA==}
 
@@ -3990,6 +4001,14 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/types@7.2.24':
+    resolution: {integrity: sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@mui/utils@5.15.20':
     resolution: {integrity: sha512-mAbYx0sovrnpAu1zHc3MDIhPqL8RPVC5W5xcO1b7PiSCJPtckIZmBkp8hefamAvUiAV8gpfMOM6Zb+eSisbI2A==}
     engines: {node: '>=12.0.0'}
@@ -4002,6 +4021,16 @@ packages:
 
   '@mui/utils@6.4.3':
     resolution: {integrity: sha512-jxHRHh3BqVXE9ABxDm+Tc3wlBooYz/4XPa0+4AI+iF38rV1/+btJmSUgG4shDtSWVs/I97aDn5jBCt6SF2Uq2A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/utils@6.4.8':
+    resolution: {integrity: sha512-C86gfiZ5BfZ51KqzqoHi1WuuM2QdSKoFhbkZeAfQRB+jCc4YNhhj11UXFVMMsqBgZ+Zy8IHNJW3M9Wj/LOwRXQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -4564,6 +4593,7 @@ packages:
   '@playwright/test@1.42.1':
     resolution: {integrity: sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==}
     engines: {node: '>=16'}
+    deprecated: Please update to the latest version of Playwright to test up-to-date browsers.
     hasBin: true
 
   '@polka/url@1.0.0-next.21':
@@ -7961,6 +7991,7 @@ packages:
   gm@1.25.0:
     resolution: {integrity: sha512-4kKdWXTtgQ4biIo7hZA396HT062nDVVHPjQcurNZ3o/voYN+o5FUC5kOwuORbpExp3XbTJ3SU7iRipiIhQtovw==}
     engines: {node: '>=14'}
+    deprecated: The gm module has been sunset. Please migrate to an alternative. https://github.com/aheckmann/gm?tab=readme-ov-file#2025-02-24-this-project-is-not-maintained
 
   goober@2.1.13:
     resolution: {integrity: sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==}
@@ -14618,6 +14649,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.1
 
+  '@mui/base@5.0.0-beta.70(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@floating-ui/react-dom': 2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@mui/types': 7.2.24(@types/react@19.0.1)
+      '@mui/utils': 6.4.8(@types/react@19.0.1)(react@19.0.0)
+      '@popperjs/core': 2.11.8
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.1
+
   '@mui/core-downloads-tracker@5.15.8': {}
 
   '@mui/joy@5.0.0-beta.22(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@types/react@19.0.1)(react@19.0.0))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
@@ -14698,6 +14743,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.1
 
+  '@mui/types@7.2.24(@types/react@19.0.1)':
+    optionalDependencies:
+      '@types/react': 19.0.1
+
   '@mui/utils@5.15.20(@types/react@18.3.3)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.23.9
@@ -14722,6 +14771,18 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.23.9
       '@mui/types': 7.2.21(@types/react@19.0.1)
+      '@types/prop-types': 15.7.14
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.0.0
+      react-is: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.1
+
+  '@mui/utils@6.4.8(@types/react@19.0.1)(react@19.0.0)':
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@mui/types': 7.2.24(@types/react@19.0.1)
       '@types/prop-types': 15.7.14
       clsx: 2.1.1
       prop-types: 15.8.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3894,18 +3894,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/base@5.0.0-beta.69':
-    resolution: {integrity: sha512-r2YyGUXpZxj8rLAlbjp1x2BnMERTZ/dMqd9cClKj2OJ7ALAuiv/9X5E9eHfRc9o/dGRuLSMq/WTjREktJVjxVA==}
-    engines: {node: '>=14.0.0'}
-    deprecated: This package has been replaced by @base-ui-components/react
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@mui/base@5.0.0-beta.70':
     resolution: {integrity: sha512-Tb/BIhJzb0pa5zv/wu7OdokY9ZKEDqcu1BDFnohyvGCoHuSXbEr90rPq1qeNW3XvTBIbNWHEF7gqge+xpUo6tQ==}
     engines: {node: '>=14.0.0'}
@@ -3993,14 +3981,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/types@7.2.21':
-    resolution: {integrity: sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@mui/types@7.2.24':
     resolution: {integrity: sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==}
     peerDependencies:
@@ -4015,16 +3995,6 @@ packages:
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/utils@6.4.3':
-    resolution: {integrity: sha512-jxHRHh3BqVXE9ABxDm+Tc3wlBooYz/4XPa0+4AI+iF38rV1/+btJmSUgG4shDtSWVs/I97aDn5jBCt6SF2Uq2A==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -14611,7 +14581,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.23.9
       '@floating-ui/react-dom': 2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@mui/types': 7.2.21(@types/react@19.0.1)
+      '@mui/types': 7.2.24(@types/react@19.0.1)
       '@mui/utils': 5.15.20(@types/react@19.0.1)(react@19.0.0)
       '@popperjs/core': 2.11.8
       clsx: 2.1.1
@@ -14625,22 +14595,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.23.9
       '@floating-ui/react-dom': 2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@mui/types': 7.2.21(@types/react@19.0.1)
+      '@mui/types': 7.2.24(@types/react@19.0.1)
       '@mui/utils': 5.15.20(@types/react@19.0.1)(react@19.0.0)
-      '@popperjs/core': 2.11.8
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-    optionalDependencies:
-      '@types/react': 19.0.1
-
-  '@mui/base@5.0.0-beta.69(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      '@babel/runtime': 7.23.9
-      '@floating-ui/react-dom': 2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@mui/types': 7.2.21(@types/react@19.0.1)
-      '@mui/utils': 6.4.3(@types/react@19.0.1)(react@19.0.0)
       '@popperjs/core': 2.11.8
       clsx: 2.1.1
       prop-types: 15.8.1
@@ -14671,7 +14627,7 @@ snapshots:
       '@mui/base': 5.0.0-beta.31(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mui/core-downloads-tracker': 5.15.8
       '@mui/system': 5.15.12(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@types/react@19.0.1)(react@19.0.0))(@types/react@19.0.1)(react@19.0.0)
-      '@mui/types': 7.2.21(@types/react@19.0.1)
+      '@mui/types': 7.2.24(@types/react@19.0.1)
       '@mui/utils': 5.15.20(@types/react@19.0.1)(react@19.0.0)
       clsx: 2.1.1
       prop-types: 15.8.1
@@ -14688,7 +14644,7 @@ snapshots:
       '@mui/base': 5.0.0-beta.31(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mui/core-downloads-tracker': 5.15.8
       '@mui/system': 5.15.12(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@types/react@19.0.1)(react@19.0.0))(@types/react@19.0.1)(react@19.0.0)
-      '@mui/types': 7.2.21(@types/react@19.0.1)
+      '@mui/types': 7.2.24(@types/react@19.0.1)
       '@mui/utils': 5.15.20(@types/react@19.0.1)(react@19.0.0)
       '@types/react-transition-group': 4.4.10
       clsx: 2.1.1
@@ -14728,7 +14684,7 @@ snapshots:
       '@babel/runtime': 7.23.9
       '@mui/private-theming': 5.15.12(@types/react@19.0.1)(react@19.0.0)
       '@mui/styled-engine': 5.15.11(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@types/react@19.0.1)(react@19.0.0))(react@19.0.0)
-      '@mui/types': 7.2.21(@types/react@19.0.1)
+      '@mui/types': 7.2.24(@types/react@19.0.1)
       '@mui/utils': 5.15.20(@types/react@19.0.1)(react@19.0.0)
       clsx: 2.1.1
       csstype: 3.1.3
@@ -14737,10 +14693,6 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.0.1)(react@19.0.0)
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@types/react@19.0.1)(react@19.0.0)
-      '@types/react': 19.0.1
-
-  '@mui/types@7.2.21(@types/react@19.0.1)':
-    optionalDependencies:
       '@types/react': 19.0.1
 
   '@mui/types@7.2.24(@types/react@19.0.1)':
@@ -14764,18 +14716,6 @@ snapshots:
       prop-types: 15.8.1
       react: 19.0.0
       react-is: 18.3.1
-    optionalDependencies:
-      '@types/react': 19.0.1
-
-  '@mui/utils@6.4.3(@types/react@19.0.1)(react@19.0.0)':
-    dependencies:
-      '@babel/runtime': 7.23.9
-      '@mui/types': 7.2.21(@types/react@19.0.1)
-      '@types/prop-types': 15.7.14
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-is: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.1
 
@@ -14815,7 +14755,7 @@ snapshots:
   '@mui/x-data-grid-generator@7.0.0-beta.7(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@types/react@19.0.1)(react@19.0.0))(@mui/icons-material@packages+mui-icons-material+build)(@mui/material@packages+mui-material+build)(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@mui/base': 5.0.0-beta.69(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@mui/base': 5.0.0-beta.70(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mui/icons-material': link:packages/mui-icons-material/build
       '@mui/material': link:packages/mui-material/build
       '@mui/x-data-grid-premium': 7.0.0-beta.7(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.1)(react@19.0.0))(@types/react@19.0.1)(react@19.0.0))(@mui/material@packages+mui-material+build)(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Cherry pick from https://github.com/mui/material-ui/pull/45545 and https://github.com/mui/material-ui/pull/45368

Need this PR to release on v5 because MUI X docs depends on this version. To unblock #45386 so that the docs (both core and x) can migrate to CSS variables to fix the dark mode flicker issue.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
