### PR TITLE
[support-infra] Remove dead 'workflow_call:'

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -4,7 +4,6 @@ on:
   issues:
     types:
       - closed
-  workflow_call:
 
 permissions: {}
 


### PR DESCRIPTION
See https://docs.github.com/en/actions/sharing-automations/reusing-workflows#creating-a-reusable-workflow for what `workflow_call:` is for. Since we don't plan on reusing this workflow, It looks like we should remove this, to not create confusion.