### PR TITLE
[material-ui][Chip] Fix Adornments misaligned in RTL

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -108,8 +108,8 @@ const ChipRoot = styled('div', {
         pointerEvents: 'none',
       },
       [`& .${chipClasses.avatar}`]: {
-        marginLeft: 5,
-        marginRight: -6,
+        marginInlineStart: 5,
+        marginInlineEnd: -6,
         width: 24,
         height: 24,
         color: theme.vars ? theme.vars.palette.Chip.defaultAvatarColor : textColor,
@@ -124,15 +124,15 @@ const ChipRoot = styled('div', {
         backgroundColor: (theme.vars || theme).palette.secondary.dark,
       },
       [`& .${chipClasses.avatarSmall}`]: {
-        marginLeft: 4,
-        marginRight: -4,
+        marginInlineStart: 4,
+        marginInlineEnd: -4,
         width: 18,
         height: 18,
         fontSize: theme.typography.pxToRem(10),
       },
       [`& .${chipClasses.icon}`]: {
-        marginLeft: 5,
-        marginRight: -6,
+        marginInlineStart: 5,
+        marginInlineEnd: -6,
       },
       [`& .${chipClasses.deleteIcon}`]: {
         WebkitTapHighlightColor: 'transparent',
@@ -141,7 +141,9 @@ const ChipRoot = styled('div', {
           : alpha(theme.palette.text.primary, 0.26),
         fontSize: 22,
         cursor: 'pointer',
-        margin: '0 5px 0 -6px',
+        marginBlock: 0,
+        marginInlineStart: -6,
+        marginInlineEnd: 5,
         '&:hover': {
           color: theme.vars
             ? `rgba(${theme.vars.palette.text.primaryChannel} / 0.4)`
@@ -155,13 +157,13 @@ const ChipRoot = styled('div', {
             height: 24,
             [`& .${chipClasses.icon}`]: {
               fontSize: 18,
-              marginLeft: 4,
-              marginRight: -4,
+              marginInlineStart: 4,
+              marginInlineEnd: -4,
             },
             [`& .${chipClasses.deleteIcon}`]: {
               fontSize: 16,
-              marginRight: 4,
-              marginLeft: -4,
+              marginInlineEnd: 4,
+              marginInlineStart: -4,
             },
           },
         },
@@ -278,22 +280,22 @@ const ChipRoot = styled('div', {
               backgroundColor: (theme.vars || theme).palette.action.focus,
             },
             [`& .${chipClasses.avatar}`]: {
-              marginLeft: 4,
+              marginInlineStart: 4,
             },
             [`& .${chipClasses.avatarSmall}`]: {
-              marginLeft: 2,
+              marginInlineStart: 2,
             },
             [`& .${chipClasses.icon}`]: {
-              marginLeft: 4,
+              marginInlineStart: 4,
             },
             [`& .${chipClasses.iconSmall}`]: {
-              marginLeft: 2,
+              marginInlineStart: 2,
             },
             [`& .${chipClasses.deleteIcon}`]: {
-              marginRight: 5,
+              marginInlineEnd: 5,
             },
             [`& .${chipClasses.deleteIconSmall}`]: {
-              marginRight: 3,
+              marginInlineEnd: 3,
             },
           },
         },

--- a/test/regressions/fixtures/Chip/ChipLtr.js
+++ b/test/regressions/fixtures/Chip/ChipLtr.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import Avatar from '@mui/material/Avatar';
+
+export default function ChipLtr() {
+  return (
+    <Box sx={{ width: 500 }}>
+      <Stack direction="row" spacing={1}>
+        <Chip avatar={<Avatar>M</Avatar>} label="Avatar" />
+        <Chip
+          avatar={<Avatar>N</Avatar>}
+          label="Avatar"
+          variant="outlined"
+        />
+      </Stack>
+    </Box>
+  );
+}

--- a/test/regressions/fixtures/Chip/ChipLtr.js
+++ b/test/regressions/fixtures/Chip/ChipLtr.js
@@ -9,11 +9,7 @@ export default function ChipLtr() {
     <Box sx={{ width: 500 }}>
       <Stack direction="row" spacing={1}>
         <Chip avatar={<Avatar>M</Avatar>} label="Avatar" />
-        <Chip
-          avatar={<Avatar>N</Avatar>}
-          label="Avatar"
-          variant="outlined"
-        />
+        <Chip avatar={<Avatar>N</Avatar>} label="Avatar" variant="outlined" />
       </Stack>
     </Box>
   );

--- a/test/regressions/fixtures/Chip/ChipRtl.js
+++ b/test/regressions/fixtures/Chip/ChipRtl.js
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { prefixer } from 'stylis';
+import rtlPlugin from 'stylis-plugin-rtl';
+import { StyleSheetManager } from 'styled-components';
+import { CacheProvider } from '@emotion/react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import createCache from '@emotion/cache';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import Avatar from '@mui/material/Avatar';
+
+// Create rtl cache
+const cacheRtl = createCache({
+  key: 'muirtl',
+  stylisPlugins: [prefixer, rtlPlugin],
+});
+
+const theme = createTheme({ direction: 'rtl' });
+
+export default function ChipRtl() {
+  return (
+    <StyleSheetManager stylisPlugins={[rtlPlugin]}>
+      <CacheProvider value={cacheRtl}>
+        <ThemeProvider theme={theme}>
+          <Box dir="rtl" sx={{ width: 500 }}>
+            <Stack direction="row" spacing={1}>
+              <Chip avatar={<Avatar>M</Avatar>} label="Avatar" />
+              <Chip avatar={<Avatar>N</Avatar>} label="Avatar" variant="outlined" />
+            </Stack>
+          </Box>
+        </ThemeProvider>
+      </CacheProvider>
+    </StyleSheetManager>
+  );
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes: #45193

**Problem:**
The Chip component used `marginLeft` and `marginRight` in its styles, which caused incorrect alignment and spacing in `RTL` layouts. This happened because those directional styles don’t automatically flip when `dir="rtl"` is applied, unless the theme explicitly sets `direction: 'rtl'`.

**Solution:**
Replaced hardcoded directional margins with logical CSS properties (`marginInlineStart` and `marginInlineEnd`) to ensure correct spacing in both `LTR` and `RTL` contexts, regardless of whether `RTL` is set via theme or `dir` attribute.

**Tests:**
Added regression tests to validate the Chip’s layout and spacing in both LTR and RTL directions.


