### PR TITLE
[blog] Improve setup to create crisp videos

### DIFF
--- a/docs/pages/blog/mui-x-v8.md
+++ b/docs/pages/blog/mui-x-v8.md
@@ -84,7 +84,7 @@ This flexibility enables faster insight discovery and more efficient data analys
 This feature is available right out of the box, but you can also create a preconfigured setup to tailor it to your user requirements.
 
 <figure>
-  <video autoplay muted loop playsinline width="1350" height="1126" controls style="border: 0; width: 675px">
+  <video autoplay muted loop playsinline width="1366" height="1142" controls style="border: 0; width: 683px">
     <source src="/static/blog/mui-x-v8/pivoting.mp4" type="video/mp4">
   </video>
   <figcaption>A common pivoting use case</figcaption>


### PR DESCRIPTION
Chatting with Jose, I realized that we could use Blender to manipulate video edits. https://www.notion.so/mui-org/High-quality-media-5a1686758f4f4267989b67a1c2c270da?pvs=4#e84a9b137b984de3a3461a41066dadbd used to document how to use CapCut or VN, but neither of those tools allows for getting pixel-perfect outputs.

I have updated this docs with Blender. I'm so much happier with this workflow than the previous one. We get:

- (new) No pixel rasterization. It looks crisp.
- (new) Not too big file size.
- Scale 1:1. No feeling that the scale is not correct.
- PPI > 250. Two physical pixels per CSS pixel.
- 60 FPS.

I doubt we could do better. I would hope to record in 120 Hz, but I don't know how, and the file size might be too big, and very few people have a screen compatible.

Before: https://mui.com/blog/mui-x-v8/#pivoting
After: https://deploy-preview-45971--material-ui.netlify.app/blog/mui-x-v8/#pivoting