### PR TITLE
[docs] Update v7 related copy

### DIFF
--- a/docs/data/material/getting-started/overview/overview.md
+++ b/docs/data/material/getting-started/overview/overview.md
@@ -13,7 +13,7 @@ Material UI is an open-source React component library that implements Google's 
 It includes a comprehensive collection of prebuilt components that are ready for use in production right out of the box and features a suite of customization options that make it easy to implement your own custom design system on top of our components.
 
 :::info
-Material UI v6 supports Material Design 2.
+Material UI supports Material Design 2.
 You can follow [this GitHub issue](https://github.com/mui/material-ui/issues/29345) for future design-related updates.
 :::
 

--- a/docs/data/material/migration/upgrade-to-v6/migrating-to-pigment-css.md
+++ b/docs/data/material/migration/upgrade-to-v6/migrating-to-pigment-css.md
@@ -1,16 +1,16 @@
 # Migrating to Pigment CSS
 
-<p class="description">This guide helps you integrate Pigment CSS with Material UI v6.</p>
+<p class="description">This guide helps you integrate Pigment CSS with Material UI.</p>
 
 :::warning
 Pigment CSS is currently in the early alpha stage of development. We're actively working on improving its performance and stability. If you find any problem, please open a [GitHub issue](https://github.com/mui/pigment-css/issues).
 :::
 
-Before going through this guide, make sure you have [upgraded to Material UI v6](/material-ui/migration/upgrade-to-v6/).
+Before going through this guide, make sure you have [upgraded to Material UI v7](/material-ui/migration/upgrade-to-v7/) (or [v6](/material-ui/migration/upgrade-to-v6/)).
 
 ## Introduction
 
-The default styling engine of Material UI v6 is [Emotion](https://emotion.sh/docs/introduction).
+The default styling engine of Material UI is [Emotion](https://emotion.sh/docs/introduction).
 It lets you write styles in a CSS-in-JS fashion, which is great for dynamic styles that depend on states and props. However, it has some performance drawbacks when it comes to frequent re-renders because the style recalculation happens on the client-side.
 It also does not fully support [React Server Components](https://react.dev/reference/rsc/server-components), a new rendering paradigm that renders components ahead of time on the server.
 

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -60,14 +60,14 @@ In general, you can expect the following release cycle:
 
 ## Release schedule
 
-| Date           | Version | Status       |
-| :------------- | :------ | :----------- |
-| 2025           | v7.0.0  | Work started |
-| August 2024    | v6.0.0  | Released     |
-| September 2021 | v5.0.0  | Released     |
-| May 2019       | v4.0.0  | Released     |
-| September 2018 | v3.0.0  | Released     |
-| May 2018       | v1.0.0  | Released     |
+| Date           | Version | Status   |
+| :------------- | :------ | :------- |
+| March 2025     | v7.0.0  | Released |
+| August 2024    | v6.0.0  | Released |
+| September 2021 | v5.0.0  | Released |
+| May 2019       | v4.0.0  | Released |
+| September 2018 | v3.0.0  | Released |
+| May 2018       | v1.0.0  | Released |
 
 You can follow the [milestones](https://github.com/mui/material-ui/milestones) for a more detailed overview.
 

--- a/examples/material-ui-cra-tailwind-ts/README.md
+++ b/examples/material-ui-cra-tailwind-ts/README.md
@@ -27,7 +27,7 @@ or:
 ## The idea behind the example
 
 This example demonstrates how you can use [Tailwind CSS](https://tailwindcss.com/) and [Create React App](https://github.com/facebookincubator/create-react-app) together with Material UI.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI.
 
 ## What's next?
 

--- a/examples/material-ui-cra-ts/README.md
+++ b/examples/material-ui-cra-ts/README.md
@@ -31,7 +31,7 @@ or:
 <!-- #host-reference -->
 
 This example demonstrates how you can use Material UI with [Create React App](https://github.com/facebookincubator/create-react-app) in [TypeScript](https://github.com/Microsoft/TypeScript).
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI.
 If you prefer, you can [use styled-components instead](https://mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## What's next?

--- a/examples/material-ui-cra/README.md
+++ b/examples/material-ui-cra/README.md
@@ -31,7 +31,7 @@ or:
 <!-- #host-reference -->
 
 This example demonstrates how you can use [Create React App](https://github.com/facebookincubator/create-react-app) with Material UI.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI.
 If you prefer, you can [use styled-components instead](https://mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## What's next?

--- a/examples/material-ui-express-ssr/README.md
+++ b/examples/material-ui-express-ssr/README.md
@@ -32,7 +32,7 @@ or:
 
 This is the reference implementation of the [Server Rendering tutorial](https://mui.com/material-ui/guides/server-rendering/).
 
-The example project includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+The example project includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI.
 If you prefer, you can [use styled-components instead](https://mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## What's next?

--- a/examples/material-ui-gatsby/README.md
+++ b/examples/material-ui-gatsby/README.md
@@ -23,7 +23,7 @@ npm run develop
 <!-- #host-reference -->
 
 The project uses [Gatsby](https://github.com/gatsbyjs/gatsby), which is a static site generator for React.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI.
 If you prefer, you can [use styled-components instead](https://mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## What's next?

--- a/examples/material-ui-nextjs-pages-router-ts/README.md
+++ b/examples/material-ui-nextjs-pages-router-ts/README.md
@@ -35,7 +35,7 @@ We recommend starting new projects with the [Material UI with Next.js (App Rout
 <!-- #host-reference -->
 
 The project uses [Next.js](https://github.com/vercel/next.js), which is a framework for server-rendered React apps.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI.
 If you prefer, you can [use styled-components instead](https://mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## The link component

--- a/examples/material-ui-nextjs-pages-router/README.md
+++ b/examples/material-ui-nextjs-pages-router/README.md
@@ -35,7 +35,7 @@ We recommend starting new projects with the [Material UI with Next.js (App Rout
 <!-- #host-reference -->
 
 The project uses [Next.js](https://github.com/vercel/next.js), which is a framework for server-rendered React apps.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI.
 If you prefer, you can [use styled-components instead](https://mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## The Link component

--- a/examples/material-ui-nextjs-ts-v4-v5-migration/README.md
+++ b/examples/material-ui-nextjs-ts-v4-v5-migration/README.md
@@ -29,7 +29,7 @@ or:
 ## The idea behind the example
 
 The project uses [Next.js](https://github.com/vercel/next.js), which is a framework for server-rendered React apps.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI.
 If you prefer, you can [use styled-components instead](https://mui.com/material-ui/integrations/interoperability/#styled-components).
 
 It also includes `@mui/styles`, the legacy styling solution that uses JSS as an engine.

--- a/examples/material-ui-preact/README.md
+++ b/examples/material-ui-preact/README.md
@@ -24,7 +24,7 @@ The project uses Material UI with [Preact](https://github.com/developit/preact)
 
 This example uses CRA with `react-app-rewired` for adding webpack aliases for Preact.
 
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI.
 
 <!-- #host-reference -->
 

--- a/examples/material-ui-remix-ts/README.md
+++ b/examples/material-ui-remix-ts/README.md
@@ -31,7 +31,7 @@ or:
 <!-- #host-reference -->
 
 The project uses [Remix](https://remix.run/), which is a full-stack web framework.
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI.
 If you prefer, you can [use styled-components instead](https://mui.com/material-ui/integrations/interoperability/#styled-components).
 
 ## What's next?

--- a/examples/material-ui-vite-ts/README.md
+++ b/examples/material-ui-vite-ts/README.md
@@ -29,7 +29,7 @@ or:
 ## The idea behind the example
 
 This example uses [Vite.js](https://github.com/vitejs/vite).
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI.
 
 ## What's next?
 

--- a/examples/material-ui-vite/README.md
+++ b/examples/material-ui-vite/README.md
@@ -29,7 +29,7 @@ or:
 ## The idea behind the example
 
 This example uses [Vite.js](https://github.com/vitejs/vite).
-It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI v6.
+It includes `@mui/material` and its peer dependencies, including [Emotion](https://emotion.sh/docs/introduction), the default style engine in Material UI.
 
 ## What's next?
 


### PR DESCRIPTION
- Updates some outdated copy after the v7 release.
- Updates v7 to "released" in https://mui.com/versions/
  <img width="352" alt="Screenshot 2025-03-27 at 15 15 03" src="https://github.com/user-attachments/assets/fb2b3332-d4ef-44b2-8372-f4125757c0d0" />
