### PR TITLE
[nextjs] Fix nonce issues

### DIFF
--- a/packages/mui-material-nextjs/src/v13-pagesRouter/createCache.ts
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/createCache.ts
@@ -5,7 +5,7 @@ const isBrowser = typeof document !== 'undefined';
 // On the client side, Create a meta tag at the top of the <head> and set it as insertionPoint.
 // This assures that MUI styles are loaded first.
 // It allows developers to easily override MUI styles with other styling solutions, like CSS modules.
-export default function createEmotionCache(options: Options) {
+export default function createEmotionCache(options?: Options) {
   let insertionPoint;
 
   if (isBrowser) {

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/createCache.ts
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/createCache.ts
@@ -5,7 +5,7 @@ const isBrowser = typeof document !== 'undefined';
 // On the client side, Create a meta tag at the top of the <head> and set it as insertionPoint.
 // This assures that MUI styles are loaded first.
 // It allows developers to easily override MUI styles with other styling solutions, like CSS modules.
-export default function createEmotionCache(options?: Omit<Options, 'key'>) {
+export default function createEmotionCache(options?: Partial<Options>) {
   let insertionPoint;
 
   if (isBrowser) {
@@ -15,5 +15,5 @@ export default function createEmotionCache(options?: Omit<Options, 'key'>) {
     insertionPoint = emotionInsertionPoint ?? undefined;
   }
 
-  return createCache({ ...options, key: 'mui', insertionPoint });
+  return createCache({ key: 'mui', insertionPoint, ...options });
 }

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/createCache.ts
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/createCache.ts
@@ -1,11 +1,11 @@
-import createCache from '@emotion/cache';
+import createCache, { Options } from '@emotion/cache';
 
 const isBrowser = typeof document !== 'undefined';
 
 // On the client side, Create a meta tag at the top of the <head> and set it as insertionPoint.
 // This assures that MUI styles are loaded first.
 // It allows developers to easily override MUI styles with other styling solutions, like CSS modules.
-export default function createEmotionCache() {
+export default function createEmotionCache(options: Options) {
   let insertionPoint;
 
   if (isBrowser) {
@@ -15,5 +15,5 @@ export default function createEmotionCache() {
     insertionPoint = emotionInsertionPoint ?? undefined;
   }
 
-  return createCache({ key: 'mui', insertionPoint });
+  return createCache({ ...options, key: 'mui', insertionPoint });
 }

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/createCache.ts
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/createCache.ts
@@ -5,7 +5,7 @@ const isBrowser = typeof document !== 'undefined';
 // On the client side, Create a meta tag at the top of the <head> and set it as insertionPoint.
 // This assures that MUI styles are loaded first.
 // It allows developers to easily override MUI styles with other styling solutions, like CSS modules.
-export default function createEmotionCache(options?: Options) {
+export default function createEmotionCache(options?: Omit<Options, 'key'>) {
   let insertionPoint;
 
   if (isBrowser) {

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/index.ts
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/index.ts
@@ -1,2 +1,3 @@
 export * from './pagesRouterV13Document';
 export * from './pagesRouterV13App';
+export { default as createEmotionCache } from './createCache';

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
@@ -103,7 +103,7 @@ export async function documentGetInitialProps(
         return {
           ...initialProps,
           emotionStyleTags: styles.map((style) =>
-            style.ids.length > 0 ? (
+            style.css.trim() ? (
               <style
                 data-emotion={`${style.key} ${style.ids.join(' ')}`}
                 key={style.key}

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
@@ -100,18 +100,19 @@ export async function documentGetInitialProps(
         },
       resolveProps: async (initialProps) => {
         const { styles } = extractCriticalToChunks(initialProps.html);
-        console.log(styles);
         return {
           ...initialProps,
-          emotionStyleTags: styles.map((style) => (
-            <style
-              data-emotion={`${style.key} ${style.ids.join(' ')}`}
-              key={style.key}
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: style.css }}
-              nonce={cache.nonce}
-            />
-          )),
+          emotionStyleTags: styles.map((style) =>
+            style.css.trim() ? (
+              <style
+                data-emotion={`${style.key} ${style.ids.join(' ')}`}
+                key={style.key}
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{ __html: style.css }}
+                nonce={cache.nonce}
+              />
+            ) : null,
+          ),
         };
       },
     },

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
@@ -102,14 +102,16 @@ export async function documentGetInitialProps(
         const { styles } = extractCriticalToChunks(initialProps.html);
         return {
           ...initialProps,
-          emotionStyleTags: styles.map((style) => (
-            <style
-              data-emotion={`${style.key} ${style.ids.join(' ')}`}
-              key={style.key}
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: style.css }}
-            />
-          )),
+          emotionStyleTags: styles.map((style) =>
+            style.ids.length > 0 ? (
+              <style
+                data-emotion={`${style.key} ${style.ids.join(' ')}`}
+                key={style.key}
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{ __html: style.css }}
+              />
+            ) : null,
+          ),
         };
       },
     },

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
@@ -100,18 +100,18 @@ export async function documentGetInitialProps(
         },
       resolveProps: async (initialProps) => {
         const { styles } = extractCriticalToChunks(initialProps.html);
+        console.log(styles);
         return {
           ...initialProps,
-          emotionStyleTags: styles.map((style) =>
-            style.css.trim() ? (
-              <style
-                data-emotion={`${style.key} ${style.ids.join(' ')}`}
-                key={style.key}
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={{ __html: style.css }}
-              />
-            ) : null,
-          ),
+          emotionStyleTags: styles.map((style) => (
+            <style
+              data-emotion={`${style.key} ${style.ids.join(' ')}`}
+              key={style.key}
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: style.css }}
+              nonce={cache.nonce}
+            />
+          )),
         };
       },
     },


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/45774

* Add nonce to critical css style tags.
* Make `createEmotionCache` available to users and allow passing options.

This makes the [pages router example](https://github.com/mui/material-ui/tree/11f7526210f2ec6b27a20d7620c8020731cb0704/examples/material-ui-nextjs-pages-router-ts) work with strict CSP when making the following alterations:

```tsx
// ./middleware.ts
import { NextResponse } from "next/server";
import type { NextRequest } from "next/server";
import { generateNonce } from "./src/nonce";

export function middleware(request: NextRequest) {
  // Generate unique nonce for each request
  const nonce = generateNonce();

  // Important: Store nonce in headers to access it throughout the request lifecycle
  const requestHeaders = new Headers(request.headers);
  requestHeaders.set("x-nonce", nonce);

  // Important: Define CSP directives with nonce
  // Each directive controls different resource types
  const cspHeader = `
  default-src 'self';
  script-src 'self' 'nonce-${nonce}';
  style-src 'self' 'nonce-${nonce}';
  img-src 'self';
  font-src 'self';
  object-src 'none';
  base-uri 'self';
  form-action 'self';
  frame-ancestors 'none';
  upgrade-insecure-requests;
`
    .replace(/\s{2,}/g, " ")
    .trim();

  const response = NextResponse.next({
    request: {
      headers: requestHeaders,
    },
  });

  if (process.env.NODE_ENV === "production") {
    // Set the CSP header in the response
    response.headers.set("Content-Security-Policy", cspHeader);
  }

  return response;
}
```

```tsx
// ./pages/_document.tsx
import * as React from "react";
import {
  Html,
  Head,
  Main,
  NextScript,
  DocumentProps,
  DocumentContext,
} from "next/document";
import {
  DocumentHeadTags,
  DocumentHeadTagsProps,
  documentGetInitialProps,
  createEmotionCache,
} from "@mui/material-nextjs/v15-pagesRouter";
import theme, { roboto } from "../src/theme";

export default function MyDocument(
  props: DocumentProps & DocumentHeadTagsProps & { nonce: string }
) {
  const { nonce } = props;

  return (
    <Html lang="en" className={roboto.className}>
      <Head>
        {/* PWA primary color */}
        <meta name="theme-color" content={theme.palette.primary.main} />
        <link rel="shortcut icon" href="/favicon.ico" />
        <meta name="emotion-insertion-point" content="" />
        <meta name="csp-nonce" content={nonce} />
        <DocumentHeadTags {...props} />
      </Head>
      <body>
        <Main />
        <NextScript nonce={nonce} />
      </body>
    </Html>
  );
}

MyDocument.getInitialProps = async (ctx: DocumentContext) => {
  const { req } = ctx;
  const nonce = req?.headers["x-nonce"];
  if (typeof nonce !== "string") {
    throw new Error('"nonce" header is missing');
  }
  const emotionCache = createEmotionCache({ nonce });
  const finalProps = await documentGetInitialProps(ctx, {
    emotionCache,
  });
  return { ...finalProps, nonce };
};
```

```tsx
// ./pages/_app.tsx
import * as React from "react";
import Head from "next/head";
import { AppProps } from "next/app";
import {
  AppCacheProvider,
  createEmotionCache,
} from "@mui/material-nextjs/v15-pagesRouter";
import { ThemeProvider } from "@mui/material/styles";
import CssBaseline from "@mui/material/CssBaseline";
import theme from "../src/theme";
import { NextPageContext } from "next";
import { IncomingMessage } from "http";

export default function MyApp(props: AppProps & { nonce: string }) {
  const { Component, pageProps, nonce } = props;

  const cache = React.useMemo(() => createEmotionCache({ nonce }), [nonce]);

  return (
    <AppCacheProvider {...props} emotionCache={cache}>
      <Head>
        <meta name="viewport" content="initial-scale=1, width=device-width" />
      </Head>
      <ThemeProvider theme={theme}>
        {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
        <CssBaseline />
        <Component {...pageProps} />
      </ThemeProvider>
    </AppCacheProvider>
  );
}

function getNonce(req?: IncomingMessage) {
  if (req) {
    return req.headers["x-nonce"];
  }
  const nonceMeta = document.querySelector('meta[name="csp-nonce"]');
  if (nonceMeta) {
    return nonceMeta.getAttribute("content");
  }
  return null;
}

MyApp.getInitialProps = async ({ ctx }: { ctx: NextPageContext }) => {
  const { req } = ctx;
  // Note: This only works server-side
  const nonce = getNonce(req);
  if (!nonce) {
    throw new Error("Nonce not found");
  }
  return { nonce };
};
```