### PR TITLE
[docs] Avoid unwanted undefined in page title

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -156,7 +156,11 @@ export default function AppLayoutDocs(props) {
         }}
       />
       <AdManager {...(hasTabs && { classSelector: '.component-tabs' })}>
-        <Head title={`${title} - ${productName}`} description={description} card={card} />
+        <Head
+          title={`${title}${productName ? ` - ${productName}` : ''}`}
+          description={description}
+          card={card}
+        />
         <Main disableToc={disableToc}>
           {/*
             Render the TOCs first to avoid layout shift when the HTML is streamed.


### PR DESCRIPTION
Before this change, "undefined" was showing up in the versions docs page title https://mui.com/versions/

<img width="680" alt="Screenshot 2025-03-27 at 15 51 47" src="https://github.com/user-attachments/assets/e214a5bc-77d3-40c4-bb9f-7adb58509bfb" />
