### PR TITLE
[docs] Fix lab version install instructions

### DIFF
--- a/docs/data/material/components/about-the-lab/about-the-lab.md
+++ b/docs/data/material/components/about-the-lab/about-the-lab.md
@@ -24,20 +24,20 @@ To install and save in your `package.json` dependencies, run one of the followin
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/lab@^6.0.0 @mui/material@^6.0.0
+npm install @mui/lab@^6.0.0-beta @mui/material@^6.0.0
 ```
 
 ```bash pnpm
-pnpm add @mui/lab@^6.0.0 @mui/material@^6.0.0
+pnpm add @mui/lab@^6.0.0-beta @mui/material@^6.0.0
 ```
 
 ```bash yarn
-yarn add @mui/lab@^6.0.0 @mui/material@^6.0.0
+yarn add @mui/lab@^6.0.0-beta @mui/material@^6.0.0
 ```
 
 </codeblock>
 
-If you wish to use the latest version, remove the `@^6.0.0` suffix.
+If you wish to use the latest version, remove the `@^6.0.0-beta` suffix.
 
 Note that the lab has a peer dependency on the Material UI components.
 

--- a/packages/mui-lab/README.md
+++ b/packages/mui-lab/README.md
@@ -9,7 +9,7 @@ Install the package in your project directory with:
 <!-- #npm-tag-reference -->
 
 ```bash
-npm install @mui/lab@^6.0.0
+npm install @mui/lab@^6.0.0-beta
 ```
 
 The lab has peer dependencies on the Material Design components and on the Emotion library.


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/issues/45764

Fix the dependency range in the lab's install instructions
