### PR TITLE
[docs] Update `@mui/icons-material` install command to use 6.x version

### DIFF
--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -122,6 +122,8 @@ To install Roboto through the Google Web Fonts CDN, add the following code insid
 To use the [font Icon component](/material-ui/icons/#icon-font-icons) or the prebuilt SVG Material Icons (such as those found in the [icon demos](/material-ui/icons/)), you must first install the [Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) font.
 You can do so with npm, or with the Google Web Fonts CDN.
 
+<!-- #npm-tag-reference -->
+
 <codeblock storageKey="package-manager">
 
 ```bash npm

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -125,15 +125,15 @@ You can do so with npm, or with the Google Web Fonts CDN.
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/icons-material
+npm install @mui/icons-material@^6.0.0
 ```
 
 ```bash pnpm
-pnpm add @mui/icons-material
+pnpm add @mui/icons-material@^6.0.0
 ```
 
 ```bash yarn
-yarn add @mui/icons-material
+yarn add @mui/icons-material@^6.0.0
 ```
 
 </codeblock>


### PR DESCRIPTION
Copy/pasting the command to install mui/icons-material fails because it tries and installs latest which needs material v7.x, but we explicitly are using v6.x. Updated the script to request v6 like the other install snippets on this page.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
