### PR TITLE
container-query-issue

### DIFF
--- a/packages/mui-system/src/resolveSx.test.ts
+++ b/packages/mui-system/src/resolveSx.test.ts
@@ -1,0 +1,100 @@
+// src/system/resolveSx.test.ts
+
+import { expect } from 'chai';
+import { resolveSx } from './sx';
+import { createTheme } from '@mui/material/styles';
+
+describe('resolveSx', () => {
+  const theme = createTheme({
+    breakpoints: {
+      values: {
+        xs: 0,
+        sm: 600,
+        md: 900,
+        lg: 1200,
+        xl: 1536,
+      },
+    },
+    containerQueries: {
+      up: (key: string) => `@container ${key}`,
+    },
+  });
+
+  it('should resolve normal sx properties', () => {
+    const inputSx = { color: 'red', padding: '10px' };
+    const output = resolveSx(theme, inputSx);
+
+    expect(output).to.deep.equal({
+      color: 'red',
+      padding: '10px',
+    });
+  });
+
+  it('should resolve container queries using breakpoints', () => {
+    const inputSx = {
+      color: 'blue',
+      sm: {
+        color: 'green',
+      },
+      md: {
+        padding: '20px',
+      },
+    };
+    const output = resolveSx(theme, inputSx);
+
+    expect(output).to.deep.equal({
+      color: 'blue',
+      '@container sm': {
+        color: 'green',
+      },
+      '@container md': {
+        padding: '20px',
+      },
+    });
+  });
+
+  it('should handle nested container queries', () => {
+    const inputSx = {
+      sm: {
+        md: {
+          color: 'yellow',
+        },
+      },
+    };
+    const output = resolveSx(theme, inputSx);
+
+    expect(output).to.deep.equal({
+      '@container sm': {
+        '@container md': {
+          color: 'yellow',
+        },
+      },
+    });
+  });
+
+  it('should warn if containerQueries.up is not available', () => {
+    const faultyTheme = createTheme({
+      breakpoints: {
+        values: {
+          xs: 0,
+          sm: 600,
+          md: 900,
+        },
+      },
+    });
+
+    const inputSx = {
+      sm: {
+        color: 'pink',
+      },
+    };
+
+    const consoleWarnStub = sinon.stub(console, 'warn');
+    resolveSx(faultyTheme, inputSx);
+
+    expect(consoleWarnStub.calledOnce).to.be.true;
+    expect(consoleWarnStub.firstCall.args[0]).to.include('MUI: containerQueries.up("sm") not available on the theme.');
+
+    consoleWarnStub.restore();
+  });
+});

--- a/packages/mui-system/src/resolveSxContainerQueries.ts
+++ b/packages/mui-system/src/resolveSxContainerQueries.ts
@@ -1,0 +1,52 @@
+import { SxProps } from './styleFunctionSx';
+import {Theme} from "@mui/material/styles";
+import { Breakpoint } from './createBreakpoints/createBreakpoints'
+
+type CssObject = Record<string, any>;
+
+function isBreakpointKey(theme: Theme, key: string): key is Breakpoint {
+  return theme.breakpoints.keys.includes(key as Breakpoint);
+}
+
+function resolveSxContainerQueries(
+  sx: SxProps<Theme> | undefined,
+  theme: Theme,
+): CssObject {
+  if (!sx) return {};
+
+  const sxObject = typeof sx === 'function' ? sx(theme) : sx;
+
+  if (typeof sxObject !== 'object' || Array.isArray(sxObject)) {
+    return sxObject as CssObject;
+  }
+
+  const containerQueries: CssObject = {};
+  const regularStyles: CssObject = {};
+
+  Object.entries(sxObject).forEach(([key, value]) => {
+    if (isBreakpointKey(theme, key)) {
+
+      const containerQuery = theme.containerQueries?.up?.(key);
+
+      if (containerQuery) {
+        containerQueries[containerQuery] = resolveSxContainerQueries(
+          value as SxProps<Theme>,
+          theme,
+        );
+      } else {
+        console.warn(
+          `MUI: containerQueries.up("${key}") not available on the theme.`,
+        );
+      }
+    } else {
+      regularStyles[key] = value;
+    }
+  });
+
+  return {
+    ...regularStyles,
+    ...containerQueries,
+  };
+}
+
+export default resolveSxContainerQueries;

--- a/packages/mui-system/src/sx.ts
+++ b/packages/mui-system/src/sx.ts
@@ -1,0 +1,24 @@
+import { unstable_styleFunctionSx as styleFunctionSx } from '@mui/system';
+import {resolveSxValue} from '../../mui-joy/src/styles/styleUtils';
+import { SxProps } from './styleFunctionSx';
+import { Theme } from './createTheme/createTheme';
+import resolveSxContainerQueries from './resolveSxContainerQueries';
+
+type CSSObject = Record<string, any>;
+
+export function resolveSx(
+  theme: Theme,
+  sxInput: SxProps<Theme> | undefined,
+): CSSObject {
+  if (!sxInput) {
+    return {};
+  }
+
+  const sxWithContainerQueries = resolveSxContainerQueries(sxInput, theme);
+
+  const finalStyles = resolveSxValue(theme, sxWithContainerQueries);
+
+  return finalStyles;
+}
+
+export default styleFunctionSx;


### PR DESCRIPTION
This PR introduces a new enhancement to the sx prop handling in MUI System:

- Container queries can now be defined using the theme’s breakpoints keys (sm, md, lg, etc.) directly inside sx.
- Previously, container queries required using @-prefixed keys or the theme.containerQueries.up() method manually.
- This makes the developer experience more natural and consistent with how breakpoints are used elsewhere in MUI.