### PR TITLE
[core] Remove legacy esmExternals Next.js option

### DIFF
--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -74,7 +74,6 @@ function withDocsInfra(nextConfig) {
     },
     experimental: {
       scrollRestoration: true,
-      esmExternals: false,
       workerThreads: false,
       cpus: 3,
       ...nextConfig.experimental,


### PR DESCRIPTION
<img width="850" alt="SCR-20250417-bssv" src="https://github.com/user-attachments/assets/e134acef-7e8c-46e2-9423-baf6cfb148e2" />

Added in #37332, and https://github.com/mui/material-ui/pull/37264#issuecomment-1551116576 initially.