### PR TITLE
[code-infra] Remove type generation of modern build

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "docs:sync-team": "tsx ./docs/scripts/syncTeamMembers.ts && pnpm prettier",
     "docs:mdicons:synonyms": "cross-env BABEL_ENV=development babel-node --extensions \".tsx,.ts,.js,.mjs\" ./docs/scripts/updateIconSynonyms && pnpm prettier",
     "docs:zipRules": "cd docs && rm mui-vale.zip && zip -r mui-vale.zip mui-vale && cd ../ && vale sync",
-    "extract-error-codes": "cross-env MUI_EXTRACT_ERROR_CODES=true lerna run --concurrency 1 build:modern",
+    "extract-error-codes": "cross-env MUI_EXTRACT_ERROR_CODES=true lerna run --concurrency 1 build:stable",
     "template:screenshot": "cross-env BABEL_ENV=development babel-node --extensions \".tsx,.ts,.js\" ./docs/scripts/generateTemplateScreenshots",
     "install:codesandbox": "pnpm install --no-frozen-lockfile",
     "jsonlint": "node ./scripts/jsonlint.mjs",

--- a/packages/mui-docs/package.json
+++ b/packages/mui-docs/package.json
@@ -24,7 +24,6 @@
   "homepage": "https://github.com/mui/material-ui/tree/master/packages/mui-docs",
   "scripts": {
     "build": "pnpm build:node && pnpm build:stable && pnpm build:types && pnpm build:copy-files",
-    "build:modern": "echo 'Skip modern build'",
     "build:node": "node ../../scripts/build.mjs node",
     "build:stable": "node ../../scripts/build.mjs stable",
     "build:types": "tsx ../../scripts/buildTypes.mts",

--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -32,7 +32,6 @@
     "build:esm-pkg": "node ./scripts/create-esm-package-json.mjs",
     "build:lib": "pnpm build:node && pnpm build:stable",
     "build:lib:clean": "rimraf lib/ && pnpm build:lib",
-    "build:modern": "echo 'Skip modern build'",
     "build:node": "node ../../scripts/build.mjs node --largeFiles --outDir lib",
     "build:stable": "node ../../scripts/build.mjs stable --largeFiles --outDir lib --skipEsmPkg",
     "build:copy-files": "node ../../scripts/copyFiles.mjs",

--- a/scripts/buildTypes.mts
+++ b/scripts/buildTypes.mts
@@ -137,7 +137,7 @@ yargs(process.argv.slice(2))
           alias: 'c',
           type: 'array',
           description: 'Directories where the type definition files should be copied',
-          default: ['build', 'build/modern'],
+          default: ['build'],
         })
         .option('removeCss', {
           type: 'boolean',


### PR DESCRIPTION
Forgot this in https://github.com/mui/material-ui/pull/45784