### PR TITLE
[docs] Fix markdown typo in templates.md

### DIFF
--- a/docs/data/material/getting-started/templates/templates.md
+++ b/docs/data/material/getting-started/templates/templates.md
@@ -42,7 +42,7 @@ You can find complete templates and themes like those shown below in the <a href
 </span>
 </a>
 
-## ## Experimental- Toolpad
+## Experimental- Toolpad
 
 If you're looking to build internal tools and dashboards fast, but don't want to start building from scratch, you can find examples of functional dashboards–with authentication, routing, and theming already integrated–in the [featured examples section](https://mui.com/toolpad/core/introduction/examples/#featured-examples) of the Toolpad Core docs.
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
There is a typo in documentation! Let's fix it :) 
<img width="918" alt="Screenshot 2025-04-14 at 22 50 25" src="https://github.com/user-attachments/assets/c4944da2-8aff-46c3-9685-4b40d413a6a9" />

Introduced in #45273