### PR TITLE
[joy-ui][Modal] Manually set tab-index incase of reversed orientation

### DIFF
--- a/packages/mui-joy/src/DialogActions/DialogActions.tsx
+++ b/packages/mui-joy/src/DialogActions/DialogActions.tsx
@@ -67,7 +67,23 @@ const DialogActions = React.forwardRef(function DialogActions(inProps, ref) {
     ownerState,
   });
 
-  return <SlotRoot {...rootProps}>{children}</SlotRoot>;
+  const totalChildren = React.Children.count(children);
+
+  // manually set tabindex in case of reverse orientation
+  const childrenWithTabIndex =
+    orientation === 'horizontal-reverse'
+      ? React.Children.map(children, (child, index) => {
+          // Check if the child is a valid React element before adding props
+          if (React.isValidElement(child)) {
+            return React.cloneElement(child as React.ReactElement<HTMLElement>, {
+              tabIndex: totalChildren - index,
+            });
+          }
+          return child; // If not a React element, return it as is
+        })
+      : children;
+
+  return <SlotRoot {...rootProps}>{childrenWithTabIndex}</SlotRoot>;
 }) as OverridableComponent<DialogActionsTypeMap>;
 
 DialogActions.propTypes /* remove-proptypes */ = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

##### Issue
- Fixes issue #42185 

##### Description
- The dom order is changed when the orientation is reversed causing the tab navigation to be reversed.
- This change manually sets the tab-index in this case.