### PR TITLE
[code-infra] Ensure `translations.json` is present in all `@mui/docs` package builds

### DIFF
--- a/packages/mui-docs/package.json
+++ b/packages/mui-docs/package.json
@@ -28,7 +28,7 @@
     "build:node": "node ../../scripts/build.mjs node",
     "build:stable": "node ../../scripts/build.mjs stable",
     "build:types": "tsx ../../scripts/buildTypes.mts",
-    "build:copy-files": "node ../../scripts/copyFiles.mjs ./src/translations/translations.json:./translations/translations.json ./src/translations/translations.json:./node/translations/translations.json",
+    "build:copy-files": "node ../../scripts/copyFiles.mjs ./src/translations/translations.json:./translations/translations.json ./src/translations/translations.json:./node/translations/translations.json ./src/translations/translations.json:./esm/translations/translations.json",
     "prebuild": "rimraf build",
     "release": "pnpm build && pnpm publish",
     "test": "exit 0",

--- a/packages/mui-docs/package.json
+++ b/packages/mui-docs/package.json
@@ -28,7 +28,7 @@
     "build:node": "node ../../scripts/build.mjs node",
     "build:stable": "node ../../scripts/build.mjs stable",
     "build:types": "tsx ../../scripts/buildTypes.mts",
-    "build:copy-files": "node ../../scripts/copyFiles.mjs ./src/translations/translations.json:./translations/translations.json ./src/translations/translations.json:./node/translations/translations.json ./src/translations/translations.json:./esm/translations/translations.json",
+    "build:copy-files": "node ../../scripts/copyFiles.mjs ./src/translations/translations.json:./translations/translations.json ./src/translations/translations.json:./esm/translations/translations.json ./src/translations/translations.json:./modern/translations/translations.json",
     "prebuild": "rimraf build",
     "release": "pnpm build && pnpm publish",
     "test": "exit 0",

--- a/packages/mui-docs/src/translations/index.ts
+++ b/packages/mui-docs/src/translations/index.ts
@@ -1,5 +1,5 @@
 import type { Translations } from '../i18n';
-import en from './translations.json';
+import en from './translations.json' with { type: 'json' };
 
 export default {
   en,

--- a/packages/mui-docs/src/translations/index.ts
+++ b/packages/mui-docs/src/translations/index.ts
@@ -1,5 +1,5 @@
 import type { Translations } from '../i18n';
-import en from './translations.json' with { type: 'json' };
+import en from './translations.json';
 
 export default {
   en,


### PR DESCRIPTION
Fixes: https://mui-org.slack.com/archives/C042YB5RB3N/p1742407588778789

Related question: do we need the node build, which does not look like it works..? 🤔 🤷 
<img width="438" alt="Screenshot 2025-03-19 at 23 01 28" src="https://github.com/user-attachments/assets/9a834614-1be3-47d4-a061-7415f19750b3" />
