### PR TITLE
Fix `strict` and `strictEffects` not enabling Strict Mode in React 19

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -20,4 +20,7 @@ module.exports = {
     '**/build/**',
     'docs/.next/**',
   ],
+  // detect-modules doesn't work with @babel/register
+  // https://github.com/babel/babel/issues/6737
+  'node-option': ['no-experimental-detect-module'],
 };

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@pigment-css/react": "0.0.30",
     "@playwright/test": "1.51.1",
     "@types/babel__core": "^7.20.5",
+    "@types/babel__register": "^7.17.3",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash": "^4.17.16",
     "@types/mocha": "^10.0.10",

--- a/packages-internal/test-utils/src/createRenderer.test.js
+++ b/packages-internal/test-utils/src/createRenderer.test.js
@@ -30,17 +30,25 @@ describe('createRenderer', () => {
   });
 
   it('uses strict mode when strict and strictEffects are true', () => {
-    let mounted = 0;
+    let effectCalls = 0;
+    let refCalls = 0;
     function Component() {
       React.useEffect(() => {
-        mounted += 1;
+        effectCalls += 1;
       });
 
-      return null;
+      return (
+        <div
+          ref={() => {
+            refCalls += 1;
+          }}
+        />
+      );
     }
 
     render(<Component />, { strict: true, strictEffects: true });
 
-    expect(mounted).to.equal(2);
+    expect(effectCalls).to.equal(2);
+    expect(refCalls).to.equal(3);
   });
 });

--- a/packages-internal/test-utils/src/createRenderer.test.js
+++ b/packages-internal/test-utils/src/createRenderer.test.js
@@ -28,4 +28,19 @@ describe('createRenderer', () => {
     expect(descriptions[1]).to.have.property('id', 'r:2');
     expect(descriptions[2]).to.have.property('id', 'r:3');
   });
+
+  it('uses strict mode when strict and strictEffects are true', () => {
+    let mounted = 0;
+    function Component() {
+      React.useEffect(() => {
+        mounted += 1;
+      });
+
+      return null;
+    }
+
+    render(<Component />, { strict: true, strictEffects: true });
+
+    expect(mounted).to.equal(2);
+  });
 });

--- a/packages-internal/test-utils/src/setupBabel.js
+++ b/packages-internal/test-utils/src/setupBabel.js
@@ -1,3 +1,3 @@
 require('@babel/register')({
-  extensions: ['.js', '.mjs', '.ts', '.tsx'],
+  extensions: ['.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx'],
 });

--- a/packages/mui-base/src/FocusTrap/FocusTrap.test.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.test.tsx
@@ -219,7 +219,7 @@ describe('<FocusTrap />', () => {
         </div>
       );
     }
-    const { setProps, getByRole } = render(<Test />);
+    const { setProps, getByRole } = render(<Test />, { strict: React.version.startsWith('18.') });
     expect(screen.getByTestId('root')).toHaveFocus();
 
     act(() => {

--- a/packages/mui-base/src/Input/Input.test.tsx
+++ b/packages/mui-base/src/Input/Input.test.tsx
@@ -281,9 +281,7 @@ describe('<Input />', () => {
         );
       }).toErrorDev([
         'MUI: You have provided a `slots.input` to the input component\nthat does not correctly handle the `ref` prop.\nMake sure the `ref` prop is called with a HTMLInputElement.',
-        // React 18 Strict Effects run mount effects twice
-        React.version.startsWith('18') &&
-          'MUI: You have provided a `slots.input` to the input component\nthat does not correctly handle the `ref` prop.\nMake sure the `ref` prop is called with a HTMLInputElement.',
+        'MUI: You have provided a `slots.input` to the input component\nthat does not correctly handle the `ref` prop.\nMake sure the `ref` prop is called with a HTMLInputElement.',
       ]);
     });
   });

