### PR TITLE
Fix: CSSProperties type export from @mui/material/styles

### DIFF
--- a/packages/mui-material/src/styles/index.d.ts
+++ b/packages/mui-material/src/styles/index.d.ts
@@ -141,3 +141,6 @@ export { default as shouldSkipGeneratingVar } from './shouldSkipGeneratingVar';
 // Private methods for creating parts of the theme
 export { default as private_createTypography } from './createTypography';
 export { default as private_excludeVariablesFromRoot } from './excludeVariablesFromRoot';
+
+// Export CSSProperties from createMixins (which contains our extended version)
+export type { CSSProperties } from './createMixins';


### PR DESCRIPTION
- Description

This PR fixes a regression in MUI v7 where the CSSProperties type was no longer available when importing directly from @mui/material/styles. Previously, users could import this type from @mui/material/styles/createMixins, but the direct import was broken after the v7 update.

- Changes

Added explicit re-export of CSSProperties type in packages/mui-material/src/styles/index.d.ts
Preserved the type definition in createMixins.d.ts
Ensured no duplicate exports or type conflicts