### PR TITLE
[docs] Add missing `forceThemeRerender` prop type on `ThemeProviderProps`

### DIFF
--- a/packages/mui-material/src/styles/ThemeProvider.tsx
+++ b/packages/mui-material/src/styles/ThemeProvider.tsx
@@ -80,6 +80,11 @@ export interface ThemeProviderProps<Theme = DefaultTheme> extends ThemeProviderC
    * @default false
    */
   disableTransitionOnChange?: boolean;
+  /**
+   * If `true`, force theme change between modes
+   * @default false
+   */
+  forceThemeRerender?: boolean;
 }
 
 export default function ThemeProvider<Theme = DefaultTheme>({


### PR DESCRIPTION
After upgrading to the `@material-ui@7.0.1` I noticed that my logic for switching between light and dark theme stopped working. I followed [this](https://mui.com/material-ui/migration/upgrade-to-v7/#theme-behavior-changes) migration guide and discovered that solution was to pass `forceThemeRerender` on my `ThemeProvider`. 

While this resolved the issue I noticed that the property type is not added on `ThemeProviderProps`. This PR 
simply adds the prop type to avoid TS errors.

<img width="400" alt="Screenshot 2025-04-02 at 2 58 11 PM" src="https://github.com/user-attachments/assets/94b17555-53da-4b46-ad8b-5e9abac42993" />
