### PR TITLE
[core] Update buildTypes script to optionally remove css imports

### DIFF
--- a/scripts/buildTypes.mts
+++ b/scripts/buildTypes.mts
@@ -14,7 +14,7 @@ async function emitDeclarations(tsconfig: string, outDir: string) {
   await $$`tsc -p ${tsconfig} --outDir ${outDir} --declaration --emitDeclarationOnly`;
 }
 
-async function addImportExtensions(folder: string) {
+async function addImportExtensions(folder: string, removeCss: boolean) {
   // eslint-disable-next-line no-console
   console.log(`Adding import extensions`);
   const dtsFiles = await glob('**/*.d.ts', { absolute: true, cwd: folder });
@@ -22,14 +22,24 @@ async function addImportExtensions(folder: string) {
     throw new Error(`Unable to find declaration files in '${folder}'`);
   }
 
+  const babelPlugins: babel.PluginItem[] = [
+    ['@babel/plugin-syntax-typescript', { dts: true }],
+    ['@mui/internal-babel-plugin-resolve-imports'],
+  ];
+  if (removeCss) {
+    babelPlugins.push([
+      'babel-plugin-transform-remove-imports',
+      {
+        test: /\.css$/,
+      },
+    ]);
+  }
+
   await Promise.all(
     dtsFiles.map(async (dtsFile) => {
       const result = await babel.transformFileAsync(dtsFile, {
         configFile: false,
-        plugins: [
-          ['@babel/plugin-syntax-typescript', { dts: true }],
-          ['@mui/internal-babel-plugin-resolve-imports'],
-        ],
+        plugins: babelPlugins,
       });
 
       if (typeof result?.code === 'string') {
@@ -67,6 +77,7 @@ async function copyDeclarations(sourceDirectory: string, destinationDirectory: s
 interface HandlerArgv {
   skipTsc: boolean;
   copy: string[];
+  removeCss: boolean;
 }
 
 async function main(argv: HandlerArgv) {
@@ -101,7 +112,7 @@ async function main(argv: HandlerArgv) {
     await emitDeclarations(tsconfigPath, esmOrOutDir);
   }
 
-  await addImportExtensions(esmOrOutDir);
+  await addImportExtensions(esmOrOutDir, argv.removeCss);
 
   await Promise.all(
     argv.copy.map((copy) => copyDeclarations(esmOrOutDir, path.join(packageRoot, copy))),
@@ -124,6 +135,11 @@ yargs(process.argv.slice(2))
           type: 'array',
           description: 'Directories where the type definition files should be copied',
           default: ['build', 'build/modern'],
+        })
+        .option('removeCss', {
+          type: 'boolean',
+          default: false,
+          describe: 'Set to `true` if you want to remove the css imports in the type definitions',
         });
     },
     main,


### PR DESCRIPTION
This will be required later in the `mui-next` repo to remove all the import/export statements trying to import/export from '.css' files.

I have tested it locally in `mui-next` repo.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
