### PR TITLE
[v5.x][core] Fix types version

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -42,7 +42,7 @@
     "@mui/styled-engine-sc": "workspace:^",
     "@mui/styles": "workspace:^",
     "@mui/system": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "@mui/x-charts": "6.19.5",
     "@mui/x-data-grid": "7.0.0-beta.7",

--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.9",
     "@floating-ui/react-dom": "^2.0.8",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "@popperjs/core": "^2.11.8",
     "clsx": "^2.1.0",
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@mui-internal/test-utils": "workspace:^",
     "@mui/internal-babel-macros": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/chai": "^4.3.12",

--- a/packages/mui-joy/package.json
+++ b/packages/mui-joy/package.json
@@ -42,7 +42,7 @@
     "@mui/base": "workspace:*",
     "@mui/core-downloads-tracker": "workspace:^",
     "@mui/system": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "clsx": "^2.1.0",
     "prop-types": "^15.8.1"

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -44,7 +44,7 @@
     "@babel/runtime": "^7.23.9",
     "@mui/base": "workspace:*",
     "@mui/system": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "clsx": "^2.1.0",
     "prop-types": "^15.8.1"

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -45,7 +45,7 @@
     "@babel/runtime": "^7.23.9",
     "@mui/core-downloads-tracker": "workspace:^",
     "@mui/system": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "@popperjs/core": "^2.11.8",
     "@types/react-transition-group": "^4.4.10",

--- a/packages/mui-private-theming/package.json
+++ b/packages/mui-private-theming/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@mui-internal/test-utils": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@types/chai": "^4.3.12",
     "@types/react": "^19.0.0",
     "chai": "^4.4.1",

--- a/packages/mui-styles/package.json
+++ b/packages/mui-styles/package.json
@@ -41,7 +41,7 @@
     "@babel/runtime": "^7.23.9",
     "@emotion/hash": "^0.9.1",
     "@mui/private-theming": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "clsx": "^2.1.0",
     "csstype": "^3.1.3",

--- a/packages/mui-system/package.json
+++ b/packages/mui-system/package.json
@@ -43,7 +43,7 @@
     "@babel/runtime": "^7.23.9",
     "@mui/private-theming": "workspace:^",
     "@mui/styled-engine": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@mui/utils": "workspace:^",
     "clsx": "^2.1.0",
     "csstype": "^3.1.3",

--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.9",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@types/prop-types": "^15.7.12",
     "clsx": "^2.1.1",
     "prop-types": "^15.8.1",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@mui-internal/test-utils": "workspace:^",
     "@mui/internal-babel-macros": "workspace:^",
-    "@mui/types": "workspace:^",
+    "@mui/types": "workspace:~",
     "@types/chai": "^4.3.12",
     "@types/mocha": "^10.0.6",
     "@types/node": "^18.19.48",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,7 +499,7 @@ importers:
         specifier: workspace:^
         version: link:../packages/mui-system/build
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../packages/mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1090,7 +1090,7 @@ importers:
         specifier: ^2.0.8
         version: 2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1361,7 +1361,7 @@ importers:
         specifier: workspace:^
         version: link:../mui-system/build
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1438,7 +1438,7 @@ importers:
         specifier: workspace:^
         version: link:../mui-system/build
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1500,7 +1500,7 @@ importers:
         specifier: workspace:^
         version: link:../mui-system/build
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1658,7 +1658,7 @@ importers:
         specifier: workspace:^
         version: link:../test-utils
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@types/chai':
         specifier: ^4.3.12
@@ -1768,7 +1768,7 @@ importers:
         specifier: workspace:^
         version: link:../mui-private-theming/build
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1854,7 +1854,7 @@ importers:
         specifier: workspace:^
         version: link:../mui-styled-engine/build
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@mui/utils':
         specifier: workspace:^
@@ -1932,7 +1932,7 @@ importers:
         specifier: ^7.23.9
         version: 7.23.9
       '@mui/types':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../mui-types/build
       '@types/prop-types':
         specifier: ^15.7.12


### PR DESCRIPTION
Use`~` instead of `^` for `@mui/types` dependency, so v5 packages don't resolve to `7.3.0` or higher