### PR TITLE
[material-ui][Fab] Fix default variant text color when using CSS vars

### DIFF
--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -66,7 +66,7 @@ const FabRoot = styled(ButtonBase, {
       boxShadow: (theme.vars || theme).shadows[12],
     },
     color: theme.vars
-      ? theme.vars.palette.text.primary
+      ? theme.vars.palette.grey[900]
       : theme.palette.getContrastText?.(theme.palette.grey[300]),
     backgroundColor: (theme.vars || theme).palette.grey[300],
     '&:hover': {


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/45712

|before|after|
|---|---|
|<img width="379" alt="Screenshot 2025-03-27 at 15 20 24" src="https://github.com/user-attachments/assets/7c8e7aaa-a292-4d81-8371-7edcb1455cbf" />|<img width="382" alt="Screenshot 2025-03-27 at 15 21 38" src="https://github.com/user-attachments/assets/3388cd80-e4a3-4465-891b-fad6cbf283cf" />|
|<img width="384" alt="Screenshot 2025-03-27 at 15 20 16" src="https://github.com/user-attachments/assets/139f930c-d568-4e4a-b8ad-e64da477fdb4" />|<img width="393" alt="Screenshot 2025-03-27 at 15 21 44" src="https://github.com/user-attachments/assets/506feda6-f603-45ac-906b-44934c38a47b" />|