--- a/packages/mui-base/src/Portal/Portal.test.tsx
+++ b/packages/mui-base/src/Portal/Portal.test.tsx
@@ -46,9 +46,9 @@ describe('<Portal />', () => {
         </Portal>,
       );
       const mountNode = document.querySelector('.woofPortal');
-      expect(refSpy.args).to.deep.equal([[mountNode]]);
+      expect(refSpy.args).to.deep.equal([[mountNode], [null], [mountNode]]);
       unmount();
-      expect(refSpy.args).to.deep.equal([[mountNode], [null]]);
+      expect(refSpy.args).to.deep.equal([[mountNode], [null], [mountNode], [null]]);
     });
 
     it('should have access to the mountNode when switching disabledPortal', () => {
@@ -59,14 +59,27 @@ describe('<Portal />', () => {
         </Portal>,
       );
       const mountNode = document.querySelector('.woofPortal');
-      expect(refSpy.args).to.deep.equal([[mountNode]]);
+      expect(refSpy.args).to.deep.equal([[mountNode], [null], [mountNode]]);
       setProps({
         disablePortal: false,
         ref: refSpy,
       });
-      expect(refSpy.args).to.deep.equal([[mountNode], [null], [document.body]]);
+      expect(refSpy.args).to.deep.equal([
+        [mountNode],
+        [null],
+        [mountNode],
+        [null],
+        [document.body],
+      ]);
       unmount();
-      expect(refSpy.args).to.deep.equal([[mountNode], [null], [document.body], [null]]);
+      expect(refSpy.args).to.deep.equal([
+        [mountNode],
+        [null],
+        [mountNode],
+        [null],
+        [document.body],
+        [null],
+      ]);
     });
   });
 

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.test.js
@@ -322,6 +322,7 @@ describe('useAutocomplete', () => {
         <ErrorBoundary>
           <Test options={['foo', 'bar']} />
         </ErrorBoundary>,
+        { strict: reactMajor < 19 },
       );
     }).toErrorDev(devErrorMessages);
   });

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
@@ -1927,7 +1927,7 @@ describe('Joy <Autocomplete />', () => {
           </React.Fragment>
         );
       }
-      const { user } = render(<MyComponent />);
+      const { user } = render(<MyComponent />, { strict: reactMajor === 18 });
 
       await user.click(screen.getByText('Reset'));
 
