### PR TITLE
[docs] export `sxChip` again from `AppNavDrawerItem`

### DIFF
--- a/docs/src/modules/components/AppNavDrawerItem.tsx
+++ b/docs/src/modules/components/AppNavDrawerItem.tsx
@@ -256,7 +256,7 @@ const StyledLi = styled('li', { shouldForwardProp: (prop) => prop !== 'depth' })
   }),
 );
 
-const sxChip = (color: 'warning' | 'success' | 'grey' | 'primary'): SxProps<Theme> => [
+export const sxChip = (color: 'warning' | 'success' | 'grey' | 'primary'): SxProps<Theme> => [
   (theme) => ({
     ml: 1,
     fontSize: theme.typography.pxToRem(10),


### PR DESCRIPTION
Bring back the export that was removed in https://github.com/mui/material-ui/pull/45548/. Toolpad docs are relying on it