### PR TITLE
Remove baseUrl and skipLibCheck

### DIFF
--- a/packages/mui-system/tsconfig.json
+++ b/packages/mui-system/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src/**/*", "test/**/*"],
-  "exclude": ["test/typescript/moduleAugmentation"],
-  "compilerOptions": {
-    "skipLibCheck": true
-  }
+  "exclude": ["test/typescript/moduleAugmentation"]
 }

--- a/packages/mui-types/src/index.spec.ts
+++ b/packages/mui-types/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'packages/mui-types/src';
+import { expectType } from '.';
 
 function expectTypeTypes() {
   // it rejects assignability to `any`

--- a/patches/styled-components.patch
+++ b/patches/styled-components.patch
@@ -1,0 +1,10 @@
+diff --git a/dist/hoc/withTheme.d.ts b/dist/hoc/withTheme.d.ts
+index ccc495498f5088f8985ea715a3874b145b54c6ef..a63a1c69a95785c8e916b6b7e8257f0012bf8f4c 100644
+--- a/dist/hoc/withTheme.d.ts
++++ b/dist/hoc/withTheme.d.ts
+@@ -1,3 +1,4 @@
+ import React from 'react';
+ import { AnyComponent, ExecutionProps } from '../types';
+-export default function withTheme<T extends AnyComponent>(Component: T): React.ForwardRefExoticComponent<React.PropsWithoutRef<JSX.LibraryManagedAttributes<T, ExecutionProps>> & React.RefAttributes<T>> & { [key in Exclude<keyof T, T extends React.MemoExoticComponent<any> ? "propTypes" | "defaultProps" | "displayName" | "$$typeof" | "type" | "compare" : T extends React.ForwardRefExoticComponent<any> ? "propTypes" | "defaultProps" | "displayName" | "$$typeof" | "render" : "length" | "propTypes" | "contextType" | "contextTypes" | "childContextTypes" | "defaultProps" | "displayName" | "getDerivedStateFromProps" | "getDerivedStateFromError" | "name" | "type" | "getDefaultProps" | "mixins" | "prototype" | "caller" | "callee" | "arguments" | "arity">]: T[key]; };
++
++export default function withTheme<T extends AnyComponent>(Component: T): React.ForwardRefExoticComponent<React.PropsWithoutRef<React.JSX.LibraryManagedAttributes<T, ExecutionProps>> & React.RefAttributes<T>> & { [key in Exclude<keyof T, T extends React.MemoExoticComponent<any> ? "propTypes" | "defaultProps" | "displayName" | "$$typeof" | "type" | "compare" : T extends React.ForwardRefExoticComponent<any> ? "propTypes" | "defaultProps" | "displayName" | "$$typeof" | "render" : "length" | "propTypes" | "contextType" | "contextTypes" | "childContextTypes" | "defaultProps" | "displayName" | "getDerivedStateFromProps" | "getDerivedStateFromError" | "name" | "type" | "getDefaultProps" | "mixins" | "prototype" | "caller" | "callee" | "arguments" | "arity">]: T[key]; };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,11 @@ overrides:
   '@pigment-css/nextjs-plugin': 0.0.30
   '@pigment-css/vite-plugin': 0.0.30
 
+patchedDependencies:
+  styled-components:
+    hash: 383c648dfdb5dfc82fbe414d54027d8c982a01c6320370f0ecfdb387e753c09f
+    path: patches/styled-components.patch
+
 importers:
 
   .:
@@ -616,7 +621,7 @@ importers:
         version: 6.1.6
       styled-components:
         specifier: ^6.1.16
-        version: 6.1.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 6.1.16(patch_hash=383c648dfdb5dfc82fbe414d54027d8c982a01c6320370f0ecfdb387e753c09f)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       styled-system:
         specifier: ^5.1.5
         version: 5.1.5
@@ -886,7 +891,7 @@ importers:
         version: 6.0.1
       styled-components:
         specifier: ^6.1.16
-        version: 6.1.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 6.1.16(patch_hash=383c648dfdb5dfc82fbe414d54027d8c982a01c6320370f0ecfdb387e753c09f)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       stylis:
         specifier: 4.2.0
         version: 4.2.0
@@ -2049,7 +2054,7 @@ importers:
         version: 19.1.0
       styled-components:
         specifier: ^6.1.16
-        version: 6.1.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 6.1.16(patch_hash=383c648dfdb5dfc82fbe414d54027d8c982a01c6320370f0ecfdb387e753c09f)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     publishDirectory: build
 
   packages/mui-system:
@@ -2120,7 +2125,7 @@ importers:
         version: 19.0.5
       styled-components:
         specifier: ^6.1.16
-        version: 6.1.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 6.1.16(patch_hash=383c648dfdb5dfc82fbe414d54027d8c982a01c6320370f0ecfdb387e753c09f)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     publishDirectory: build
 
   packages/mui-types:
@@ -2338,7 +2343,7 @@ importers:
         version: 19.0.5
       styled-components:
         specifier: ^6.1.16
-        version: 6.1.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 6.1.16(patch_hash=383c648dfdb5dfc82fbe414d54027d8c982a01c6320370f0ecfdb387e753c09f)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       stylis:
         specifier: 4.2.0
         version: 4.2.0
@@ -25970,7 +25975,7 @@ snapshots:
       minimist: 1.2.8
       through: 2.3.8
 
-  styled-components@6.1.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  styled-components@6.1.16(patch_hash=383c648dfdb5dfc82fbe414d54027d8c982a01c6320370f0ecfdb387e753c09f)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@emotion/is-prop-valid': 1.2.2
       '@emotion/unitless': 0.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,12 @@
 packages:
-  - 'benchmark'
-  - 'packages/*'
-  - 'packages/mui-envinfo/test'
-  - 'packages-internal/*'
-  - 'docs'
-  - 'test'
-  - 'test/moduleResolution'
-  - 'apps/*'
-  - 'scripts/sizeSnapshot'
+  - benchmark
+  - packages/*
+  - packages/mui-envinfo/test
+  - packages-internal/*
+  - docs
+  - test
+  - test/moduleResolution
+  - apps/*
+  - scripts/sizeSnapshot
+patchedDependencies:
+  styled-components: patches/styled-components.patch

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "strict": true,
     "noEmit": true,
     "experimentalDecorators": true,
-    "baseUrl": "./",
     "allowSyntheticDefaultImports": true,
     "noErrorTruncation": false,
     "allowJs": true,
@@ -47,7 +46,8 @@
         "./packages-internal/scripts/typescript-to-proptypes/src"
       ],
       "@mui/internal-test-utils": ["./packages-internal/test-utils/src"],
-      "@mui/internal-test-utils/*": ["./packages-internal/test-utils/src/*"]
+      "@mui/internal-test-utils/*": ["./packages-internal/test-utils/src/*"],
+      "docs/*": ["./docs/*"]
     },
     // Otherwise we get react-native typings which conflict with dom.lib.
     "types": ["node", "react", "mocha"]


### PR DESCRIPTION
It doesn't make sense to be able to resolve from the monorepo root everywhere in the project. Ideally these paths are defined on the package level, and mimic the workspace dependencies of that specific package only. 
Also removing skipLibCheck in @mui/system