### PR TITLE
[nextjs] Add warnings to nextjs router integration

### DIFF
--- a/packages/mui-material-nextjs/src/nextCompatRouter.cjs
+++ b/packages/mui-material-nextjs/src/nextCompatRouter.cjs
@@ -1,0 +1,1 @@
+module.exports = require('next/compat/router');

--- a/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
+++ b/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
@@ -34,7 +34,7 @@ export default function AppRouterCacheProvider(props: AppRouterCacheProviderProp
     const router = usePagesRouter();
     if (router) {
       console.warn(
-        'The app router CacheProvider is not compatible with the pages router. Please use the pages router CacheProvider from `@mui/material-ui-nextjs` instead.',
+        'The app router CacheProvider is not compatible with the pages router. Please use the pages router CacheProvider from `@mui/material-ui-nextjs/vx-appRouter` instead.',
       );
     }
   }

--- a/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
+++ b/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
@@ -33,8 +33,11 @@ export default function AppRouterCacheProvider(props: AppRouterCacheProviderProp
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const router = usePagesRouter();
     if (router) {
-      console.warn(
-        'The app router CacheProvider is not compatible with the pages router. Please use the pages router CacheProvider from `@mui/material-ui-nextjs/vx-appRouter` instead.',
+      console.error(
+        [
+          'The app router CacheProvider is not compatible with the pages router.',
+          'Please use the pages router CacheProvider from `@mui/material-ui-nextjs/vx-appRouter` instead.',
+        ].join('\n'),
       );
     }
   }

--- a/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
+++ b/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
@@ -2,7 +2,8 @@
 import * as React from 'react';
 import createCache, { EmotionCache, Options as OptionsOfCreateCache } from '@emotion/cache';
 import { CacheProvider as DefaultCacheProvider } from '@emotion/react';
-import { useServerInsertedHTML } from 'next/navigation';
+import { useServerInsertedHTML } from './nextNavigation.cjs';
+import { useRouter as usePagesRouter } from '../nextCompatRouter.cjs';
 
 export type AppRouterCacheProviderProps = {
   /**
@@ -28,6 +29,15 @@ export type AppRouterCacheProviderProps = {
  * See https://github.com/mui/material-ui/issues/26561#issuecomment-855286153 for why it's a problem.
  */
 export default function AppRouterCacheProvider(props: AppRouterCacheProviderProps) {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const router = usePagesRouter();
+    if (router) {
+      console.warn(
+        'The app router CacheProvider is not compatible with the pages router. Please use the pages router CacheProvider from `@mui/material-ui-nextjs` instead.',
+      );
+    }
+  }
   const { options, CacheProvider = DefaultCacheProvider, children } = props;
 
   const [registry] = React.useState(() => {

--- a/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
+++ b/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
@@ -35,8 +35,8 @@ export default function AppRouterCacheProvider(props: AppRouterCacheProviderProp
     if (router) {
       console.error(
         [
-          'The app router CacheProvider is not compatible with the pages router.',
-          'Please use the pages router CacheProvider from `@mui/material-ui-nextjs/vx-appRouter` instead.',
+          'The App Router CacheProvider is not compatible with the Pages Router.',
+          'Please use the Pages Router CacheProvider from `@mui/material-ui-nextjs/vx-pagesRouter` instead.',
         ].join('\n'),
       );
     }

--- a/packages/mui-material-nextjs/src/v13-appRouter/nextNavigation.cjs
+++ b/packages/mui-material-nextjs/src/v13-appRouter/nextNavigation.cjs
@@ -1,0 +1,1 @@
+module.exports = require('next/navigation');

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13App.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13App.tsx
@@ -19,8 +19,8 @@ export function AppCacheProvider({
     if (!router) {
       console.error(
         [
-          'The pages router CacheProvider is not compatible with the pages router.',
-          'Please use the app router CacheProvider from `@mui/material-ui-nextjs/vx-pagesRouter` instead.',
+          'The Pages router CacheProvider is not compatible with the App router.',
+          'Please use the App Router CacheProvider from `@mui/material-ui-nextjs/vx-appRouter` instead.',
         ].join('n'),
       );
     }

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13App.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13App.tsx
@@ -17,8 +17,11 @@ export function AppCacheProvider({
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const router = usePagesRouter();
     if (!router) {
-      console.warn(
-        'The pages router CacheProvider is not compatible with the pages router. Please use the app router CacheProvider from `@mui/material-ui-nextjs/vx-pagesRouter` instead.',
+      console.error(
+        [
+          'The pages router CacheProvider is not compatible with the pages router.',
+          'Please use the app router CacheProvider from `@mui/material-ui-nextjs/vx-pagesRouter` instead.',
+        ].join('n'),
       );
     }
   }

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13App.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13App.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { CacheProvider, EmotionCache } from '@emotion/react';
 import createEmotionCache from './createCache';
+import { useRouter as usePagesRouter } from '../nextCompatRouter.cjs';
 
 export interface EmotionCacheProviderProps {
   emotionCache?: EmotionCache;
@@ -12,5 +13,14 @@ export function AppCacheProvider({
   emotionCache = defaultEmotionCache,
   children,
 }: React.PropsWithChildren<EmotionCacheProviderProps>) {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const router = usePagesRouter();
+    if (!router) {
+      console.warn(
+        'The pages router CacheProvider is not compatible with the pages router. Please use the app router CacheProvider from `@mui/material-ui-nextjs` instead.',
+      );
+    }
+  }
   return <CacheProvider value={emotionCache}>{children}</CacheProvider>;
 }

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13App.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13App.tsx
@@ -18,7 +18,7 @@ export function AppCacheProvider({
     const router = usePagesRouter();
     if (!router) {
       console.warn(
-        'The pages router CacheProvider is not compatible with the pages router. Please use the app router CacheProvider from `@mui/material-ui-nextjs` instead.',
+        'The pages router CacheProvider is not compatible with the pages router. Please use the app router CacheProvider from `@mui/material-ui-nextjs/vx-pagesRouter` instead.',
       );
     }
   }


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/issues/45731#issuecomment-2767119561

* Make sure `next/navigation` can be imported correctly under ESM.
* Add warnings to `@mui/material-ui-nextjs` when used under the wrong router implementation.