### PR TITLE
[system] Memoize the return value of `useThemeProps`

### DIFF
--- a/packages/mui-system/src/useThemeProps/useThemeProps.js
+++ b/packages/mui-system/src/useThemeProps/useThemeProps.js
@@ -1,4 +1,5 @@
 'use client';
+import * as React from 'react';
 import getThemeProps from './getThemeProps';
 import useTheme from '../useTheme';
 
@@ -7,5 +8,5 @@ export default function useThemeProps({ props, name, defaultTheme, themeId }) {
   if (themeId) {
     theme = theme[themeId] || theme;
   }
-  return getThemeProps({ theme, name, props });
+  return React.useMemo(() => getThemeProps({ theme, name, props }), [theme, name, props]);
 }


### PR DESCRIPTION
For the data grid, users are seeing unwanted re-renders when using `theme.components.MuiDataGrid.defaultProps` https://github.com/mui/mui-x/issues/17128. It seems to be a result of [`themedProps` here](https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/DataGrid/useDataGridProps.ts#L49) not being stable across renders.

This PR wraps the result of `getThemeProps` in a `React.useMemo` to make the returned value of `useThemeProps` stable across renders.

---

I'm conscious this change affects every Material UI component, so if that's undesirable, perhaps in the data grid package we could bypass the hook and call `getThemeProps` directly, memoizing the returned value there.