### PR TITLE
[docs] Fix Masonry and Toolpad dark mode demos 

### DIFF
--- a/docs/data/material/components/breadcrumbs/PageContainerBasic.js
+++ b/docs/data/material/components/breadcrumbs/PageContainerBasic.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled, createTheme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import { AppProvider } from '@toolpad/core/AppProvider';
 import {
@@ -73,13 +73,6 @@ function CustomPageHeader() {
   return <PageHeader slots={{ toolbar: CustomPageToolbar }} />;
 }
 
-const demoTheme = createTheme({
-  colorSchemes: { light: true, dark: true },
-  cssVariables: {
-    colorSchemeSelector: 'data-mui-color-scheme',
-  },
-});
-
 export default function PageContainerBasic(props) {
   const { window } = props;
   const router = useDemoRouter('/inbox/all');
@@ -90,7 +83,6 @@ export default function PageContainerBasic(props) {
     <AppProvider
       navigation={NAVIGATION}
       router={router}
-      theme={demoTheme}
       window={demoWindow}
       branding={{
         title: 'ACME Inc.',

--- a/docs/data/material/components/breadcrumbs/PageContainerBasic.js
+++ b/docs/data/material/components/breadcrumbs/PageContainerBasic.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import { styled, createTheme } from '@mui/material/styles';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import { AppProvider } from '@toolpad/core/AppProvider';
 import {
@@ -38,8 +38,8 @@ function useDemoRouter(initialPath) {
 }
 
 const Skeleton = styled('div')(({ theme, height }) => ({
-  backgroundColor: theme.palette.action.hover,
-  borderRadius: theme.shape.borderRadius,
+  backgroundColor: (theme.vars || theme).palette.action.hover,
+  borderRadius: (theme.vars || theme).shape.borderRadius,
   height,
   content: '" "',
 }));
@@ -73,6 +73,10 @@ function CustomPageHeader() {
   return <PageHeader slots={{ toolbar: CustomPageToolbar }} />;
 }
 
+const demoTheme = createTheme({
+  colorSchemes: { light: true, dark: true },
+});
+
 export default function PageContainerBasic(props) {
   const { window } = props;
   const router = useDemoRouter('/inbox/all');
@@ -83,6 +87,7 @@ export default function PageContainerBasic(props) {
     <AppProvider
       navigation={NAVIGATION}
       router={router}
+      theme={demoTheme}
       window={demoWindow}
       branding={{
         title: 'ACME Inc.',

--- a/docs/data/material/components/breadcrumbs/PageContainerBasic.tsx
+++ b/docs/data/material/components/breadcrumbs/PageContainerBasic.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import { styled, createTheme } from '@mui/material/styles';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import { AppProvider, Navigation, Router } from '@toolpad/core/AppProvider';
 import {
@@ -38,8 +38,8 @@ function useDemoRouter(initialPath: string): Router {
 }
 
 const Skeleton = styled('div')<{ height: number }>(({ theme, height }) => ({
-  backgroundColor: theme.palette.action.hover,
-  borderRadius: theme.shape.borderRadius,
+  backgroundColor: (theme.vars || theme).palette.action.hover,
+  borderRadius: (theme.vars || theme).shape.borderRadius,
   height,
   content: '" "',
 }));
@@ -73,6 +73,10 @@ function CustomPageHeader() {
   return <PageHeader slots={{ toolbar: CustomPageToolbar }} />;
 }
 
+const demoTheme = createTheme({
+  colorSchemes: { light: true, dark: true },
+});
+
 export default function PageContainerBasic(props: any) {
   const { window } = props;
   const router = useDemoRouter('/inbox/all');
@@ -83,6 +87,7 @@ export default function PageContainerBasic(props: any) {
     <AppProvider
       navigation={NAVIGATION}
       router={router}
+      theme={demoTheme}
       window={demoWindow}
       branding={{
         title: 'ACME Inc.',

--- a/docs/data/material/components/breadcrumbs/PageContainerBasic.tsx
+++ b/docs/data/material/components/breadcrumbs/PageContainerBasic.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled, createTheme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import { AppProvider, Navigation, Router } from '@toolpad/core/AppProvider';
 import {
@@ -73,13 +73,6 @@ function CustomPageHeader() {
   return <PageHeader slots={{ toolbar: CustomPageToolbar }} />;
 }
 
-const demoTheme = createTheme({
-  colorSchemes: { light: true, dark: true },
-  cssVariables: {
-    colorSchemeSelector: 'data-mui-color-scheme',
-  },
-});
-
 export default function PageContainerBasic(props: any) {
   const { window } = props;
   const router = useDemoRouter('/inbox/all');
@@ -90,7 +83,6 @@ export default function PageContainerBasic(props: any) {
     <AppProvider
       navigation={NAVIGATION}
       router={router}
-      theme={demoTheme}
       window={demoWindow}
       branding={{
         title: 'ACME Inc.',

--- a/docs/data/material/components/masonry/BasicMasonry.js
+++ b/docs/data/material/components/masonry/BasicMasonry.js
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/BasicMasonry.tsx
+++ b/docs/data/material/components/masonry/BasicMasonry.tsx
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/FixedColumns.js
+++ b/docs/data/material/components/masonry/FixedColumns.js
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/FixedColumns.tsx
+++ b/docs/data/material/components/masonry/FixedColumns.tsx
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/FixedSpacing.js
+++ b/docs/data/material/components/masonry/FixedSpacing.js
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/FixedSpacing.tsx
+++ b/docs/data/material/components/masonry/FixedSpacing.tsx
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/ImageMasonry.js
+++ b/docs/data/material/components/masonry/ImageMasonry.js
@@ -9,7 +9,7 @@ const Label = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   borderBottomLeftRadius: 0,
   borderBottomRightRadius: 0,
   ...theme.applyStyles('dark', {

--- a/docs/data/material/components/masonry/ImageMasonry.tsx
+++ b/docs/data/material/components/masonry/ImageMasonry.tsx
@@ -9,7 +9,7 @@ const Label = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   borderBottomLeftRadius: 0,
   borderBottomRightRadius: 0,
   ...theme.applyStyles('dark', {

--- a/docs/data/material/components/masonry/MasonryWithVariableHeightItems.js
+++ b/docs/data/material/components/masonry/MasonryWithVariableHeightItems.js
@@ -13,7 +13,7 @@ const heights = [150, 30, 90, 70, 90, 100, 150, 30, 50, 80];
 
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
   backgroundColor: '#fff',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/MasonryWithVariableHeightItems.tsx
+++ b/docs/data/material/components/masonry/MasonryWithVariableHeightItems.tsx
@@ -13,7 +13,7 @@ const heights = [150, 30, 90, 70, 90, 100, 150, 30, 50, 80];
 
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
   backgroundColor: '#fff',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/ResponsiveColumns.js
+++ b/docs/data/material/components/masonry/ResponsiveColumns.js
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/ResponsiveColumns.tsx
+++ b/docs/data/material/components/masonry/ResponsiveColumns.tsx
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/ResponsiveSpacing.js
+++ b/docs/data/material/components/masonry/ResponsiveSpacing.js
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/ResponsiveSpacing.tsx
+++ b/docs/data/material/components/masonry/ResponsiveSpacing.tsx
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/SSRMasonry.js
+++ b/docs/data/material/components/masonry/SSRMasonry.js
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/SSRMasonry.tsx
+++ b/docs/data/material/components/masonry/SSRMasonry.tsx
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/Sequential.js
+++ b/docs/data/material/components/masonry/Sequential.js
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),

--- a/docs/data/material/components/masonry/Sequential.tsx
+++ b/docs/data/material/components/masonry/Sequential.tsx
@@ -11,7 +11,7 @@ const Item = styled(Paper)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(0.5),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.applyStyles('dark', {
     backgroundColor: '#1A2027',
   }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Issues

- Masonry demos does not appear correctly on dark mode
- On dark mode, navigating to Container or Breadcrumbs page instantly switched to light mode.

## Root cause

- Masonry: the demos are not using CSS variables.
- For breadcrumbs and container page, the issue comes from the Toolpad demo (the bottom of the page). Toolpad uses different key for storing mode in the local storage, so when landing on those pages Toolpad will start as `system` mode (resulted as `light` in daylight environment).

## Fixes

- Masonry: apply `(theme.vars || theme)` to colors
- Toolpad: remove CSS variables from the theme, so that Toolpad uses the same context from the page level and mode is synchronized.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
