### PR TITLE
[docs] Update migration instructions and codemod references for deprecated APIs

### DIFF
--- a/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
+++ b/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
@@ -1333,7 +1333,7 @@ The Input's prop `componentsProps` was deprecated in favor of `slotProps`:
 
 ## InputBase
 
-Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#input-base-props) below to migrate the code as described in the following sections:
+Use the [input-base-props-codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#input-base-props) and [input-base-classes-codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#input-base-classes) codemods below to migrate the code as described in the following sections:
 
 ```bash
 npx @mui/codemod@latest deprecations/input-base-props <path>
@@ -1930,7 +1930,7 @@ The Popper's prop `componentsProps` was deprecated in favor of `slotProps`:
 Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#rating-props) below to migrate the code as described in the following sections:
 
 ```bash
-npx @mui/codemod@latest deprecations/step-label-props <path>
+npx @mui/codemod@latest deprecations/rating-props <path>
 ```
 
 ### IconContainerComponent
@@ -1992,7 +1992,7 @@ Here's how to migrate:
 
 ## Slider
 
-Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#slider-props) below to migrate the code as described in the following sections:
+Use the [slider-props-codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#slider-props) and [slider-classes-codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#slider-classes) codemods below to migrate the code as described in the following sections:
 
 ```bash
 npx @mui/codemod@latest deprecations/slider-props <path>
@@ -2172,7 +2172,7 @@ Here's how to migrate:
 
 ## Tabs
 
-Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#tabs-props) below to migrate the code as described in the following sections:
+Use the [tab-props-codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#tabs-props), [tab-classes-codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#tabs-classes) codemods below to migrate the code as described in the following sections:
 
 ```bash
 npx @mui/codemod@latest deprecations/tabs-classes <path>

--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -393,6 +393,10 @@ npx @mui/codemod@latest deprecations/avatar-group-props <path>
  />
 ```
 
+```bash
+npx @mui/codemod@latest deprecations/avatar-props <path>
+```
+
 #### `backdrop-props`
 
 ```diff
@@ -1609,7 +1613,7 @@ npx @mui/codemod@latest deprecations/outlined-input-props <path>
 #### `rating-props`
 
 ```diff
- <Snackbar
+ <Rating
 -  IconContainerComponent={CustomContainer}
 +  slots={{
 +    icon: { component: CustomContainer }
@@ -1618,7 +1622,7 @@ npx @mui/codemod@latest deprecations/outlined-input-props <path>
 ```
 
 ```bash
-npx @mui/codemod deprecations/snackbar-props <path>
+npx @mui/codemod deprecations/rating-props <path>
 ```
 
 #### `select-classes`
@@ -1861,6 +1865,18 @@ JS transforms:
  },
 ```
 
+CSS transforms:
+
+```diff
+-.MuiStepConnector-lineHorizontal
++.MuiStepConnector-horizontal > .MuiStepConnector-line
+```
+
+```diff
+-.MuiStepConnector-lineVertical
++.MuiStepConnector-vertical > .MuiStepConnector-line
+```
+
 ```bash
 npx @mui/codemod deprecations/step-connector-classes <path>
 ```
@@ -1970,22 +1986,6 @@ CSS transforms:
 
 ```bash
 npx @mui/codemod@latest deprecations/toggle-button-group-classes <path>
-```
-
-CSS transforms:
-
-```diff
--.MuiStepConnector-lineHorizontal
-+.MuiStepConnector-horizontal > .MuiStepConnector-line
-```
-
-```diff
--.MuiStepConnector-lineVertical
-+.MuiStepConnector-vertical > .MuiStepConnector-line
-```
-
-```bash
-npx @mui/codemod@latest deprecations/step-connector-classes <path>
 ```
 
 #### `tab-classes`


### PR DESCRIPTION
The changes aim to improve the clarity and accuracy of migration instructions for various components.

Updates to migration documentation:

docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md: Updated migration instructions to include additional codemods for InputBase, Slider, and Tabs components. 
docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md: Corrected the codemod reference for the Rating component.
Updates to codemod references:

packages/mui-codemod/README.md: Added missing codemod command for avatar-props.
packages/mui-codemod/README.md: Corrected codemod commands for rating-props. 
packages/mui-codemod/README.md: Moved CSS transforms for step-connector-classes to an appropriate section. 

