### PR TITLE
[docs] Fix joy templates error

### DIFF
--- a/packages/mui-docs/src/NProgressBar/NProgressBar.js
+++ b/packages/mui-docs/src/NProgressBar/NProgressBar.js
@@ -50,7 +50,7 @@ function NProgressBar(props) {
             height: 2,
             zIndex: (theme.vars || theme).zIndex.tooltip,
             backgroundColor: (theme.vars || theme).palette.primary[200],
-            ...theme.applyDarkStyles({
+            ...theme.applyStyles('dark', {
               backgroundColor: (theme.vars || theme).palette.primary[700],
             }),
             '& .nprogress-bar': {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fixes https://github.com/mui/material-ui/issues/45707

Currently, all [joy templates](https://mui.com/joy-ui/getting-started/templates/) throw error.

## Root cause

The `NProgressBar` is used in all of the joy templates. It try to access `theme.applyDarkStyles` but the branding theme was removed from the global `_app.js` so the error appear.

Fixed by replacing `applyDarkStyles` (was internal for docs) with official `applyStyles` that comes with the default theme. 
~I took an extra step to replace all occurrences of `applyDarkStyles` because it's no longer needed.~ (split to another PR)

Next step:
- create another PR to replace all occurrences and do the same for MUI X repo
- remove `applyDarkStyles` from the core docs

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
