### PR TITLE
[icons] fix: correct the exported types for "@mui/icons-material" index path on v7

### DIFF
--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -88,10 +88,10 @@
   },
   "typesVersions": {
     "*": {
-      "index": [
+      ".": [
         "./index.d.ts"
       ],
-      "*": [
+      "./*": [
         "./icon.d.ts"
       ]
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

While upgrading from v6 to v7 I noticed that the type information seems to be wrong for the index path of "@mui/icons-material". Locally I'm using Typescript 5.5.4, transpiling to both CJS & ESM.

This probably slipped through v7 testing as using the recommended ("option 1" in the docs) icon import pattern (i.e. `import AccessAlarmIcon from '@mui/icons-material/AccessAlarm';`) wouldn't catch this, but using the named export pattern fails (ie. `import { AccessAlarm } from '@mui/icons-material';`) as it gets `icon.d.ts` typing instead of `index.d.ts`.

This fix seems to work locally, but I'm not a TS/ESM packaging wizard.