### PR TITLE
[docs-infra] Fix layout shift between MIT and commercial pages

### DIFF
--- a/docs/data/docs-infra/pages.ts
+++ b/docs/data/docs-infra/pages.ts
@@ -17,6 +17,7 @@ const pages: readonly MuiPage[] = [
       { pathname: '/experiments/docs/codeblock' },
       { pathname: '/experiments/docs/custom-components' },
       { pathname: '/experiments/docs/demos' },
+      { pathname: '/experiments/docs/pro-feature', title: 'Pro feature', plan: 'pro' },
       { pathname: '/experiments/docs/data-grid-premium', title: 'API DataGridPremium' },
     ],
   },

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -148,7 +148,7 @@ export default class MyDocument extends Document {
               },
               '.plan-pro, .plan-premium': {
                 display: 'inline-block',
-                height: '1em',
+                height: '0.9em',
                 width: '1em',
                 verticalAlign: 'middle',
                 marginLeft: '0.3em',

--- a/docs/pages/experiments/docs/pro-feature.js
+++ b/docs/pages/experiments/docs/pro-feature.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from './pro-feature.md?muiMarkdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}

--- a/docs/pages/experiments/docs/pro-feature.md
+++ b/docs/pages/experiments/docs/pro-feature.md
@@ -1,0 +1,7 @@
+---
+title: Pro feature
+---
+
+# Pro feature [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
+
+<p class="description">This is a Pro feature.</p>


### PR DESCRIPTION
I was annoyed by this when browsing the docs. See how the layout of the page changes when you move from an MIT to a commercial feature https://mui.com/x/react-data-grid/tree-data/. I have created a simpler reproduction in:

https://github.com/user-attachments/assets/d90e3156-8c8e-427b-8373-bb1d65590dcc

After: https://deploy-preview-45760--material-ui.netlify.app/experiments/docs/pro-feature/