@@ -2202,6 +2202,7 @@ describe('Joy <Autocomplete />', () => {
       const options = ['one', 'two', 'three'];
       render(
         <Autocomplete onHighlightChange={handleHighlightChange} options={options} open autoFocus />,
+        { strict: reactMajor !== 19 },
       );
       const textbox = screen.getByRole('combobox');
 
@@ -2209,9 +2210,9 @@ describe('Joy <Autocomplete />', () => {
 
       expect(handleHighlightChange.callCount).to.equal(
         // FIXME: highlighted index implementation should be implemented using React not the DOM.
-        reactMajor >= 18 ? 4 : 3,
+        reactMajor === 18 ? 4 : 3,
       );
-      if (reactMajor >= 18) {
+      if (reactMajor === 18) {
         expect(handleHighlightChange.args[2][0]).to.equal(undefined);
         expect(handleHighlightChange.args[2][1]).to.equal(null);
         expect(handleHighlightChange.args[2][2]).to.equal('auto');
@@ -2223,7 +2224,7 @@ describe('Joy <Autocomplete />', () => {
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       expect(handleHighlightChange.callCount).to.equal(
         // FIXME: highlighted index implementation should be implemented using React not the DOM.
-        reactMajor >= 18 ? 5 : 4,
+        reactMajor === 18 ? 5 : 4,
       );
       expect(handleHighlightChange.lastCall.args[0]).not.to.equal(undefined);
       expect(handleHighlightChange.lastCall.args[1]).to.equal(options[1]);
@@ -2235,14 +2236,15 @@ describe('Joy <Autocomplete />', () => {
       const options = ['one', 'two', 'three'];
       const { getAllByRole } = render(
         <Autocomplete onHighlightChange={handleHighlightChange} options={options} open autoFocus />,
+        { strict: reactMajor !== 19 },
       );
       const firstOption = getAllByRole('option')[0];
       fireEvent.mouseMove(firstOption);
       expect(handleHighlightChange.callCount).to.equal(
         // FIXME: highlighted index implementation should be implemented using React not the DOM.
-        reactMajor >= 18 ? 4 : 3,
+        reactMajor === 18 ? 4 : 3,
       );
-      if (reactMajor >= 18) {
+      if (reactMajor === 18) {
         expect(handleHighlightChange.args[2][0]).to.equal(undefined);
         expect(handleHighlightChange.args[2][1]).to.equal(null);
         expect(handleHighlightChange.args[2][2]).to.equal('auto');

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { act, createRenderer, fireEvent, screen, reactMajor } from '@mui/internal-test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { ThemeProvider } from '@emotion/react';
 import FormControl, { useFormControl } from '@mui/material/FormControl';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -280,13 +280,11 @@ describe('<InputBase />', () => {
         const errorMessage =
           'MUI: You have provided a `inputComponent` to the input component\nthat does not correctly handle the `ref` prop.\nMake sure the `ref` prop is called with a HTMLInputElement.';
 
-        let expectedOccurrences = 2;
-
         expect(() => {
           render(
             <InputBase inputProps={{ ref: triggerChangeRef }} inputComponent={BadInputComponent} />,
           );
-        }).toErrorDev(Array(expectedOccurrences).fill(errorMessage));
+        }).toErrorDev([errorMessage, errorMessage]);
       });
     });
   });

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -280,11 +280,7 @@ describe('<InputBase />', () => {
         const errorMessage =
           'MUI: You have provided a `inputComponent` to the input component\nthat does not correctly handle the `ref` prop.\nMake sure the `ref` prop is called with a HTMLInputElement.';
 
-        let expectedOccurrences = 1;
-
-        if (reactMajor === 18) {
-          expectedOccurrences = 2;
-        }
+        let expectedOccurrences = 2;
 
         expect(() => {
           render(
@@ -505,11 +501,6 @@ describe('<InputBase />', () => {
         const errorMessage =
           'MUI: There are multiple `InputBase` components inside a FormControl.\nThis creates visual inconsistencies, only use one `InputBase`.';
 
-        let expectedOccurrences = 1;
-
-        if (reactMajor === 18) {
-          expectedOccurrences = 2;
-        }
         expect(() => {
           render(
             <FormControl>
@@ -520,7 +511,7 @@ describe('<InputBase />', () => {
               </div>
             </FormControl>,
           );
-        }).toErrorDev(Array(expectedOccurrences).fill(errorMessage));
+        }).toErrorDev([errorMessage, errorMessage]);
       });
 
       it('should not warn if only one input is rendered', () => {

--- a/packages/mui-material/src/Portal/Portal.test.tsx
+++ b/packages/mui-material/src/Portal/Portal.test.tsx
@@ -46,9 +46,9 @@ describe('<Portal />', () => {
         </Portal>,
       );
       const mountNode = document.querySelector('.woofPortal');
-      expect(refSpy.args).to.deep.equal([[mountNode]]);
+      expect(refSpy.args).to.deep.equal([[mountNode], [null], [mountNode]]);
       unmount();
-      expect(refSpy.args).to.deep.equal([[mountNode], [null]]);
+      expect(refSpy.args).to.deep.equal([[mountNode], [null], [mountNode], [null]]);
     });
 
     it('should have access to the mountNode when switching disabledPortal', () => {
@@ -59,14 +59,27 @@ describe('<Portal />', () => {
         </Portal>,
       );
       const mountNode = document.querySelector('.woofPortal');
-      expect(refSpy.args).to.deep.equal([[mountNode]]);
+      expect(refSpy.args).to.deep.equal([[mountNode], [null], [mountNode]]);
       setProps({
         disablePortal: false,
         ref: refSpy,
       });
-      expect(refSpy.args).to.deep.equal([[mountNode], [null], [document.body]]);
+      expect(refSpy.args).to.deep.equal([
+        [mountNode],
+        [null],
+        [mountNode],
+        [null],
+        [document.body],
+      ]);
       unmount();
-      expect(refSpy.args).to.deep.equal([[mountNode], [null], [document.body], [null]]);
+      expect(refSpy.args).to.deep.equal([
+        [mountNode],
+        [null],
+        [mountNode],
+        [null],
+        [document.body],
+        [null],
+      ]);
     });
   });
 

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -390,6 +390,7 @@ describe('<Select />', () => {
               <MenuItem value={10}>Ten</MenuItem>
               <MenuItem value={30}>Thirty</MenuItem>
             </Select>,
+            { strict: reactMajor !== 19 },
           ),
         ).toWarnDev(Array(expectedOccurrences).fill(errorMessage));
       });

--- a/packages/mui-material/src/Tabs/Tabs.test.js
+++ b/packages/mui-material/src/Tabs/Tabs.test.js
@@ -369,6 +369,7 @@ describe('<Tabs />', () => {
               <Tab value={1} />
               <Tab value={3} />
             </Tabs>,
+            { strict: reactMajor !== 19 },
           );
         }).toErrorDev([
           'You can provide one of the following values: 1, 3',

--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
@@ -219,7 +219,7 @@ describe('<FocusTrap />', () => {
         </div>
       );
     }
-    const { setProps, getByRole } = render(<Test />);
+    const { setProps, getByRole } = render(<Test />, { strict: React.version.startsWith('18.') });
     expect(screen.getByTestId('root')).toHaveFocus();
 
     act(() => {

--- a/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
+++ b/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
+import { createRenderer, screen, fireEvent, reactMajor } from '@mui/internal-test-utils';
 import Box from '@mui/material/Box';
 import {
   CssVarsProvider,
@@ -468,7 +468,7 @@ describe('[Material UI] ThemeProviderWithVars', () => {
         </ThemeProvider>
       );
     }
-    const { container } = render(<App />);
+    const { container } = render(<App />, { strict: reactMajor !== 19 });
 
     expect(container).to.have.text('1 light');
 
@@ -540,7 +540,7 @@ describe('[Material UI] ThemeProviderWithVars', () => {
         </ThemeProvider>
       );
     }
-    const { container } = render(<App />);
+    const { container } = render(<App />, { strict: reactMajor !== 19 });
 
     expect(container).to.have.text('1 light');
 

--- a/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
+++ b/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
@@ -503,7 +503,7 @@ describe('[Material UI] ThemeProviderWithVars', () => {
         </ThemeProvider>
       );
     }
-    const { container } = render(<App />);
+    const { container } = render(<App />, { strict: reactMajor !== 19 });
 
     expect(container).to.have.text(`1 light ${createTheme().palette.primary.main}`);
 

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
@@ -322,6 +322,7 @@ describe('useAutocomplete', () => {
         <ErrorBoundary>
           <Test options={['foo', 'bar']} />
         </ErrorBoundary>,
+        { strict: reactMajor < 19 },
       );
     }).toErrorDev(devErrorMessages);
   });

--- a/packages/mui-system/src/cssVars/useCurrentColorScheme.test.js
+++ b/packages/mui-system/src/cssVars/useCurrentColorScheme.test.js
@@ -108,7 +108,7 @@ describe('useCurrentColorScheme', () => {
       return <div>{mode}</div>;
     }
 
-    const { container } = render(<Data />);
+    const { container } = render(<Data />, { strict: reactMajor !== 19 });
 
     expect(container.firstChild.textContent).to.equal('light');
     expect(effectRunCount).to.equal(reactMajor >= 19 ? 2 : 3);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
+      '@types/babel__register':
+        specifier: ^7.17.3
+        version: 7.17.3
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -5560,6 +5563,9 @@ packages:
 
   '@types/babel__helper-module-imports@7.18.3':
     resolution: {integrity: sha512-2pyr9Vlriessj2KI85SEF7qma8vA3vzquQMw3wn6kL5lsfjH/YxJ1Noytk4/FJElpYybUbyaC37CVfEgfyme9A==}
+
+  '@types/babel__register@7.17.3':
+    resolution: {integrity: sha512-hy9H39BUIGO0C88bLxQD5rqBvqMgjPjDnA8Mx+fjAqtOi4OG7qYaZUMlDHfLOx5G9WtBzhfchzxKl37LTsVRbA==}
 
   '@types/babel__template@7.4.1':
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
@@ -17323,6 +17329,10 @@ snapshots:
     dependencies:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
+
+  '@types/babel__register@7.17.3':
+    dependencies:
+      '@types/babel__core': 7.20.5
 
   '@types/babel__template@7.4.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,14 @@
 packages:
-  - 'benchmark'
-  - 'packages/*'
-  - 'packages/mui-envinfo/test'
-  - 'packages-internal/*'
-  - 'docs'
-  - 'test'
-  - 'test/moduleResolution'
-  - 'apps/*'
-  - 'scripts/sizeSnapshot'
+  - benchmark
+  - packages/*
+  - packages/mui-envinfo/test
+  - packages-internal/*
+  - docs
+  - test
+  - test/moduleResolution
+  - apps/*
+  - scripts/sizeSnapshot
+onlyBuiltDependencies:
+  - esbuild
+  - msw
+  - nx


### PR DESCRIPTION
Fix `strict` and `strictEffects` not enabling Strict Mode in React 19. 

Failing test before the fix: https://app.circleci.com/pipelines/github/mui/material-ui/150321/workflows/b726b7ae-d5cf-4759-bd41-b025f7c04dec/jobs/807845

Bug reproduction opened in React Testing Library: https://github.com/testing-library/react-testing-library/issues/1388

Many tests were failing, so I had to fix them. On most of them, I've disabled strict mode. That solution didn't work for the two `Autocomplete.test.tsx` tests, so I changed the assertion. 

