### PR TITLE
[code-infra] Fix `StrictMode` effects not being called twice in React 19 tests

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -20,4 +20,7 @@ module.exports = {
     '**/build/**',
     'docs/.next/**',
   ],
+  // detect-modules doesn't work with @babel/register
+  // https://github.com/babel/babel/issues/6737
+  'node-option': ['no-experimental-detect-module'],
 };

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@pigment-css/react": "0.0.30",
     "@playwright/test": "1.51.1",
     "@types/babel__core": "^7.20.5",
+    "@types/babel__register": "^7.17.3",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash": "^4.17.16",
     "@types/mocha": "^10.0.10",

--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -233,7 +233,7 @@ interface ServerRenderConfiguration extends RenderConfiguration {
   container: HTMLElement;
 }
 
-export type RenderOptions = Partial<RenderConfiguration>;
+export type RenderOptions = Omit<Partial<RenderConfiguration>, 'reactStrictMode'>;
 
 export interface MuiRenderResult extends RenderResult<typeof queries & typeof customQueries> {
   user: ReturnType<typeof userEvent.setup>;

--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -12,6 +12,7 @@ import {
   screen as rtlScreen,
   Screen,
   render as testingLibraryRender,
+  RenderOptions as TestingLibraryRenderOptions,
   within,
 } from '@testing-library/react/pure';
 import { userEvent } from '@testing-library/user-event';
@@ -201,7 +202,7 @@ const customQueries = {
   findAllDescriptionsOf,
 };
 
-interface RenderConfiguration {
+interface RenderConfiguration extends Pick<TestingLibraryRenderOptions, 'reactStrictMode'> {
   /**
    * https://testing-library.com/docs/react-testing-library/api#container
    */
@@ -256,7 +257,7 @@ function render(
   element: React.ReactElement<DataAttributes>,
   configuration: ClientRenderConfiguration,
 ): MuiRenderResult {
-  const { container, hydrate, wrapper } = configuration;
+  const { container, hydrate, wrapper, reactStrictMode } = configuration;
 
   const testingLibraryRenderResult = traceSync('render', () =>
     testingLibraryRender(element, {
@@ -264,6 +265,7 @@ function render(
       hydrate,
       queries: { ...queries, ...customQueries },
       wrapper,
+      reactStrictMode,
     }),
   );
   const result: MuiRenderResult = {
@@ -628,24 +630,16 @@ export function createRenderer(globalOptions: CreateRendererOptions = {}): Rende
     serverContainer = null!;
   });
 
-  function createWrapper(options: Partial<RenderConfiguration>) {
-    const {
-      strict = globalStrict,
-      strictEffects = globalStrictEffects,
-      wrapper: InnerWrapper = React.Fragment,
-    } = options;
+  function createWrapper(options: Pick<RenderOptions, 'wrapper'>) {
+    const { wrapper: InnerWrapper = React.Fragment } = options;
 
-    const usesLegacyRoot = reactMajor < 18;
-    const Mode = strict && (strictEffects || usesLegacyRoot) ? React.StrictMode : React.Fragment;
     return function Wrapper({ children }: { children?: React.ReactNode }) {
       return (
-        <Mode>
-          <EmotionCacheProvider value={emotionCache}>
-            <React.Profiler id={profiler.id} onRender={profiler.onRender}>
-              <InnerWrapper>{children}</InnerWrapper>
-            </React.Profiler>
-          </EmotionCacheProvider>
-        </Mode>
+        <EmotionCacheProvider value={emotionCache}>
+          <React.Profiler id={profiler.id} onRender={profiler.onRender}>
+            <InnerWrapper>{children}</InnerWrapper>
+          </React.Profiler>
+        </EmotionCacheProvider>
       );
     };
   }
@@ -661,8 +655,14 @@ export function createRenderer(globalOptions: CreateRendererOptions = {}): Rende
         );
       }
 
+      const usesLegacyRoot = reactMajor < 18;
+      const reactStrictMode =
+        (options.strict ?? globalStrict) &&
+        ((options.strictEffects ?? globalStrictEffects) || usesLegacyRoot);
+
       return render(element, {
         ...options,
+        reactStrictMode,
         hydrate: false,
         wrapper: createWrapper(options),
       });

--- a/packages-internal/test-utils/src/setupBabel.js
+++ b/packages-internal/test-utils/src/setupBabel.js
@@ -1,3 +1,3 @@
 require('@babel/register')({
-  extensions: ['.js', '.mjs', '.ts', '.tsx'],
+  extensions: ['.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx'],
 });

--- a/packages/mui-base/src/FocusTrap/FocusTrap.test.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { expect } from 'chai';
-import { act, createRenderer, screen } from '@mui/internal-test-utils';
+import { act, createRenderer, reactMajor, screen } from '@mui/internal-test-utils';
 import { FocusTrap } from '@mui/base/FocusTrap';
 import { Portal } from '@mui/base/Portal';
 
@@ -219,7 +219,7 @@ describe('<FocusTrap />', () => {
         </div>
       );
     }
-    const { setProps, getByRole } = render(<Test />);
+    const { setProps, getByRole } = render(<Test />, { strict: reactMajor <= 18 });
     expect(screen.getByTestId('root')).toHaveFocus();
 
     act(() => {

--- a/packages/mui-base/src/Input/Input.test.tsx
+++ b/packages/mui-base/src/Input/Input.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { createRenderer, fireEvent, screen, act } from '@mui/internal-test-utils';
+import { createRenderer, fireEvent, screen, act, reactMajor } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { Input, inputClasses, InputOwnerState } from '@mui/base/Input';
@@ -281,8 +281,8 @@ describe('<Input />', () => {
         );
       }).toErrorDev([
         'MUI: You have provided a `slots.input` to the input component\nthat does not correctly handle the `ref` prop.\nMake sure the `ref` prop is called with a HTMLInputElement.',
-        // React 18 Strict Effects run mount effects twice
-        React.version.startsWith('18') &&
+        // React Strict Mode runs mount effects twice
+        reactMajor >= 18 &&
           'MUI: You have provided a `slots.input` to the input component\nthat does not correctly handle the `ref` prop.\nMake sure the `ref` prop is called with a HTMLInputElement.',
       ]);
     });

--- a/packages/mui-base/src/Portal/Portal.test.tsx
+++ b/packages/mui-base/src/Portal/Portal.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer } from '@mui/internal-test-utils';
+import { createRenderer, reactMajor } from '@mui/internal-test-utils';
 import { Portal, PortalProps } from '@mui/base/Portal';
 
 describe('<Portal />', () => {
@@ -44,6 +44,7 @@ describe('<Portal />', () => {
         <Portal disablePortal ref={refSpy}>
           <h1 className="woofPortal">Foo</h1>
         </Portal>,
+        { strict: reactMajor <= 18 },
       );
       const mountNode = document.querySelector('.woofPortal');
       expect(refSpy.args).to.deep.equal([[mountNode]]);
@@ -57,6 +58,7 @@ describe('<Portal />', () => {
         <Portal disablePortal ref={refSpy}>
           <h1 className="woofPortal">Foo</h1>
         </Portal>,
+        { strict: reactMajor <= 18 },
       );
       const mountNode = document.querySelector('.woofPortal');
       expect(refSpy.args).to.deep.equal([[mountNode]]);

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.test.js
@@ -313,6 +313,14 @@ describe('useAutocomplete', () => {
         aboveErrorTestComponentMessage,
         aboveErrorTestComponentMessage,
       ],
+      19: [
+        muiErrorMessage,
+        muiErrorMessage,
+        nodeErrorMessage,
+        nodeErrorMessage,
+        nodeErrorMessage,
+        nodeErrorMessage,
+      ],
     };
 
     const devErrorMessages = errorMessagesByReactMajor[reactMajor] || defaultErrorMessages;

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
@@ -1931,7 +1931,8 @@ describe('Joy <Autocomplete />', () => {
 
       await user.click(screen.getByText('Reset'));
 
-      const expectedCallCount = reactMajor === 18 ? 4 : 2;
+      // eslint-disable-next-line no-nested-ternary
+      const expectedCallCount = reactMajor >= 19 ? 3 : reactMajor === 18 ? 4 : 2;
 
       expect(handleInputChange.callCount).to.equal(expectedCallCount);
       expect(handleInputChange.args[expectedCallCount - 1][1]).to.equal(options[1].name);
@@ -2209,7 +2210,8 @@ describe('Joy <Autocomplete />', () => {
 
       expect(handleHighlightChange.callCount).to.equal(
         // FIXME: highlighted index implementation should be implemented using React not the DOM.
-        reactMajor >= 18 ? 4 : 3,
+        // eslint-disable-next-line no-nested-ternary
+        reactMajor >= 19 ? 5 : reactMajor >= 18 ? 4 : 3,
       );
       if (reactMajor >= 18) {
         expect(handleHighlightChange.args[2][0]).to.equal(undefined);
@@ -2223,7 +2225,8 @@ describe('Joy <Autocomplete />', () => {
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       expect(handleHighlightChange.callCount).to.equal(
         // FIXME: highlighted index implementation should be implemented using React not the DOM.
-        reactMajor >= 18 ? 5 : 4,
+        // eslint-disable-next-line no-nested-ternary
+        reactMajor >= 19 ? 6 : reactMajor >= 18 ? 5 : 4,
       );
       expect(handleHighlightChange.lastCall.args[0]).not.to.equal(undefined);
       expect(handleHighlightChange.lastCall.args[1]).to.equal(options[1]);
@@ -2240,7 +2243,8 @@ describe('Joy <Autocomplete />', () => {
       fireEvent.mouseMove(firstOption);
       expect(handleHighlightChange.callCount).to.equal(
         // FIXME: highlighted index implementation should be implemented using React not the DOM.
-        reactMajor >= 18 ? 4 : 3,
+        // eslint-disable-next-line no-nested-ternary
+        reactMajor >= 19 ? 5 : reactMajor >= 18 ? 4 : 3,
       );
       if (reactMajor >= 18) {
         expect(handleHighlightChange.args[2][0]).to.equal(undefined);

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -282,7 +282,7 @@ describe('<InputBase />', () => {
 
         let expectedOccurrences = 1;
 
-        if (reactMajor === 18) {
+        if (reactMajor >= 18) {
           expectedOccurrences = 2;
         }
 
@@ -507,7 +507,7 @@ describe('<InputBase />', () => {
 
         let expectedOccurrences = 1;
 
-        if (reactMajor === 18) {
+        if (reactMajor >= 18) {
           expectedOccurrences = 2;
         }
         expect(() => {

--- a/packages/mui-material/src/Portal/Portal.test.tsx
+++ b/packages/mui-material/src/Portal/Portal.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer } from '@mui/internal-test-utils';
+import { createRenderer, reactMajor } from '@mui/internal-test-utils';
 import Portal, { PortalProps } from '@mui/material/Portal';
 
 describe('<Portal />', () => {
@@ -44,6 +44,7 @@ describe('<Portal />', () => {
         <Portal disablePortal ref={refSpy}>
           <h1 className="woofPortal">Foo</h1>
         </Portal>,
+        { strict: reactMajor <= 18 },
       );
       const mountNode = document.querySelector('.woofPortal');
       expect(refSpy.args).to.deep.equal([[mountNode]]);
@@ -57,6 +58,7 @@ describe('<Portal />', () => {
         <Portal disablePortal ref={refSpy}>
           <h1 className="woofPortal">Foo</h1>
         </Portal>,
+        { strict: reactMajor <= 18 },
       );
       const mountNode = document.querySelector('.woofPortal');
       expect(refSpy.args).to.deep.equal([[mountNode]]);

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -380,7 +380,7 @@ describe('<Select />', () => {
 
         let expectedOccurrences = 2;
 
-        if (reactMajor === 18) {
+        if (reactMajor >= 18) {
           expectedOccurrences = 3;
         }
 

--- a/packages/mui-material/src/Tabs/Tabs.test.js
+++ b/packages/mui-material/src/Tabs/Tabs.test.js
@@ -372,11 +372,11 @@ describe('<Tabs />', () => {
           );
         }).toErrorDev([
           'You can provide one of the following values: 1, 3',
-          // React 18 Strict Effects run mount effects twice
-          reactMajor === 18 && 'You can provide one of the following values: 1, 3',
+          // React Strict Mode runs mount effects twice
+          reactMajor >= 18 && 'You can provide one of the following values: 1, 3',
           'You can provide one of the following values: 1, 3',
-          // React 18 Strict Effects run mount effects twice
-          reactMajor === 18 && 'You can provide one of the following values: 1, 3',
+          // React Strict Mode runs mount effects twice
+          reactMajor >= 18 && 'You can provide one of the following values: 1, 3',
           'You can provide one of the following values: 1, 3',
           'You can provide one of the following values: 1, 3',
         ]);

--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { expect } from 'chai';
-import { act, createRenderer, screen } from '@mui/internal-test-utils';
+import { act, createRenderer, reactMajor, screen } from '@mui/internal-test-utils';
 import FocusTrap from '@mui/material/Unstable_TrapFocus';
 import Portal from '@mui/material/Portal';
 
@@ -219,7 +219,7 @@ describe('<FocusTrap />', () => {
         </div>
       );
     }
-    const { setProps, getByRole } = render(<Test />);
+    const { setProps, getByRole } = render(<Test />, { strict: reactMajor <= 18 });
     expect(screen.getByTestId('root')).toHaveFocus();
 
     act(() => {

--- a/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
+++ b/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
+import { createRenderer, screen, fireEvent, reactMajor } from '@mui/internal-test-utils';
 import Box from '@mui/material/Box';
 import {
   CssVarsProvider,
@@ -470,11 +470,11 @@ describe('[Material UI] ThemeProviderWithVars', () => {
     }
     const { container } = render(<App />);
 
-    expect(container).to.have.text('1 light');
+    expect(container).to.have.text(`${reactMajor >= 19 ? 2 : 1} light`);
 
     fireEvent.click(screen.getByRole('button'));
 
-    expect(container).to.have.text('1 light');
+    expect(container).to.have.text(`${reactMajor >= 19 ? 2 : 1} light`);
   });
 
   it('palette mode should change if not using CSS variables', () => {
@@ -505,12 +505,14 @@ describe('[Material UI] ThemeProviderWithVars', () => {
     }
     const { container } = render(<App />);
 
-    expect(container).to.have.text(`1 light ${createTheme().palette.primary.main}`);
+    expect(container).to.have.text(
+      `${reactMajor >= 19 ? 2 : 1} light ${createTheme().palette.primary.main}`,
+    );
 
     fireEvent.click(screen.getByRole('button'));
 
     expect(container).to.have.text(
-      `2 dark ${createTheme({ palette: { mode: 'dark' } }).palette.primary.main}`,
+      `${reactMajor >= 19 ? 3 : 2} dark ${createTheme({ palette: { mode: 'dark' } }).palette.primary.main}`,
     );
   });
 
@@ -542,10 +544,10 @@ describe('[Material UI] ThemeProviderWithVars', () => {
     }
     const { container } = render(<App />);
 
-    expect(container).to.have.text('1 light');
+    expect(container).to.have.text(`${reactMajor >= 19 ? 2 : 1} light`);
 
     fireEvent.click(screen.getByRole('button'));
 
-    expect(container).to.have.text('2 dark');
+    expect(container).to.have.text(`${reactMajor >= 19 ? 3 : 2} dark`);
   });
 });

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
@@ -313,6 +313,14 @@ describe('useAutocomplete', () => {
         aboveErrorTestComponentMessage,
         aboveErrorTestComponentMessage,
       ],
+      19: [
+        muiErrorMessage,
+        muiErrorMessage,
+        nodeErrorMessage,
+        nodeErrorMessage,
+        nodeErrorMessage,
+        nodeErrorMessage,
+      ],
     };
 
     const devErrorMessages = errorMessagesByReactMajor[reactMajor] || defaultErrorMessages;

--- a/packages/mui-system/src/cssVars/useCurrentColorScheme.test.js
+++ b/packages/mui-system/src/cssVars/useCurrentColorScheme.test.js
@@ -111,7 +111,7 @@ describe('useCurrentColorScheme', () => {
     const { container } = render(<Data />);
 
     expect(container.firstChild.textContent).to.equal('light');
-    expect(effectRunCount).to.equal(reactMajor >= 19 ? 2 : 3);
+    expect(effectRunCount).to.equal(3);
   });
 
   it('[noSsr] does not trigger a re-render', () => {

--- a/packages/mui-system/src/cssVars/useCurrentColorScheme.test.js
+++ b/packages/mui-system/src/cssVars/useCurrentColorScheme.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, fireEvent, act, screen, reactMajor } from '@mui/internal-test-utils';
+import { createRenderer, fireEvent, act, screen } from '@mui/internal-test-utils';
 import {
   DEFAULT_MODE_STORAGE_KEY,
   DEFAULT_COLOR_SCHEME_STORAGE_KEY,

--- a/packages/mui-utils/src/useForkRef/useForkRef.test.tsx
+++ b/packages/mui-utils/src/useForkRef/useForkRef.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, MuiRenderResult, screen } from '@mui/internal-test-utils';
+import { createRenderer, reactMajor, MuiRenderResult, screen } from '@mui/internal-test-utils';
 import useForkRef from './useForkRef';
 import getReactElementRef from '../getReactElementRef';
 
@@ -156,20 +156,20 @@ describe('useForkRef', () => {
     const { unmount } = render(<App />);
 
     expect(setup.args[0][0]).to.equal('test');
-    expect(setup.callCount).to.equal(1);
-    expect(cleanUp.callCount).to.equal(0);
+    expect(setup.callCount).to.equal(reactMajor >= 19 ? 2 : 1);
+    expect(cleanUp.callCount).to.equal(reactMajor >= 19 ? 1 : 0);
 
     expect(setup2.args[0][0]).to.equal('test');
-    expect(setup2.callCount).to.equal(1);
+    expect(setup2.callCount).to.equal(reactMajor >= 19 ? 2 : 1);
 
     unmount();
 
-    expect(setup.callCount).to.equal(1);
-    expect(cleanUp.callCount).to.equal(1);
+    expect(setup.callCount).to.equal(reactMajor >= 19 ? 2 : 1);
+    expect(cleanUp.callCount).to.equal(reactMajor >= 19 ? 2 : 1);
 
     // Setup was not called again
-    expect(setup2.callCount).to.equal(1);
+    expect(setup2.callCount).to.equal(reactMajor >= 19 ? 2 : 1);
     // Null handler hit because no cleanup is returned
-    expect(nullHandler.callCount).to.equal(1);
+    expect(nullHandler.callCount).to.equal(reactMajor >= 19 ? 2 : 1);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
+      '@types/babel__register':
+        specifier: ^7.17.3
+        version: 7.17.3
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -5684,6 +5687,9 @@ packages:
 
   '@types/babel__helper-module-imports@7.18.3':
     resolution: {integrity: sha512-2pyr9Vlriessj2KI85SEF7qma8vA3vzquQMw3wn6kL5lsfjH/YxJ1Noytk4/FJElpYybUbyaC37CVfEgfyme9A==}
+
+  '@types/babel__register@7.17.3':
+    resolution: {integrity: sha512-hy9H39BUIGO0C88bLxQD5rqBvqMgjPjDnA8Mx+fjAqtOi4OG7qYaZUMlDHfLOx5G9WtBzhfchzxKl37LTsVRbA==}
 
   '@types/babel__template@7.4.1':
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
@@ -17613,6 +17619,10 @@ snapshots:
     dependencies:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.7
+
+  '@types/babel__register@7.17.3':
+    dependencies:
+      '@types/babel__core': 7.20.5
 
   '@types/babel__template@7.4.1':
     dependencies:


### PR DESCRIPTION
Related to https://github.com/testing-library/react-testing-library/pull/1390.

In React 19, `StrictMode` won't double-call effects on initial mount unless `StrictMode` is at the root of the app. Our previous way of enabling `StrictMode` created a `Wrapper`, meaning that the `Wrapper` component was at the root of the app, resulting in the double calling of effects not happening in initial mount in React 19.

This PR uses the new property `reactStrictMode` from `@testing-library/react` to enable double-calling on initial mount in React 19 tests.

This option was introduced in [this PR](https://github.com/testing-library/react-testing-library/pull/1390), that's why I also upgraded the dependency.

This PR also changes some tests. In the ones I was most confident, I actually updated the assertions. For the ones I wasn't, I disabled strict mode for that particular test in React 19. If you know how to fix it, please let me know 😄 