### PR TITLE
[core] Update scripts to support base-ui

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,7 +64,7 @@ module.exports = /** @type {Config} */ ({
     'plugin:eslint-plugin-import/recommended',
     'plugin:eslint-plugin-import/typescript',
     'eslint-config-airbnb',
-    './eslint/config-airbnb-typescript.js',
+    require.resolve('./eslint/config-airbnb-typescript.js'),
     'eslint-config-prettier',
   ],
   parser: '@typescript-eslint/parser',

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "fast-glob": "^3.3.3",
     "fs-extra": "^11.3.0",
     "globby": "^14.1.0",
+    "jsonc-parser": "^3.3.1",
     "karma": "^6.4.4",
     "karma-browserstack-launcher": "~1.6.0",
     "karma-chrome-launcher": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       globby:
         specifier: ^14.1.0
         version: 14.1.0
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       karma:
         specifier: ^6.4.4
         version: 6.4.4

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -18,7 +18,7 @@ const validBundles = [
 ];
 
 async function run(argv) {
-  const { bundle, largeFiles, outDir: outDirBase, verbose } = argv;
+  const { bundle, largeFiles, outDir: outDirBase, verbose, cjsDir } = argv;
 
   if (!validBundles.includes(bundle)) {
     throw new TypeError(
@@ -53,7 +53,7 @@ async function run(argv) {
   const outFileExtension = '.js';
 
   const relativeOutDir = {
-    node: './',
+    node: cjsDir,
     modern: './modern',
     stable: './esm',
   }[bundle];
@@ -142,6 +142,11 @@ yargs(process.argv.slice(2))
           default: false,
           describe:
             "Set to `true` if you don't want to generate a package.json file in the /esm folder.",
+        })
+        .option('cjsDir', {
+          default: './',
+          type: 'string',
+          description: 'The directory to copy the cjs files to.',
         })
         .option('out-dir', { default: './build', type: 'string' })
         .option('verbose', { type: 'boolean' });

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -17,6 +17,12 @@ const validBundles = [
   'stable',
 ];
 
+const bundleTypes = {
+  modern: 'module',
+  stable: 'module',
+  node: 'commonjs',
+};
+
 async function run(argv) {
   const { bundle, largeFiles, outDir: outDirBase, verbose, cjsDir } = argv;
 
@@ -107,12 +113,15 @@ async function run(argv) {
   // `--extensions-.cjs --out-file-extension .cjs`
   await cjsCopy({ from: srcDir, to: outDir });
 
-  const isEsm = bundle === 'modern' || bundle === 'stable';
-  if (isEsm && !argv.skipEsmPkg) {
+  // Write a package.json file in the output directory if we are building the modern or stable bundle
+  // or if the output directory is not the root of the package.
+  const shouldWriteBundlePackageJson =
+    bundle === 'modern' || bundle === 'stable' || relativeOutDir !== './';
+  if (shouldWriteBundlePackageJson && !argv.skipEsmPkg) {
     const rootBundlePackageJson = path.join(outDir, 'package.json');
     await fs.writeFile(
       rootBundlePackageJson,
-      JSON.stringify({ type: 'module', sideEffects: packageJson.sideEffects }),
+      JSON.stringify({ type: bundleTypes[bundle], sideEffects: packageJson.sideEffects }),
     );
   }
 

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,11 +1,33 @@
 import path from 'path';
 import url from 'url';
+import fs from 'fs';
+
+function findUpFile(fileName, cwd = process.cwd(), maxIterations = 5) {
+  const pathName = path.join(cwd, fileName);
+  if (fs.existsSync(pathName)) {
+    return pathName;
+  }
+  if (maxIterations === 0) {
+    return null;
+  }
+  return findUpFile(fileName, path.dirname(cwd), maxIterations - 1);
+}
 
 /**
- * Returns the full path of the root directory of this repository.
+ * Returns the full path of the root directory of the monorepo.
  */
 // eslint-disable-next-line import/prefer-default-export
 export function getWorkspaceRoot() {
+  // Short circuit when available
+  if (process.env.NX_WORKSPACE_ROOT) {
+    return process.env.NX_WORKSPACE_ROOT;
+  }
+
+  const workspaceFilePath = findUpFile('pnpm-workspace.yaml', process.cwd());
+  if (workspaceFilePath) {
+    return path.dirname(workspaceFilePath);
+  }
+
   const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
   const workspaceRoot = path.resolve(currentDirectory, '..');
   return workspaceRoot;

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -18,7 +18,7 @@ function findUpFile(fileName, cwd = process.cwd(), maxIterations = 5) {
  */
 // eslint-disable-next-line import/prefer-default-export
 export function getWorkspaceRoot() {
-  // Short circuit when available
+  // Use this when available. Avoids the need to check for the workspace file.
   if (process.env.NX_WORKSPACE_ROOT) {
     return process.env.NX_WORKSPACE_ROOT;
   }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Some of the notable changes -

* Updated `getWorkspaceRoot` function to get the root directory relative to the current working directory. This would allow us to use this function across other repos as well. Without this change, it would return a directory inside `node_modules` when used in other repos.
* Updated the build script to customize the cjs output. Default continues to be the root of the `build` directory. This allows us to use this in `base-ui` repo to override this to `cjs` directory inside `build`.
* Updated `buildTypes.mts` script to optionally accept a list of directories to copy the emitted types to (from the default `esm` directory). The default has been set to `['build', 'build/modern']` to cater to core repo.

The scripts have been tested in both `base-ui` and `mui-next` repos using git commit hash.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
