### PR TITLE
[system] Fix palette mode does not change when not use CSS vars

### DIFF
--- a/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
+++ b/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
@@ -477,6 +477,43 @@ describe('[Material UI] ThemeProviderWithVars', () => {
     expect(container).to.have.text('1 light');
   });
 
+  it('palette mode should change if not use CSS variables', () => {
+    function Toggle() {
+      const [count, setCount] = React.useState(0);
+      const { setMode } = useColorScheme();
+      const theme = useTheme();
+      React.useEffect(() => {
+        setCount((prev) => prev + 1);
+      }, [theme]);
+      return (
+        <button onClick={() => setMode('dark')}>
+          {count} {theme.palette.mode} {theme.palette.primary.main}
+        </button>
+      );
+    }
+
+    const theme = createTheme({
+      cssVariables: false,
+      colorSchemes: { light: true, dark: true },
+    });
+    function App() {
+      return (
+        <ThemeProvider theme={theme}>
+          <Toggle />
+        </ThemeProvider>
+      );
+    }
+    const { container } = render(<App />);
+
+    expect(container).to.have.text(`1 light ${createTheme().palette.primary.main}`);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(container).to.have.text(
+      `2 dark ${createTheme({ palette: { mode: 'dark' } }).palette.primary.main}`,
+    );
+  });
+
   it('`forceThemeRerender` recalculates the theme', () => {
     function Toggle() {
       const [count, setCount] = React.useState(0);

--- a/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
+++ b/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
@@ -477,7 +477,7 @@ describe('[Material UI] ThemeProviderWithVars', () => {
     expect(container).to.have.text('1 light');
   });
 
-  it('palette mode should change if not use CSS variables', () => {
+  it('palette mode should change if not using CSS variables', () => {
     function Toggle() {
       const [count, setCount] = React.useState(0);
       const { setMode } = useColorScheme();

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -145,11 +145,11 @@ export default function createCssVarsProvider(options) {
       }
     }
 
-    const calculatedColorScheme =
-      forceThemeRerender && restThemeProp.vars
-        ? // `colorScheme` is undefined on the server and hydration phase
-          colorScheme || restThemeProp.defaultColorScheme
-        : restThemeProp.defaultColorScheme;
+    // `colorScheme` is undefined on the server and hydration phase
+    let calculatedColorScheme = colorScheme || restThemeProp.defaultColorScheme;
+    if (restThemeProp.vars && !forceThemeRerender) {
+      calculatedColorScheme = restThemeProp.defaultColorScheme;
+    }
 
     const memoTheme = React.useMemo(() => {
       // 2. get the `vars` object that refers to the CSS custom properties


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Regression from https://github.com/mui/material-ui/pull/45405
Found this issue while updating the MUI X docs.

## Issue

If light and dark color schemes are used without CSS variables, the `theme.palette.mode` does not update correctly.

## Expected

The `theme.palette.mode` should change when light and dark color schemes are used without CSS variables

Test added.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
