### PR TITLE
[deps] Use `prop-types-compat` to work with all React versions in dev

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -79,6 +79,7 @@ module.exports = function getBabelConfig(api) {
       'babel-plugin-transform-react-remove-prop-types',
       {
         mode: 'unsafe-wrap',
+        libraries: ['prop-types-compat'],
       },
     ],
     [

--- a/benchmark/browser/index.js
+++ b/benchmark/browser/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { logReactMetrics } from './utils';
 
 // Get all the scenarios

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -26,7 +26,7 @@
     "fs-extra": "^11.3.0",
     "jss": "^10.10.0",
     "playwright": "^1.51.1",
-    "prop-types": "^15.8.1",
+    "prop-types-compat": "^15.8.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-is": "^19.1.0",

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -26,7 +26,10 @@ module.exports = {
       plugins: [
         '@babel/plugin-transform-react-constant-elements',
         ['babel-plugin-react-remove-properties'],
-        ['babel-plugin-transform-react-remove-prop-types', { mode: 'remove' }],
+        [
+          'babel-plugin-transform-react-remove-prop-types',
+          { mode: 'remove', libraries: ['prop-types-compat'] },
+        ],
       ],
     },
   },

--- a/docs/data/joy/components/autocomplete/AutocompleteHint.js
+++ b/docs/data/joy/components/autocomplete/AutocompleteHint.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Autocomplete from '@mui/joy/Autocomplete';
 import { Typography, styled } from '@mui/joy';
 

--- a/docs/data/joy/components/autocomplete/Virtualize.js
+++ b/docs/data/joy/components/autocomplete/Virtualize.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { FixedSizeList } from 'react-window';
 import { Popper } from '@mui/base/Popper';
 import Autocomplete from '@mui/joy/Autocomplete';

--- a/docs/data/joy/components/input/DebouncedInput.js
+++ b/docs/data/joy/components/input/DebouncedInput.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Input from '@mui/joy/Input';
 import Typography from '@mui/joy/Typography';
 import Box from '@mui/joy/Box';

--- a/docs/data/joy/components/input/InputReactImask.js
+++ b/docs/data/joy/components/input/InputReactImask.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { IMaskInput } from 'react-imask';
 import FormControl from '@mui/joy/FormControl';
 import FormLabel from '@mui/joy/FormLabel';

--- a/docs/data/joy/components/input/InputReactNumberFormat.js
+++ b/docs/data/joy/components/input/InputReactNumberFormat.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { NumericFormat } from 'react-number-format';
 import FormControl from '@mui/joy/FormControl';
 import FormLabel from '@mui/joy/FormLabel';

--- a/docs/data/joy/components/menu/MenuIconSideNavExample.js
+++ b/docs/data/joy/components/menu/MenuIconSideNavExample.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Menu, { menuClasses } from '@mui/joy/Menu';
 import MenuItem from '@mui/joy/MenuItem';
 import IconButton from '@mui/joy/IconButton';

--- a/docs/data/joy/components/modal/NestedModals.js
+++ b/docs/data/joy/components/modal/NestedModals.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Button from '@mui/joy/Button';
 import Modal from '@mui/joy/Modal';
 import ModalDialog from '@mui/joy/ModalDialog';

--- a/docs/data/joy/components/table/TableCollapsibleRow.js
+++ b/docs/data/joy/components/table/TableCollapsibleRow.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import IconButton from '@mui/joy/IconButton';
 import Table from '@mui/joy/Table';
 import Typography from '@mui/joy/Typography';

--- a/docs/data/joy/components/table/TableSortAndSelection.js
+++ b/docs/data/joy/components/table/TableSortAndSelection.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/joy/Box';
 import Table from '@mui/joy/Table';
 import Typography from '@mui/joy/Typography';

--- a/docs/data/joy/customization/creating-themed-components/StatFullTemplate.js
+++ b/docs/data/joy/customization/creating-themed-components/StatFullTemplate.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Stack from '@mui/joy/Stack';
 import { styled, useThemeProps } from '@mui/joy/styles';
 

--- a/docs/data/joy/main-features/color-inversion/ColorInversionAnyParent.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionAnyParent.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { applySolidInversion } from '@mui/joy/colorInversion';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';

--- a/docs/data/joy/main-features/color-inversion/ColorInversionAnyParentStyled.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionAnyParentStyled.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled } from '@mui/joy/styles';
 import { applySolidInversion } from '@mui/joy/colorInversion';
 import Box from '@mui/joy/Box';

--- a/docs/data/material/components/app-bar/BackToTop.js
+++ b/docs/data/material/components/app-bar/BackToTop.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';

--- a/docs/data/material/components/app-bar/DrawerAppBar.js
+++ b/docs/data/material/components/app-bar/DrawerAppBar.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';

--- a/docs/data/material/components/app-bar/ElevateAppBar.js
+++ b/docs/data/material/components/app-bar/ElevateAppBar.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';

--- a/docs/data/material/components/app-bar/HideAppBar.js
+++ b/docs/data/material/components/app-bar/HideAppBar.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';

--- a/docs/data/material/components/autocomplete/CustomizedHook.js
+++ b/docs/data/material/components/autocomplete/CustomizedHook.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import useAutocomplete from '@mui/material/useAutocomplete';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';

--- a/docs/data/material/components/autocomplete/GitHubLabel.js
+++ b/docs/data/material/components/autocomplete/GitHubLabel.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useTheme, styled } from '@mui/material/styles';
 import Popper from '@mui/material/Popper';
 import ClickAwayListener from '@mui/material/ClickAwayListener';

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Autocomplete from '@mui/material/Autocomplete';

--- a/docs/data/material/components/autocomplete/Virtualize.js
+++ b/docs/data/material/components/autocomplete/Virtualize.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import TextField from '@mui/material/TextField';
 import Autocomplete, { autocompleteClasses } from '@mui/material/Autocomplete';
 import useMediaQuery from '@mui/material/useMediaQuery';

--- a/docs/data/material/components/breadcrumbs/RouterBreadcrumbs.js
+++ b/docs/data/material/components/breadcrumbs/RouterBreadcrumbs.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 import List from '@mui/material/List';
 import Link from '@mui/material/Link';

--- a/docs/data/material/components/dialogs/ConfirmationDialog.js
+++ b/docs/data/material/components/dialogs/ConfirmationDialog.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import List from '@mui/material/List';

--- a/docs/data/material/components/dialogs/SimpleDialogDemo.js
+++ b/docs/data/material/components/dialogs/SimpleDialogDemo.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Button from '@mui/material/Button';
 import Avatar from '@mui/material/Avatar';
 import List from '@mui/material/List';

--- a/docs/data/material/components/dialogs/ToolpadDialogsNoSnap.js
+++ b/docs/data/material/components/dialogs/ToolpadDialogsNoSnap.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { DialogsProvider, useDialogs } from '@toolpad/core/useDialogs';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';

--- a/docs/data/material/components/drawers/ResponsiveDrawer.js
+++ b/docs/data/material/components/drawers/ResponsiveDrawer.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';

--- a/docs/data/material/components/drawers/SwipeableEdgeDrawer.js
+++ b/docs/data/material/components/drawers/SwipeableEdgeDrawer.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { Global } from '@emotion/react';
 import { styled } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';

--- a/docs/data/material/components/floating-action-button/FloatingActionButtonZoom.js
+++ b/docs/data/material/components/floating-action-button/FloatingActionButtonZoom.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useTheme } from '@mui/material/styles';
 import AppBar from '@mui/material/AppBar';
 import Tabs from '@mui/material/Tabs';

--- a/docs/data/material/components/icons/FontAwesomeSvgIconDemo.js
+++ b/docs/data/material/components/icons/FontAwesomeSvgIconDemo.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { faEllipsisV } from '@fortawesome/free-solid-svg-icons/faEllipsisV';
 import { faInfo } from '@fortawesome/free-solid-svg-icons/faInfo';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -4,7 +4,7 @@ import MuiPaper from '@mui/material/Paper';
 import copy from 'clipboard-copy';
 import InputBase from '@mui/material/InputBase';
 import Typography from '@mui/material/Typography';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Grid from '@mui/material/Grid';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';

--- a/docs/data/material/components/modal/SpringModal.js
+++ b/docs/data/material/components/modal/SpringModal.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Backdrop from '@mui/material/Backdrop';
 import Box from '@mui/material/Box';
 import Modal from '@mui/material/Modal';

--- a/docs/data/material/components/popper/SpringPopper.js
+++ b/docs/data/material/components/popper/SpringPopper.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 import Popper from '@mui/material/Popper';
 import { useSpring, animated } from '@react-spring/web';

--- a/docs/data/material/components/progress/CircularWithValueLabel.js
+++ b/docs/data/material/components/progress/CircularWithValueLabel.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';

--- a/docs/data/material/components/progress/LinearWithValueLabel.js
+++ b/docs/data/material/components/progress/LinearWithValueLabel.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import LinearProgress from '@mui/material/LinearProgress';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';

--- a/docs/data/material/components/radio-buttons/UseRadioGroup.js
+++ b/docs/data/material/components/radio-buttons/UseRadioGroup.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled } from '@mui/material/styles';
 import RadioGroup, { useRadioGroup } from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';

--- a/docs/data/material/components/rating/RadioGroupRating.js
+++ b/docs/data/material/components/rating/RadioGroupRating.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled } from '@mui/material/styles';
 import Rating from '@mui/material/Rating';
 import SentimentVeryDissatisfiedIcon from '@mui/icons-material/SentimentVeryDissatisfied';

--- a/docs/data/material/components/skeleton/Facebook.js
+++ b/docs/data/material/components/skeleton/Facebook.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Card from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
 import CardContent from '@mui/material/CardContent';

--- a/docs/data/material/components/skeleton/SkeletonChildren.js
+++ b/docs/data/material/components/skeleton/SkeletonChildren.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';

--- a/docs/data/material/components/skeleton/SkeletonTypography.js
+++ b/docs/data/material/components/skeleton/SkeletonTypography.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Typography from '@mui/material/Typography';
 import Skeleton from '@mui/material/Skeleton';
 import Grid from '@mui/material/Grid';

--- a/docs/data/material/components/skeleton/YouTube.js
+++ b/docs/data/material/components/skeleton/YouTube.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';

--- a/docs/data/material/components/slider/CustomizedSlider.js
+++ b/docs/data/material/components/slider/CustomizedSlider.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Slider, { SliderThumb } from '@mui/material/Slider';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';

--- a/docs/data/material/components/steppers/CustomizedSteppers.js
+++ b/docs/data/material/components/steppers/CustomizedSteppers.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled } from '@mui/material/styles';
 import Stack from '@mui/material/Stack';
 import Stepper from '@mui/material/Stepper';

--- a/docs/data/material/components/table/CollapsibleTable.js
+++ b/docs/data/material/components/table/CollapsibleTable.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 import Collapse from '@mui/material/Collapse';
 import IconButton from '@mui/material/IconButton';

--- a/docs/data/material/components/table/CustomPaginationActionsTable.js
+++ b/docs/data/material/components/table/CustomPaginationActionsTable.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Table from '@mui/material/Table';

--- a/docs/data/material/components/table/EnhancedTable.js
+++ b/docs/data/material/components/table/EnhancedTable.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Table from '@mui/material/Table';

--- a/docs/data/material/components/tabs/BasicTabs.js
+++ b/docs/data/material/components/tabs/BasicTabs.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';

--- a/docs/data/material/components/tabs/FullWidthTabs.js
+++ b/docs/data/material/components/tabs/FullWidthTabs.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useTheme } from '@mui/material/styles';
 import AppBar from '@mui/material/AppBar';
 import Tabs from '@mui/material/Tabs';

--- a/docs/data/material/components/tabs/NavTabs.js
+++ b/docs/data/material/components/tabs/NavTabs.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';

--- a/docs/data/material/components/tabs/VerticalTabs.js
+++ b/docs/data/material/components/tabs/VerticalTabs.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Typography from '@mui/material/Typography';

--- a/docs/data/material/components/text-fields/FormattedInputs.js
+++ b/docs/data/material/components/text-fields/FormattedInputs.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { IMaskInput } from 'react-imask';
 import { NumericFormat } from 'react-number-format';
 import Stack from '@mui/material/Stack';

--- a/docs/data/material/customization/color/ColorDemo.js
+++ b/docs/data/material/customization/color/ColorDemo.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import AppBar from '@mui/material/AppBar';

--- a/docs/data/material/customization/color/ColorTool.js
+++ b/docs/data/material/customization/color/ColorTool.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { rgbToHex, useTheme } from '@mui/material/styles';
 import * as colors from '@mui/material/colors';
 import Box from '@mui/material/Box';

--- a/docs/data/material/customization/creating-themed-components/StatFullTemplate.js
+++ b/docs/data/material/customization/creating-themed-components/StatFullTemplate.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Stack from '@mui/material/Stack';
 import { styled, useThemeProps } from '@mui/material/styles';
 

--- a/docs/data/material/customization/overriding-component-structure/OverridingInternalSlot.js
+++ b/docs/data/material/customization/overriding-component-structure/OverridingInternalSlot.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';

--- a/docs/data/material/customization/palette/ContrastThreshold.js
+++ b/docs/data/material/customization/palette/ContrastThreshold.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createTheme, ThemeProvider, useTheme } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import { Stack } from '@mui/system';

--- a/docs/data/material/customization/palette/ManuallyProvidePaletteColor.js
+++ b/docs/data/material/customization/palette/ManuallyProvidePaletteColor.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';

--- a/docs/data/material/customization/palette/TonalOffset.js
+++ b/docs/data/material/customization/palette/TonalOffset.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createTheme, ThemeProvider, useTheme } from '@mui/material/styles';
 import { blue } from '@mui/material/colors';
 import Box from '@mui/material/Box';

--- a/docs/data/material/experimental-api/classname-generator/classname-generator.md
+++ b/docs/data/material/experimental-api/classname-generator/classname-generator.md
@@ -161,7 +161,7 @@ Import the initializer in `/pages/_app.js`.
 ```diff
 +import './MuiClassNameSetup';
  import * as React from 'react';
- import PropTypes from 'prop-types';
+ import PropTypes from 'prop-types-compat';
  import Head from 'next/head';
 
  export default function MyApp(props) {

--- a/docs/data/material/experimental-api/classname-generator/classname-generator.md
+++ b/docs/data/material/experimental-api/classname-generator/classname-generator.md
@@ -161,7 +161,6 @@ Import the initializer in `/pages/_app.js`.
 ```diff
 +import './MuiClassNameSetup';
  import * as React from 'react';
- import PropTypes from 'prop-types-compat';
  import Head from 'next/head';
 
  export default function MyApp(props) {

--- a/docs/data/material/getting-started/templates/blog/components/Latest.js
+++ b/docs/data/material/getting-started/templates/blog/components/Latest.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Avatar from '@mui/material/Avatar';
 import AvatarGroup from '@mui/material/AvatarGroup';
 import Box from '@mui/material/Box';

--- a/docs/data/material/getting-started/templates/blog/components/MainContent.js
+++ b/docs/data/material/getting-started/templates/blog/components/MainContent.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Avatar from '@mui/material/Avatar';
 import AvatarGroup from '@mui/material/AvatarGroup';
 import Box from '@mui/material/Box';

--- a/docs/data/material/getting-started/templates/checkout/components/Info.js
+++ b/docs/data/material/getting-started/templates/checkout/components/Info.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';

--- a/docs/data/material/getting-started/templates/checkout/components/InfoMobile.js
+++ b/docs/data/material/getting-started/templates/checkout/components/InfoMobile.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Drawer from '@mui/material/Drawer';

--- a/docs/data/material/getting-started/templates/dashboard/components/ChartUserByCountry.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/ChartUserByCountry.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { PieChart } from '@mui/x-charts/PieChart';
 import { useDrawingArea } from '@mui/x-charts/hooks';
 import { styled } from '@mui/material/styles';

--- a/docs/data/material/getting-started/templates/dashboard/components/CustomDatePicker.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/CustomDatePicker.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import dayjs from 'dayjs';
 import Button from '@mui/material/Button';
 import CalendarTodayRoundedIcon from '@mui/icons-material/CalendarTodayRounded';

--- a/docs/data/material/getting-started/templates/dashboard/components/CustomizedTreeView.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/CustomizedTreeView.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { animated, useSpring } from '@react-spring/web';
 

--- a/docs/data/material/getting-started/templates/dashboard/components/MenuButton.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/MenuButton.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Badge, { badgeClasses } from '@mui/material/Badge';
 import IconButton from '@mui/material/IconButton';
 

--- a/docs/data/material/getting-started/templates/dashboard/components/SessionsChart.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/SessionsChart.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useTheme } from '@mui/material/styles';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';

--- a/docs/data/material/getting-started/templates/dashboard/components/SideMenuMobile.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/SideMenuMobile.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Avatar from '@mui/material/Avatar';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';

--- a/docs/data/material/getting-started/templates/dashboard/components/StatCard.js
+++ b/docs/data/material/getting-started/templates/dashboard/components/StatCard.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';

--- a/docs/data/material/getting-started/templates/marketing-page/components/Features.js
+++ b/docs/data/material/getting-started/templates/marketing-page/components/Features.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';

--- a/docs/data/material/getting-started/templates/shared-theme/AppTheme.js
+++ b/docs/data/material/getting-started/templates/shared-theme/AppTheme.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 import { inputsCustomizations } from './customizations/inputs';

--- a/docs/data/material/getting-started/templates/sign-in-side/components/ForgotPassword.js
+++ b/docs/data/material/getting-started/templates/sign-in-side/components/ForgotPassword.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';

--- a/docs/data/material/getting-started/templates/sign-in/components/ForgotPassword.js
+++ b/docs/data/material/getting-started/templates/sign-in/components/ForgotPassword.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';

--- a/docs/data/material/integrations/routing/ButtonRouter.js
+++ b/docs/data/material/integrations/routing/ButtonRouter.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { Link as RouterLink, MemoryRouter, StaticRouter } from 'react-router';
 import Button from '@mui/material/Button';
 

--- a/docs/data/material/integrations/routing/LinkRouter.js
+++ b/docs/data/material/integrations/routing/LinkRouter.js
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { Link as RouterLink, MemoryRouter, StaticRouter } from 'react-router';
 import Link from '@mui/material/Link';
 import Box from '@mui/material/Box';

--- a/docs/data/material/integrations/routing/LinkRouterWithTheme.js
+++ b/docs/data/material/integrations/routing/LinkRouterWithTheme.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { Link as RouterLink, MemoryRouter, StaticRouter } from 'react-router';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Button from '@mui/material/Button';

--- a/docs/data/material/integrations/routing/ListRouter.js
+++ b/docs/data/material/integrations/routing/ListRouter.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import Box from '@mui/material/Box';

--- a/docs/data/material/integrations/routing/TabsRouter.js
+++ b/docs/data/material/integrations/routing/TabsRouter.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';

--- a/docs/data/system/flexbox/AlignContent.js
+++ b/docs/data/system/flexbox/AlignContent.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/flexbox/AlignItems.js
+++ b/docs/data/system/flexbox/AlignItems.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/flexbox/AlignSelf.js
+++ b/docs/data/system/flexbox/AlignSelf.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/flexbox/FlexDirection.js
+++ b/docs/data/system/flexbox/FlexDirection.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/flexbox/FlexGrow.js
+++ b/docs/data/system/flexbox/FlexGrow.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/flexbox/FlexShrink.js
+++ b/docs/data/system/flexbox/FlexShrink.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/flexbox/FlexWrap.js
+++ b/docs/data/system/flexbox/FlexWrap.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/flexbox/JustifyContent.js
+++ b/docs/data/system/flexbox/JustifyContent.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/flexbox/Order.js
+++ b/docs/data/system/flexbox/Order.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/getting-started/the-sx-prop/PassingSxProp.js
+++ b/docs/data/system/getting-started/the-sx-prop/PassingSxProp.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import ListItem from '@mui/material/ListItem';
 import FormLabel from '@mui/material/FormLabel';
 

--- a/docs/data/system/grid/Gap.js
+++ b/docs/data/system/grid/Gap.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/grid/GridAutoColumns.js
+++ b/docs/data/system/grid/GridAutoColumns.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/grid/GridAutoFlow.js
+++ b/docs/data/system/grid/GridAutoFlow.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/grid/GridAutoRows.js
+++ b/docs/data/system/grid/GridAutoRows.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/grid/GridTemplateColumns.js
+++ b/docs/data/system/grid/GridTemplateColumns.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/grid/GridTemplateRows.js
+++ b/docs/data/system/grid/GridTemplateRows.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/data/system/grid/RowAndColumnGap.js
+++ b/docs/data/system/grid/RowAndColumnGap.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 
 function Item(props) {

--- a/docs/package.json
+++ b/docs/package.json
@@ -127,7 +127,6 @@
     "@types/json2mq": "^0.2.2",
     "@types/node": "^20.17.30",
     "@types/nprogress": "^0.2.3",
-    "@types/prop-types": "^15.7.14",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@types/react-swipeable-views": "^0.13.6",

--- a/docs/package.json
+++ b/docs/package.json
@@ -87,7 +87,7 @@
     "nprogress": "^0.2.0",
     "postcss": "^8.5.3",
     "postcss-import": "^16.1.0",
-    "prop-types": "^15.8.1",
+    "prop-types-compat": "^15.8.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-draggable": "^4.4.6",

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import * as React from 'react';
 import { loadCSS } from 'fg-loadcss';
 import NextHead from 'next/head';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useRouter } from 'next/router';
 import { LicenseInfo } from '@mui/x-license';
 import materialPkgJson from '@mui/material/package.json';

--- a/docs/pages/experiments/website/dashboard-template-theme.tsx
+++ b/docs/pages/experiments/website/dashboard-template-theme.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';

--- a/docs/pages/performance/table-component.js
+++ b/docs/pages/performance/table-component.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { NoSsr } from '@mui/base/NoSsr';
 
 const createComponent = (defaultComponent) => {

--- a/docs/pages/performance/table-emotion.js
+++ b/docs/pages/performance/table-emotion.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import styled from '@emotion/styled';
 // import { styled } from '@mui/material/styles';
 import { NoSsr } from '@mui/base/NoSsr';

--- a/docs/pages/performance/table-styled-components.js
+++ b/docs/pages/performance/table-styled-components.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import styled from 'styled-components';
 import { NoSsr } from '@mui/base/NoSsr';
 

--- a/docs/scripts/formattedTSDemos.js
+++ b/docs/scripts/formattedTSDemos.js
@@ -98,7 +98,7 @@ async function transpileFile(tsxPath, project) {
     }
     const { code } = await babel.transformAsync(source, transformOptions);
 
-    if (/import \w* from 'prop-types'/.test(code)) {
+    if (/import \w* from 'prop-types-compat'/.test(code)) {
       throw new Error('TypeScript demo contains prop-types, please remove them');
     }
 

--- a/docs/src/modules/components/ApiPage.tsx
+++ b/docs/src/modules/components/ApiPage.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-danger */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { ComponentApiContent, PropsTranslations } from '@mui-internal/api-docs-builder';
 import exactProp from '@mui/utils/exactProp';
 import Typography from '@mui/material/Typography';

--- a/docs/src/modules/components/AppFrame.tsx
+++ b/docs/src/modules/components/AppFrame.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useRouter } from 'next/router';
 import GlobalStyles from '@mui/material/GlobalStyles';
 import { styled, alpha } from '@mui/material/styles';

--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useRouter } from 'next/router';
 import { styled } from '@mui/material/styles';
 import { exactProp } from '@mui/utils';

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-globals */
 /* eslint-disable material-ui/no-hardcoded-labels */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled, useTheme } from '@mui/material/styles';
 // Components
 import DialogActions from '@mui/material/DialogActions';

--- a/docs/src/modules/components/AppNavDrawer.tsx
+++ b/docs/src/modules/components/AppNavDrawer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import { styled, alpha, ThemeProvider, Theme } from '@mui/material/styles';

--- a/docs/src/modules/components/AppNavDrawerItem.tsx
+++ b/docs/src/modules/components/AppNavDrawerItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import KeyboardArrowRightRoundedIcon from '@mui/icons-material/KeyboardArrowRightRounded';
 import { alpha, styled, SxProps, Theme } from '@mui/material/styles';
 import Collapse from '@mui/material/Collapse';

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as ReactDOMServer from 'react-dom/server';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { DocSearchModal, useDocSearchKeyboardEvents } from '@docsearch/react';

--- a/docs/src/modules/components/AppSettingsDrawer.js
+++ b/docs/src/modules/components/AppSettingsDrawer.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled, useTheme, useColorScheme } from '@mui/material/styles';
 import Drawer from '@mui/material/Drawer';
 import Box from '@mui/material/Box';

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-danger */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import throttle from 'lodash/throttle';
 import { styled, alpha } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';

--- a/docs/src/modules/components/AppTheme.js
+++ b/docs/src/modules/components/AppTheme.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Head from 'docs/src/modules/components/Head';
 
 export default function AppTheme(props) {

--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useRouter } from 'next/router';
 import { styled, alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';

--- a/docs/src/modules/components/ComponentsApiContent.tsx
+++ b/docs/src/modules/components/ComponentsApiContent.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-danger */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import kebabCase from 'lodash/kebabCase';
 import { useRouter } from 'next/router';
 import exactProp from '@mui/utils/exactProp';

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import copy from 'clipboard-copy';
 import { useRouter } from 'next/router';
 import { debounce } from '@mui/material/utils';

--- a/docs/src/modules/components/DemoErrorBoundary.js
+++ b/docs/src/modules/components/DemoErrorBoundary.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Typography from '@mui/material/Typography';
 import Link from '@mui/material/Link';
 import Button from '@mui/material/Button';

--- a/docs/src/modules/components/DemoSandbox.js
+++ b/docs/src/modules/components/DemoSandbox.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { prefixer } from 'stylis';
 import rtlPlugin from 'stylis-plugin-rtl';
 import createCache from '@emotion/cache';

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import copy from 'clipboard-copy';
 import { useTheme, styled, alpha } from '@mui/material/styles';
 import IconButton from '@mui/material/IconButton';

--- a/docs/src/modules/components/EditPage.js
+++ b/docs/src/modules/components/EditPage.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Button from '@mui/material/Button';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import { useUserLanguage, useTranslate } from '@mui/docs/i18n';

--- a/docs/src/modules/components/HooksApiContent.tsx
+++ b/docs/src/modules/components/HooksApiContent.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-danger */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import kebabCase from 'lodash/kebabCase';
 import exactProp from '@mui/utils/exactProp';
 import { Translate, useTranslate, useUserLanguage } from '@mui/docs/i18n';

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { exactProp } from '@mui/utils';
 import { Ad, AdGuest } from '@mui/docs/Ad';
 import RichMarkdownElement from 'docs/src/modules/components/RichMarkdownElement';

--- a/docs/src/modules/components/MarkdownDocsV2.js
+++ b/docs/src/modules/components/MarkdownDocsV2.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useRouter } from 'next/router';
 import kebabCase from 'lodash/kebabCase';
 import { exactProp } from '@mui/utils';

--- a/docs/src/modules/components/RichMarkdownElement.js
+++ b/docs/src/modules/components/RichMarkdownElement.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useTranslate, useUserLanguage } from '@mui/docs/i18n';
 import { HighlightedCodeWithTabs } from '@mui/docs/HighlightedCodeWithTabs';
 import { MarkdownElement } from '@mui/docs/MarkdownElement';

--- a/docs/src/modules/components/ThemeContext.tsx
+++ b/docs/src/modules/components/ThemeContext.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createTheme as createMdTheme } from '@mui/material/styles';
 import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/material/utils';
 import useLazyCSS from 'docs/src/modules/utils/useLazyCSS';

--- a/docs/src/modules/components/TopLayoutBlog.js
+++ b/docs/src/modules/components/TopLayoutBlog.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled, alpha } from '@mui/material/styles';
 import { useRouter } from 'next/router';
 import { exactProp } from '@mui/utils';

--- a/docs/src/modules/components/TopLayoutCareers.js
+++ b/docs/src/modules/components/TopLayoutCareers.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled, alpha } from '@mui/material/styles';
 import Divider from '@mui/material/Divider';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';

--- a/docs/src/modules/sandbox/Dependencies.test.js
+++ b/docs/src/modules/sandbox/Dependencies.test.js
@@ -43,7 +43,7 @@ const styles = theme => ({
       // #npm-tag-reference
       '@mui/material': 'latest',
       '@mui/base': 'latest',
-      'prop-types': 'latest',
+      'prop-types-compat': 'latest',
     });
   });
 
@@ -76,7 +76,7 @@ const suggestions = [
       '@mui/material': 'latest',
       '@unexisting/thing': 'latest',
       'autosuggest-highlight': 'latest',
-      'prop-types': 'latest',
+      'prop-types-compat': 'latest',
       'react-draggable': 'latest',
     });
   });
@@ -99,7 +99,7 @@ import { LocalizationProvider as MuiPickersLocalizationProvider, KeyboardTimePic
     expect(dependencies).to.deep.equal({
       react: 'latest',
       'react-dom': 'latest',
-      'prop-types': 'latest',
+      'prop-types-compat': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
       // #npm-tag-reference
@@ -127,7 +127,7 @@ import 'exceljs';
     expect(dependencies).to.deep.equal({
       react: 'latest',
       'react-dom': 'latest',
-      'prop-types': 'latest',
+      'prop-types-compat': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
       // #npm-tag-reference
@@ -146,7 +146,7 @@ import 'exceljs';
     expect(dependencies).to.deep.equal({
       react: 'latest',
       'react-dom': 'latest',
-      'prop-types': 'latest',
+      'prop-types-compat': 'latest',
       '@emotion/react': 'latest',
       '@emotion/styled': 'latest',
       '@foo-bar/bip': 'latest',
@@ -158,7 +158,6 @@ import 'exceljs';
 
     expect(devDependencies).to.deep.equal({
       '@types/foo-bar__bip': 'latest',
-      '@types/prop-types': 'latest',
       '@types/react-dom': 'latest',
       '@types/react': 'latest',
     });

--- a/docs/src/modules/sandbox/Dependencies.test.js
+++ b/docs/src/modules/sandbox/Dependencies.test.js
@@ -12,7 +12,7 @@ describe('Dependencies', () => {
 
   const s1 = `
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { withStyles } from '@mui/material/styles';
 import Input from '@mui/material/Input';
 import InputLabel from '@mui/material/InputLabel';
@@ -50,7 +50,7 @@ const styles = theme => ({
   it('should handle * dependencies', () => {
     const source = `
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import * as _ from '@unexisting/thing';
 import Draggable from 'react-draggable';
 import match from 'autosuggest-highlight/match';
@@ -84,7 +84,7 @@ const suggestions = [
   it('should support direct import', () => {
     const source = `
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Grid from '@mui/material/Grid';
 import { withStyles } from '@mui/material/styles';
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
@@ -111,7 +111,7 @@ import { LocalizationProvider as MuiPickersLocalizationProvider, KeyboardTimePic
   it('should support import for side effect', () => {
     const source = `
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import '@mui/material/Grid';
 import '@mui/material/styles';
 import '@mui/lab/AdapterDateFns';

--- a/docs/src/modules/sandbox/Dependencies.ts
+++ b/docs/src/modules/sandbox/Dependencies.ts
@@ -8,6 +8,7 @@ const packagesWithBundledTypes = [
   'dayjs',
   'clsx',
   '@react-spring/web',
+  'prop-types-compat',
 ];
 const muiNpmOrgs = ['@mui', '@base_ui', '@pigment-css', '@toolpad'];
 

--- a/docs/src/modules/utils/StyledEngineProvider.js
+++ b/docs/src/modules/utils/StyledEngineProvider.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { StyleSheetManager } from 'styled-components';
 import { CacheProvider } from '@emotion/react';
 import { createEmotionCache as createCache } from '@mui/material-nextjs/v15-pagesRouter';

--- a/docs/src/modules/utils/codeStylingSolution.js
+++ b/docs/src/modules/utils/codeStylingSolution.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { getCookie } from 'docs/src/modules/utils/helpers';
 import { CODE_STYLING } from 'docs/src/modules/constants';
 

--- a/docs/src/modules/utils/codeVariant.js
+++ b/docs/src/modules/utils/codeVariant.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { getCookie } from 'docs/src/modules/utils/helpers';
 import { CODE_VARIANTS } from 'docs/src/modules/constants';
 

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Paper.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Paper.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import MuiPaper from '@mui/material/Paper';
 import { styled } from '@mui/material/styles';
 

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Snackbar.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Snackbar.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled } from '@mui/material/styles';
 import MuiSnackbar from '@mui/material/Snackbar';
 import { snackbarContentClasses } from '@mui/material/SnackbarContent';

--- a/docs/src/pages/premium-themes/onepirate/modules/components/TextField.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/TextField.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { styled } from '@mui/material/styles';
 import MuiTextField from '@mui/material/TextField';

--- a/docs/src/pages/premium-themes/onepirate/modules/components/Typography.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/Typography.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled } from '@mui/material/styles';
 import MuiTypography from '@mui/material/Typography';
 

--- a/docs/src/pages/premium-themes/onepirate/modules/form/FormButton.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/FormButton.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 import Button from '../components/Button';
 import defer from './defer';

--- a/docs/src/pages/premium-themes/onepirate/modules/form/FormFeedback.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/FormFeedback.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled } from '@mui/material/styles';
 
 import Typography from '../components/Typography';

--- a/docs/src/pages/premium-themes/onepirate/modules/form/RFTextField.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/RFTextField.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 import TextField from '../components/TextField';
 

--- a/docs/src/pages/premium-themes/onepirate/modules/views/AppForm.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/AppForm.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import Paper from '../components/Paper';

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductHeroLayout.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductHeroLayout.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { styled } from '@mui/material/styles';
 
 import Container from '@mui/material/Container';

--- a/docs/src/pages/premium-themes/paperbase/Header.js
+++ b/docs/src/pages/premium-themes/paperbase/Header.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import AppBar from '@mui/material/AppBar';
 import Avatar from '@mui/material/Avatar';
 import Button from '@mui/material/Button';

--- a/examples/material-ui-pigment-css-vite-ts/vite.config.ts
+++ b/examples/material-ui-pigment-css-vite-ts/vite.config.ts
@@ -15,6 +15,6 @@ const pigmentConfig = {
 export default defineConfig({
   plugins: [react(), pigment(pigmentConfig)],
   optimizeDeps: {
-    include: ['prop-types', 'react-is', 'hoist-non-react-statics'],
+    include: ['prop-types-compat', 'react-is', 'hoist-non-react-statics'],
   },
 });

--- a/packages-internal/scripts/typescript-to-proptypes/src/injectPropTypesInFile.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/src/injectPropTypesInFile.ts
@@ -242,7 +242,7 @@ function createBabelPlugin({
             !path.node.body.some((n) => {
               if (
                 babelTypes.isImportDeclaration(n) &&
-                n.source.value === 'prop-types' &&
+                n.source.value === 'prop-types-compat' &&
                 n.specifiers.length
               ) {
                 importName = n.specifiers[0].local.name;
@@ -308,7 +308,7 @@ function createBabelPlugin({
           }
 
           const propTypesImport = babel.template.ast(
-            `import ${importName} from 'prop-types'`,
+            `import ${importName} from 'prop-types-compat'`,
           ) as babel.types.ImportDeclaration;
 
           const firstImport = path

--- a/packages-internal/scripts/typescript-to-proptypes/test/code-order/input.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/code-order/input.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 function Component(props) {
   const { value } = props;

--- a/packages-internal/scripts/typescript-to-proptypes/test/code-order/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/code-order/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 function Component(props) {
   const { value } = props;

--- a/packages-internal/scripts/typescript-to-proptypes/test/component-type/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/component-type/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 function Component(props) {
   const { Foo, Bar } = props;

--- a/packages-internal/scripts/typescript-to-proptypes/test/genericUnion/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/genericUnion/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Grid(props) {
   const { series } = props;
   return <div>{series.type}</div>;

--- a/packages-internal/scripts/typescript-to-proptypes/test/getThemeProps/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/getThemeProps/output.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Modal(inProps) {
   const props = getThemeProps({ props: inProps });
   const { onKeyDown, ...other } = props;

--- a/packages-internal/scripts/typescript-to-proptypes/test/injector/should-include-component-based/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/injector/should-include-component-based/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Snackbar(props) {
   return <div {...props} />;
 }

--- a/packages-internal/scripts/typescript-to-proptypes/test/injector/should-include-filename-based/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/injector/should-include-filename-based/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Snackbar(props) {
   return <div {...props} />;
 }

--- a/packages-internal/scripts/typescript-to-proptypes/test/injector/string-props/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/injector/string-props/output.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Dialog(props) {
   const { 'aria-describedby': ariaDescribedby } = props;
   return <div></div>;

--- a/packages-internal/scripts/typescript-to-proptypes/test/injector/whitelisted-props/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/injector/whitelisted-props/output.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Foo(props) {
   return <div {...props}></div>;
 }

--- a/packages-internal/scripts/typescript-to-proptypes/test/interfaceUnion/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/interfaceUnion/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Grid(props) {
   const { series, pieSeries } = props;
   return <div>{series.type}</div>;

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-interface/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-interface/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Component(props) {
   const { classes } = props;
   return (

--- a/packages-internal/scripts/typescript-to-proptypes/test/mixed-literals/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/mixed-literals/output.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Grid(props) {
   const { spacing } = props;
   return <div>spacing: {spacing}</div>;

--- a/packages-internal/scripts/typescript-to-proptypes/test/options-test/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/options-test/output.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Foo(props) {
   const { PropA, TestProps } = props;
   return <div></div>;

--- a/packages-internal/scripts/typescript-to-proptypes/test/propTypes-casting/input.tsx
+++ b/packages-internal/scripts/typescript-to-proptypes/test/propTypes-casting/input.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 // empty props are likely a mistake.
 // We want to make sure we catch this instead of keeping .propTypes

--- a/packages-internal/scripts/typescript-to-proptypes/test/propTypes-casting/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/propTypes-casting/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 // empty props are likely a mistake.
 // We want to make sure we catch this instead of keeping .propTypes
 export default function Component(props) {

--- a/packages-internal/scripts/typescript-to-proptypes/test/reconcile-prop-types/input.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/reconcile-prop-types/input.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { chainPropTypes } from 'some-utils-module';
 
 function Component(props) {

--- a/packages-internal/scripts/typescript-to-proptypes/test/reconcile-prop-types/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/reconcile-prop-types/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { chainPropTypes } from 'some-utils-module';
 
 function Component(props) {

--- a/packages-internal/scripts/typescript-to-proptypes/test/remove-proptypes/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/remove-proptypes/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Component(props) {
   return <div>{props.children}</div>;
 }

--- a/packages-internal/scripts/typescript-to-proptypes/test/sort-unions/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/sort-unions/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 function Hidden(props) {
   const { color, only } = props;

--- a/packages-internal/scripts/typescript-to-proptypes/test/type-unknown/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/type-unknown/output.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Select(props) {
   const { value, variant } = props;
   return <div></div>;

--- a/packages-internal/scripts/typescript-to-proptypes/test/union-props/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/union-props/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 function TextField(props) {
   const { value, variant } = props;

--- a/packages-internal/scripts/typescript-to-proptypes/test/unused-prop/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/unused-prop/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 function Foo(props) {
   const { foo, ...other } = props;
   return (

--- a/packages-internal/test-utils/package.json
+++ b/packages-internal/test-utils/package.json
@@ -58,7 +58,6 @@
     "@types/chai": "^4.3.20",
     "@types/chai-dom": "^1.11.3",
     "@types/format-util": "^1.0.4",
-    "@types/prop-types": "^15.7.14",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@types/sinon": "^17.0.4",

--- a/packages-internal/test-utils/package.json
+++ b/packages-internal/test-utils/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.21",
     "mocha": "^11.1.0",
     "playwright": "^1.51.1",
-    "prop-types": "^15.8.1",
+    "prop-types-compat": "^15.8.2",
     "sinon": "^19.0.5"
   },
   "devDependencies": {

--- a/packages-internal/test-utils/src/components.tsx
+++ b/packages-internal/test-utils/src/components.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 /**
  * A basic error boundary that can be used to assert thrown errors in render.

--- a/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
@@ -735,14 +735,19 @@ export default async function generateComponentApi(
   let reactApi: ComponentReactApi;
 
   try {
-    reactApi = docgenParse(src, null, defaultHandlers.concat(muiDefaultPropsHandler), {
-      filename,
-    });
+    reactApi = docgenParse(
+      src.replace(/prop-types-compat/gm, 'prop-types'),
+      null,
+      defaultHandlers.concat(muiDefaultPropsHandler),
+      {
+        filename,
+      },
+    );
   } catch (error) {
     // fallback to default logic if there is no `create*` definition.
     if ((error as Error).message === 'No suitable component definition found.') {
       reactApi = docgenParse(
-        src,
+        src.replace(/prop-types-compat/gm, 'prop-types'),
         (ast) => {
           let node;
           // TODO migrate to react-docgen v6, using Babel AST now

--- a/packages/api-docs-builder/utils/generatePropTypeDescription.ts
+++ b/packages/api-docs-builder/utils/generatePropTypeDescription.ts
@@ -26,7 +26,7 @@ export function getChained(type: PropTypeDescriptor) {
     if (indexStart !== -1) {
       const parsed = docgenParse(
         `
-        import PropTypes from 'prop-types-compat';
+        import PropTypes from 'prop-types';
         const Foo = () => <div />
         Foo.propTypes = {
           bar: ${recast.print(recast.parse(type.raw).program.body[0].expression.arguments[0]).code}

--- a/packages/api-docs-builder/utils/generatePropTypeDescription.ts
+++ b/packages/api-docs-builder/utils/generatePropTypeDescription.ts
@@ -26,7 +26,7 @@ export function getChained(type: PropTypeDescriptor) {
     if (indexStart !== -1) {
       const parsed = docgenParse(
         `
-        import PropTypes from 'prop-types';
+        import PropTypes from 'prop-types-compat';
         const Foo = () => <div />
         Foo.propTypes = {
           bar: ${recast.print(recast.parse(type.raw).program.body[0].expression.arguments[0]).code}

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/first.actual.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/first.actual.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { connect } from 'react-redux';
 import withStyles from '@material-ui/styles/withStyles';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/first.actual.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/first.actual.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types-compat';
+import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { connect } from 'react-redux';
 import withStyles from '@material-ui/styles/withStyles';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/first.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/first.expected.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { connect } from 'react-redux';
 import NoSsr from '@material-ui/core/NoSsr';
@@ -31,14 +31,10 @@ const classes = {
   white: `${PREFIX}-white`,
   content: `${PREFIX}-content`,
   contentOpened: `${PREFIX}-contentOpened`,
-  item: `${PREFIX}-item`
+  item: `${PREFIX}-item`,
 };
 
-const StyledAppBar = styled(AppBar)((
-  {
-    theme
-  }
-) => ({
+const StyledAppBar = styled(AppBar)(({ theme }) => ({
   [`& .${classes.grow}`]: {
     display: 'block',
     flexGrow: 1,
@@ -141,7 +137,7 @@ const StyledAppBar = styled(AppBar)((
     [theme.breakpoints.up('sm')]: {
       marginRight: theme.spacing(2),
     },
-  }
+  },
 }));
 
 class AppAppBar extends React.Component {
@@ -176,11 +172,11 @@ class AppAppBar extends React.Component {
   };
 
   render() {
-    const {  children, essential, position, user } = this.props;
+    const { children, essential, position, user } = this.props;
     const { menuOpen } = this.state;
 
     return (
-      (<StyledAppBar essential={essential} position={position}>
+      <StyledAppBar essential={essential} position={position}>
         <div className={clsx(classes.wrap, { [classes.wrapOpened]: menuOpen })}>
           <Link to="/" aria-label="Back to homepage" color="inherit">
             <Logo color={menuOpen ? 'inherit' : 'textPrimary'} />
@@ -237,7 +233,7 @@ class AppAppBar extends React.Component {
             </div>
           )}
         </div>
-      </StyledAppBar>)
+      </StyledAppBar>
     );
   }
 }
@@ -250,7 +246,4 @@ AppAppBar.propTypes = {
   user: PropTypes.object,
 };
 
-export default compose(
-  
-  connect((state) => ({ user: state.data.user })),
-)(AppAppBar);
+export default compose(connect((state) => ({ user: state.data.user })))(AppAppBar);

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/first.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/first.expected.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import PropTypes from 'prop-types-compat';
+import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { connect } from 'react-redux';
 import NoSsr from '@material-ui/core/NoSsr';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/first.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/first.expected.js
@@ -31,10 +31,14 @@ const classes = {
   white: `${PREFIX}-white`,
   content: `${PREFIX}-content`,
   contentOpened: `${PREFIX}-contentOpened`,
-  item: `${PREFIX}-item`,
+  item: `${PREFIX}-item`
 };
 
-const StyledAppBar = styled(AppBar)(({ theme }) => ({
+const StyledAppBar = styled(AppBar)((
+  {
+    theme
+  }
+) => ({
   [`& .${classes.grow}`]: {
     display: 'block',
     flexGrow: 1,
@@ -137,7 +141,7 @@ const StyledAppBar = styled(AppBar)(({ theme }) => ({
     [theme.breakpoints.up('sm')]: {
       marginRight: theme.spacing(2),
     },
-  },
+  }
 }));
 
 class AppAppBar extends React.Component {
@@ -172,11 +176,11 @@ class AppAppBar extends React.Component {
   };
 
   render() {
-    const { children, essential, position, user } = this.props;
+    const {  children, essential, position, user } = this.props;
     const { menuOpen } = this.state;
 
     return (
-      <StyledAppBar essential={essential} position={position}>
+      (<StyledAppBar essential={essential} position={position}>
         <div className={clsx(classes.wrap, { [classes.wrapOpened]: menuOpen })}>
           <Link to="/" aria-label="Back to homepage" color="inherit">
             <Logo color={menuOpen ? 'inherit' : 'textPrimary'} />
@@ -233,7 +237,7 @@ class AppAppBar extends React.Component {
             </div>
           )}
         </div>
-      </StyledAppBar>
+      </StyledAppBar>)
     );
   }
 }
@@ -246,4 +250,7 @@ AppAppBar.propTypes = {
   user: PropTypes.object,
 };
 
-export default compose(connect((state) => ({ user: state.data.user })))(AppAppBar);
+export default compose(
+  
+  connect((state) => ({ user: state.data.user })),
+)(AppAppBar);

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/sixth.actual.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/sixth.actual.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/sixth.actual.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/sixth.actual.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types-compat';
+import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/sixth.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/sixth.expected.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import PropTypes from 'prop-types-compat';
+import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/sixth.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/sixth.expected.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';
@@ -16,14 +16,10 @@ const classes = {
   root: `${PREFIX}-root`,
   icon: `${PREFIX}-icon`,
   badge: `${PREFIX}-badge`,
-  transparentBadge: `${PREFIX}-transparentBadge`
+  transparentBadge: `${PREFIX}-transparentBadge`,
 };
 
-const StyledIconButton = styled(IconButton)((
-  {
-    theme
-  }
-) => ({
+const StyledIconButton = styled(IconButton)(({ theme }) => ({
   [`&.${classes.root}`]: {
     padding: 8,
     '&&&': {
@@ -45,7 +41,7 @@ const StyledIconButton = styled(IconButton)((
   [`& .${classes.transparentBadge}`]: {
     backgroundColor: theme.palette.common.white,
     color: theme.palette.primary.main,
-  }
+  },
 }));
 
 // eslint-disable-next-line react/display-name
@@ -54,7 +50,7 @@ const LinkToCart = React.forwardRef((linkProps, ref) => (
 ));
 
 function AppAppBarCart(props) {
-  const {  className, variant, cart, transparent } = props;
+  const { className, variant, cart, transparent } = props;
   const count = cart.count || 0;
 
   return variant === 'text' ? (
@@ -94,7 +90,4 @@ AppAppBarCart.defaultProps = {
   variant: 'icon',
 };
 
-export default recompose.compose(
-  
-  connect((state) => ({ cart: state.data.cart })),
-)(AppAppBarCart);
+export default recompose.compose(connect((state) => ({ cart: state.data.cart })))(AppAppBarCart);

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/sixth.expected.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test/sixth.expected.js
@@ -16,10 +16,14 @@ const classes = {
   root: `${PREFIX}-root`,
   icon: `${PREFIX}-icon`,
   badge: `${PREFIX}-badge`,
-  transparentBadge: `${PREFIX}-transparentBadge`,
+  transparentBadge: `${PREFIX}-transparentBadge`
 };
 
-const StyledIconButton = styled(IconButton)(({ theme }) => ({
+const StyledIconButton = styled(IconButton)((
+  {
+    theme
+  }
+) => ({
   [`&.${classes.root}`]: {
     padding: 8,
     '&&&': {
@@ -41,7 +45,7 @@ const StyledIconButton = styled(IconButton)(({ theme }) => ({
   [`& .${classes.transparentBadge}`]: {
     backgroundColor: theme.palette.common.white,
     color: theme.palette.primary.main,
-  },
+  }
 }));
 
 // eslint-disable-next-line react/display-name
@@ -50,7 +54,7 @@ const LinkToCart = React.forwardRef((linkProps, ref) => (
 ));
 
 function AppAppBarCart(props) {
-  const { className, variant, cart, transparent } = props;
+  const {  className, variant, cart, transparent } = props;
   const count = cart.count || 0;
 
   return variant === 'text' ? (
@@ -90,4 +94,7 @@ AppAppBarCart.defaultProps = {
   variant: 'icon',
 };
 
-export default recompose.compose(connect((state) => ({ cart: state.data.cart })))(AppAppBarCart);
+export default recompose.compose(
+  
+  connect((state) => ({ cart: state.data.cart })),
+)(AppAppBarCart);

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-actual.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-actual.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import * as ReactDOMServer from 'react-dom/server';
-import PropTypes from 'prop-types-compat';
+import PropTypes from 'prop-types';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { DocSearchModal, useDocSearchKeyboardEvents } from '@docsearch/react';
@@ -210,9 +210,8 @@ export default function AppSearch() {
   const searchButtonRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
   const [initialQuery, setInitialQuery] = React.useState(undefined);
-  const facetFilterLanguage = LANGUAGES_SSR.includes(userLanguage)
-    ? `language:${userLanguage}`
-    : `language:en`;
+  const facetFilterLanguage =
+    LANGUAGES_SSR.includes(userLanguage) ? `language:${userLanguage}` : `language:en`;
   const macOS = window.navigator.platform.toUpperCase().includes('MAC');
   const onOpen = React.useCallback(() => {
     setIsOpen(true);

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-actual.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-actual.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import * as ReactDOMServer from 'react-dom/server';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { DocSearchModal, useDocSearchKeyboardEvents } from '@docsearch/react';
@@ -210,8 +210,9 @@ export default function AppSearch() {
   const searchButtonRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
   const [initialQuery, setInitialQuery] = React.useState(undefined);
-  const facetFilterLanguage =
-    LANGUAGES_SSR.includes(userLanguage) ? `language:${userLanguage}` : `language:en`;
+  const facetFilterLanguage = LANGUAGES_SSR.includes(userLanguage)
+    ? `language:${userLanguage}`
+    : `language:en`;
   const macOS = window.navigator.platform.toUpperCase().includes('MAC');
   const onOpen = React.useCallback(() => {
     setIsOpen(true);

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-expected.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-expected.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import * as ReactDOMServer from 'react-dom/server';
-import PropTypes from 'prop-types-compat';
+import PropTypes from 'prop-types';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { DocSearchModal, useDocSearchKeyboardEvents } from '@docsearch/react';

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-expected.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-expected.js
@@ -210,9 +210,8 @@ export default function AppSearch() {
   const searchButtonRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
   const [initialQuery, setInitialQuery] = React.useState(undefined);
-  const facetFilterLanguage = LANGUAGES_SSR.includes(userLanguage)
-    ? `language:${userLanguage}`
-    : `language:en`;
+  const facetFilterLanguage =
+    LANGUAGES_SSR.includes(userLanguage) ? `language:${userLanguage}` : `language:en`;
   const macOS = window.navigator.platform.toUpperCase().includes('MAC');
   const onOpen = React.useCallback(() => {
     setIsOpen(true);

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-expected.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-expected.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import * as ReactDOMServer from 'react-dom/server';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { DocSearchModal, useDocSearchKeyboardEvents } from '@docsearch/react';
@@ -210,8 +210,9 @@ export default function AppSearch() {
   const searchButtonRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
   const [initialQuery, setInitialQuery] = React.useState(undefined);
-  const facetFilterLanguage =
-    LANGUAGES_SSR.includes(userLanguage) ? `language:${userLanguage}` : `language:en`;
+  const facetFilterLanguage = LANGUAGES_SSR.includes(userLanguage)
+    ? `language:${userLanguage}`
+    : `language:en`;
   const macOS = window.navigator.platform.toUpperCase().includes('MAC');
   const onOpen = React.useCallback(() => {
     setIsOpen(true);

--- a/packages/mui-docs/package.json
+++ b/packages/mui-docs/package.json
@@ -39,7 +39,7 @@
     "clipboard-copy": "^4.0.1",
     "clsx": "^2.1.1",
     "nprogress": "^0.2.0",
-    "prop-types": "^15.8.1"
+    "prop-types-compat": "^15.8.2"
   },
   "devDependencies": {
     "@mui/icons-material": "workspace:*",

--- a/packages/mui-docs/package.json
+++ b/packages/mui-docs/package.json
@@ -46,7 +46,6 @@
     "@mui/material": "workspace:*",
     "@types/gtag.js": "^0.0.20",
     "@types/node": "^20.17.30",
-    "@types/prop-types": "^15.7.14",
     "@types/react": "^19.1.2",
     "next": "^15.3.1",
     "react": "^19.1.0"

--- a/packages/mui-docs/src/NProgressBar/NProgressBar.js
+++ b/packages/mui-docs/src/NProgressBar/NProgressBar.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import NProgress from 'nprogress';
 import { NoSsr } from '@mui/base/NoSsr';
 import { exactProp } from '@mui/utils';

--- a/packages/mui-docs/src/i18n/i18n.tsx
+++ b/packages/mui-docs/src/i18n/i18n.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { deepmerge } from '@mui/utils';
 import defaultTranslations from '../translations';
 

--- a/packages/mui-joy/package.json
+++ b/packages/mui-joy/package.json
@@ -50,7 +50,6 @@
     "@mui/internal-test-utils": "workspace:^",
     "@mui/material": "workspace:^",
     "@types/chai": "^4.3.20",
-    "@types/prop-types": "^15.7.14",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@types/sinon": "^17.0.4",

--- a/packages/mui-joy/package.json
+++ b/packages/mui-joy/package.json
@@ -44,7 +44,7 @@
     "@mui/types": "workspace:^",
     "@mui/utils": "workspace:^",
     "clsx": "^2.1.1",
-    "prop-types": "^15.8.1"
+    "prop-types-compat": "^15.8.2"
   },
   "devDependencies": {
     "@mui/internal-test-utils": "workspace:^",

--- a/packages/mui-joy/src/Accordion/Accordion.tsx
+++ b/packages/mui-joy/src/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import {

--- a/packages/mui-joy/src/AccordionDetails/AccordionDetails.tsx
+++ b/packages/mui-joy/src/AccordionDetails/AccordionDetails.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/AccordionGroup/AccordionGroup.tsx
+++ b/packages/mui-joy/src/AccordionGroup/AccordionGroup.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/AccordionSummary/AccordionSummary.tsx
+++ b/packages/mui-joy/src/AccordionSummary/AccordionSummary.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { useThemeProps } from '../styles';

--- a/packages/mui-joy/src/Alert/Alert.tsx
+++ b/packages/mui-joy/src/Alert/Alert.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/AspectRatio/AspectRatio.tsx
+++ b/packages/mui-joy/src/AspectRatio/AspectRatio.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import {

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import {
   chainPropTypes,

--- a/packages/mui-joy/src/AutocompleteListbox/AutocompleteListbox.tsx
+++ b/packages/mui-joy/src/AutocompleteListbox/AutocompleteListbox.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/AutocompleteOption/AutocompleteOption.tsx
+++ b/packages/mui-joy/src/AutocompleteOption/AutocompleteOption.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';

--- a/packages/mui-joy/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/mui-joy/src/AvatarGroup/AvatarGroup.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { useThemeProps } from '../styles';

--- a/packages/mui-joy/src/Badge/Badge.tsx
+++ b/packages/mui-joy/src/Badge/Badge.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize, usePreviousProps } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';

--- a/packages/mui-joy/src/Box/Box.tsx
+++ b/packages/mui-joy/src/Box/Box.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { createBox } from '@mui/system';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_ClassNameGenerator as ClassNameGenerator } from '../className';
 import { Theme } from '../styles/types';
 import defaultTheme from '../styles/defaultTheme';

--- a/packages/mui-joy/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/mui-joy/src/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import {
   unstable_capitalize as capitalize,

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useButton } from '@mui/base/useButton';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
 import { Interpolation } from '@mui/system';

--- a/packages/mui-joy/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/mui-joy/src/ButtonGroup/ButtonGroup.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { unstable_traverseBreakpoints as traverseBreakpoints } from '@mui/system/Grid';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/Card/Card.tsx
+++ b/packages/mui-joy/src/Card/Card.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import {

--- a/packages/mui-joy/src/CardActions/CardActions.tsx
+++ b/packages/mui-joy/src/CardActions/CardActions.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { useThemeProps } from '../styles';

--- a/packages/mui-joy/src/CardContent/CardContent.tsx
+++ b/packages/mui-joy/src/CardContent/CardContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { useThemeProps } from '../styles';

--- a/packages/mui-joy/src/CardCover/CardCover.tsx
+++ b/packages/mui-joy/src/CardCover/CardCover.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { useThemeProps } from '../styles';

--- a/packages/mui-joy/src/CardOverflow/CardOverflow.tsx
+++ b/packages/mui-joy/src/CardOverflow/CardOverflow.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';

--- a/packages/mui-joy/src/Checkbox/Checkbox.tsx
+++ b/packages/mui-joy/src/Checkbox/Checkbox.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { unstable_useId as useId, unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
 import { useButton } from '@mui/base/useButton';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize, unstable_useForkRef as useForkRef } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/CircularProgress/CircularProgress.tsx
+++ b/packages/mui-joy/src/CircularProgress/CircularProgress.tsx
@@ -1,5 +1,5 @@
 'use client';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import * as React from 'react';
 import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/Container/Container.tsx
+++ b/packages/mui-joy/src/Container/Container.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { createContainer } from '@mui/system';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { Theme } from '../styles/types/theme';
 import styled from '../styles/styled';

--- a/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
+++ b/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import GlobalStyles from '../GlobalStyles';
 import defaultTheme from '../styles/defaultTheme';
 import { Theme, DefaultColorScheme, ColorSystem } from '../styles/types';

--- a/packages/mui-joy/src/DialogActions/DialogActions.tsx
+++ b/packages/mui-joy/src/DialogActions/DialogActions.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { useThemeProps } from '../styles';

--- a/packages/mui-joy/src/DialogContent/DialogContent.tsx
+++ b/packages/mui-joy/src/DialogContent/DialogContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { useThemeProps } from '../styles';

--- a/packages/mui-joy/src/DialogTitle/DialogTitle.tsx
+++ b/packages/mui-joy/src/DialogTitle/DialogTitle.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/Divider/Divider.tsx
+++ b/packages/mui-joy/src/Divider/Divider.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/Drawer/Drawer.tsx
+++ b/packages/mui-joy/src/Drawer/Drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import {
   HTMLElementType,
   unstable_capitalize as capitalize,

--- a/packages/mui-joy/src/FormControl/FormControl.tsx
+++ b/packages/mui-joy/src/FormControl/FormControl.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
 import { unstable_useId as useId, unstable_capitalize as capitalize } from '@mui/utils';

--- a/packages/mui-joy/src/FormHelperText/FormHelperText.tsx
+++ b/packages/mui-joy/src/FormHelperText/FormHelperText.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/FormLabel/FormLabel.tsx
+++ b/packages/mui-joy/src/FormLabel/FormLabel.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
 import { styled, useThemeProps } from '../styles';

--- a/packages/mui-joy/src/Grid/Grid.tsx
+++ b/packages/mui-joy/src/Grid/Grid.tsx
@@ -1,5 +1,5 @@
 'use client';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createGrid } from '@mui/system/Grid';
 import { OverridableComponent } from '@mui/types';
 import { styled, useThemeProps } from '../styles';

--- a/packages/mui-joy/src/IconButton/IconButton.tsx
+++ b/packages/mui-joy/src/IconButton/IconButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize, unstable_useForkRef as useForkRef } from '@mui/utils';
 import { useButton } from '@mui/base/useButton';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { OverridableComponent } from '@mui/types';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/LinearProgress/LinearProgress.tsx
+++ b/packages/mui-joy/src/LinearProgress/LinearProgress.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import {

--- a/packages/mui-joy/src/List/List.tsx
+++ b/packages/mui-joy/src/List/List.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/ListDivider/ListDivider.tsx
+++ b/packages/mui-joy/src/ListDivider/ListDivider.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/ListItem/ListItem.tsx
+++ b/packages/mui-joy/src/ListItem/ListItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import {
   unstable_capitalize as capitalize,

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { unstable_capitalize as capitalize, unstable_useForkRef as useForkRef } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/ListItemContent/ListItemContent.tsx
+++ b/packages/mui-joy/src/ListItemContent/ListItemContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/ListItemDecorator/ListItemDecorator.tsx
+++ b/packages/mui-joy/src/ListItemDecorator/ListItemDecorator.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/ListSubheader/ListSubheader.tsx
+++ b/packages/mui-joy/src/ListSubheader/ListSubheader.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
 import { unstable_useId as useId, unstable_capitalize as capitalize } from '@mui/utils';

--- a/packages/mui-joy/src/Menu/Menu.tsx
+++ b/packages/mui-joy/src/Menu/Menu.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize, refType } from '@mui/utils';
 import { OverridableComponent } from '@mui/types';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/MenuButton/MenuButton.tsx
+++ b/packages/mui-joy/src/MenuButton/MenuButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useMenuButton } from '@mui/base/useMenuButton';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/MenuItem/MenuItem.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
 import { useMenuItem, useMenuItemContextStabilizer } from '@mui/base/useMenuItem';

--- a/packages/mui-joy/src/MenuList/MenuList.tsx
+++ b/packages/mui-joy/src/MenuList/MenuList.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize, refType } from '@mui/utils';
 import { OverridableComponent } from '@mui/types';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/Modal/Modal.tsx
+++ b/packages/mui-joy/src/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { elementAcceptingRef, HTMLElementType } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/ModalClose/ModalClose.tsx
+++ b/packages/mui-joy/src/ModalClose/ModalClose.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';

--- a/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
+++ b/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/ModalOverflow/ModalOverflow.tsx
+++ b/packages/mui-joy/src/ModalOverflow/ModalOverflow.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { useThemeProps, styled } from '../styles';

--- a/packages/mui-joy/src/Option/Option.tsx
+++ b/packages/mui-joy/src/Option/Option.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
 import { useOption, useOptionContextStabilizer } from '@mui/base/useOption';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize, unstable_useId as useId } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';

--- a/packages/mui-joy/src/RadioGroup/RadioGroup.test.tsx
+++ b/packages/mui-joy/src/RadioGroup/RadioGroup.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';

--- a/packages/mui-joy/src/RadioGroup/RadioGroup.tsx
+++ b/packages/mui-joy/src/RadioGroup/RadioGroup.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
 import {

--- a/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaseline.tsx
+++ b/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaseline.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
 import { unstable_composeClasses as composeClasses } from '@mui/base';

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { OverrideProps, DefaultComponentProps } from '@mui/types';
 import { unstable_capitalize as capitalize, unstable_useForkRef as useForkRef } from '@mui/utils';

--- a/packages/mui-joy/src/Sheet/Sheet.tsx
+++ b/packages/mui-joy/src/Sheet/Sheet.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/Skeleton/Skeleton.tsx
+++ b/packages/mui-joy/src/Skeleton/Skeleton.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { keyframes, css } from '@mui/system';
 import { unstable_composeClasses as composeClasses } from '@mui/base';

--- a/packages/mui-joy/src/Slider/Slider.tsx
+++ b/packages/mui-joy/src/Slider/Slider.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import {
   unstable_composeClasses as composeClasses,

--- a/packages/mui-joy/src/Snackbar/Snackbar.tsx
+++ b/packages/mui-joy/src/Snackbar/Snackbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { ClickAwayListener } from '@mui/base/ClickAwayListener';

--- a/packages/mui-joy/src/Stack/Stack.tsx
+++ b/packages/mui-joy/src/Stack/Stack.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { createStack } from '@mui/system';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import styled from '../styles/styled';
 import { useThemeProps } from '../styles';

--- a/packages/mui-joy/src/Step/Step.tsx
+++ b/packages/mui-joy/src/Step/Step.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { useThemeProps } from '../styles';

--- a/packages/mui-joy/src/StepButton/StepButton.tsx
+++ b/packages/mui-joy/src/StepButton/StepButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { useThemeProps } from '../styles';
 import styled from '../styles/styled';

--- a/packages/mui-joy/src/StepIndicator/StepIndicator.tsx
+++ b/packages/mui-joy/src/StepIndicator/StepIndicator.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';

--- a/packages/mui-joy/src/Stepper/Stepper.tsx
+++ b/packages/mui-joy/src/Stepper/Stepper.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';

--- a/packages/mui-joy/src/SvgIcon/SvgIcon.tsx
+++ b/packages/mui-joy/src/SvgIcon/SvgIcon.tsx
@@ -3,7 +3,7 @@ import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import * as React from 'react';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';

--- a/packages/mui-joy/src/Switch/Switch.tsx
+++ b/packages/mui-joy/src/Switch/Switch.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/Tab/Tab.tsx
+++ b/packages/mui-joy/src/Tab/Tab.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize, unstable_useForkRef as useForkRef } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';

--- a/packages/mui-joy/src/TabList/TabList.tsx
+++ b/packages/mui-joy/src/TabList/TabList.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/TabPanel/TabPanel.tsx
+++ b/packages/mui-joy/src/TabPanel/TabPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/Table/Table.tsx
+++ b/packages/mui-joy/src/Table/Table.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/Tabs/Tabs.tsx
+++ b/packages/mui-joy/src/Tabs/Tabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-joy/src/Textarea/Textarea.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { OverridableComponent } from '@mui/types';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';

--- a/packages/mui-joy/src/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/mui-joy/src/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import {
   unstable_capitalize as capitalize,
   unstable_isMuiElement as isMuiElement,

--- a/packages/mui-joy/src/Tooltip/Tooltip.tsx
+++ b/packages/mui-joy/src/Tooltip/Tooltip.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import {
   unstable_capitalize as capitalize,

--- a/packages/mui-joy/src/Typography/Typography.tsx
+++ b/packages/mui-joy/src/Typography/Typography.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent } from '@mui/types';
 import {
   unstable_capitalize as capitalize,

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -50,7 +50,6 @@
     "@mui/internal-test-utils": "workspace:^",
     "@mui/material": "workspace:^",
     "@types/chai": "^4.3.20",
-    "@types/prop-types": "^15.7.14",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@types/sinon": "^17.0.4",

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -44,7 +44,7 @@
     "@mui/types": "workspace:^",
     "@mui/utils": "workspace:^",
     "clsx": "^2.1.1",
-    "prop-types": "^15.8.1"
+    "prop-types-compat": "^15.8.2"
   },
   "devDependencies": {
     "@mui/internal-test-utils": "workspace:^",

--- a/packages/mui-lab/src/DateRangePicker/DateRangePicker.ts
+++ b/packages/mui-lab/src/DateRangePicker/DateRangePicker.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 let warnedOnce = false;
 

--- a/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.ts
+++ b/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 let warnedOnce = false;
 

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -14,7 +14,7 @@ import {
   unstable_useEnhancedEffect as useEnhancedEffect,
 } from '@mui/utils';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import * as React from 'react';
 import { getMasonryUtilityClass } from './masonryClasses';
 

--- a/packages/mui-lab/src/MobileDateRangePicker/MobileDateRangePicker.ts
+++ b/packages/mui-lab/src/MobileDateRangePicker/MobileDateRangePicker.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 let warnedOnce = false;
 

--- a/packages/mui-lab/src/StaticDateRangePicker/StaticDateRangePicker.ts
+++ b/packages/mui-lab/src/StaticDateRangePicker/StaticDateRangePicker.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 let warnedOnce = false;
 

--- a/packages/mui-lab/src/TabContext/TabContext.js
+++ b/packages/mui-lab/src/TabContext/TabContext.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 /**
  * @type {React.Context<{ idPrefix: string; value: string } | null>}

--- a/packages/mui-lab/src/TabList/TabList.js
+++ b/packages/mui-lab/src/TabList/TabList.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Tabs from '@mui/material/Tabs';
 import { useTabContext, getTabId, getPanelId } from '../TabContext';
 

--- a/packages/mui-lab/src/TabPanel/TabPanel.js
+++ b/packages/mui-lab/src/TabPanel/TabPanel.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { styled, useThemeProps } from '@mui/material/styles';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-lab/src/Timeline/Timeline.tsx
+++ b/packages/mui-lab/src/Timeline/Timeline.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled, useThemeProps } from '@mui/material/styles';

--- a/packages/mui-lab/src/TimelineConnector/TimelineConnector.js
+++ b/packages/mui-lab/src/TimelineConnector/TimelineConnector.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled, useThemeProps } from '@mui/material/styles';

--- a/packages/mui-lab/src/TimelineContent/TimelineContent.js
+++ b/packages/mui-lab/src/TimelineContent/TimelineContent.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { styled, useThemeProps } from '@mui/material/styles';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-lab/src/TimelineDot/TimelineDot.js
+++ b/packages/mui-lab/src/TimelineDot/TimelineDot.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { styled, useThemeProps } from '@mui/material/styles';
 import { capitalize } from '@mui/material/utils';

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { isMuiElement } from '@mui/material/utils';
 import { styled, useThemeProps } from '@mui/material/styles';

--- a/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
+++ b/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { styled, useThemeProps } from '@mui/material/styles';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.js
+++ b/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled, useThemeProps } from '@mui/material/styles';

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -49,7 +49,7 @@
     "@types/react-transition-group": "^4.4.12",
     "clsx": "^2.1.1",
     "csstype": "^3.1.3",
-    "prop-types-compat": "^15.8.1",
+    "prop-types-compat": "^15.8.2",
     "react-is": "^19.1.0",
     "react-transition-group": "^4.4.5"
   },

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -58,7 +58,6 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/chai": "^4.3.20",
-    "@types/prop-types": "^15.7.14",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@types/sinon": "^17.0.4",

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -49,7 +49,7 @@
     "@types/react-transition-group": "^4.4.12",
     "clsx": "^2.1.1",
     "csstype": "^3.1.3",
-    "prop-types": "^15.8.1",
+    "prop-types-compat": "^15.8.1",
     "react-is": "^19.1.0",
     "react-transition-group": "^4.4.5"
   },
@@ -111,7 +111,7 @@
   "pigment-css": {
     "vite": {
       "include": [
-        "prop-types",
+        "prop-types-compat",
         "react-is",
         "hoist-non-react-statics",
         "react",

--- a/packages/mui-material/prop-types-compat.d.ts
+++ b/packages/mui-material/prop-types-compat.d.ts
@@ -1,4 +1,0 @@
-declare module 'prop-types-compat' {
-  import PropTypes from 'prop-types';
-  export default PropTypes;
-}

--- a/packages/mui-material/prop-types-compat.d.ts
+++ b/packages/mui-material/prop-types-compat.d.ts
@@ -1,0 +1,4 @@
+declare module 'prop-types-compat' {
+  import PropTypes from 'prop-types';
+  export default PropTypes;
+}

--- a/packages/mui-material/src/Accordion/Accordion.js
+++ b/packages/mui-material/src/Accordion/Accordion.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { isFragment } from 'react-is';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/Accordion/Accordion.test.js
+++ b/packages/mui-material/src/Accordion/Accordion.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, fireEvent, reactMajor, screen } from '@mui/internal-test-utils';

--- a/packages/mui-material/src/AccordionActions/AccordionActions.js
+++ b/packages/mui-material/src/AccordionActions/AccordionActions.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/AccordionDetails/AccordionDetails.js
+++ b/packages/mui-material/src/AccordionDetails/AccordionDetails.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/AccordionSummary/AccordionSummary.js
+++ b/packages/mui-material/src/AccordionSummary/AccordionSummary.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/Alert/Alert.js
+++ b/packages/mui-material/src/Alert/Alert.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { darken, lighten } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/AlertTitle/AlertTitle.js
+++ b/packages/mui-material/src/AlertTitle/AlertTitle.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/AppBar/AppBar.js
+++ b/packages/mui-material/src/AppBar/AppBar.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import integerPropType from '@mui/utils/integerPropType';
 import chainPropTypes from '@mui/utils/chainPropTypes';

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { expect } from 'chai';
 import {
   act,

--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { isFragment } from 'react-is';
 import clsx from 'clsx';
 import chainPropTypes from '@mui/utils/chainPropTypes';

--- a/packages/mui-material/src/Backdrop/Backdrop.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/Badge/Badge.js
+++ b/packages/mui-material/src/Badge/Badge.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import usePreviousProps from '@mui/utils/usePreviousProps';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/BottomNavigation/BottomNavigation.js
+++ b/packages/mui-material/src/BottomNavigation/BottomNavigation.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { isFragment } from 'react-is';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/Box/Box.js
+++ b/packages/mui-material/src/Box/Box.js
@@ -1,6 +1,6 @@
 'use client';
 import { createBox } from '@mui/system';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { unstable_ClassNameGenerator as ClassNameGenerator } from '../className';
 import { createTheme } from '../styles';
 import THEME_ID from '../styles/identifier';

--- a/packages/mui-material/src/Breadcrumbs/BreadcrumbCollapsed.js
+++ b/packages/mui-material/src/Breadcrumbs/BreadcrumbCollapsed.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { emphasize } from '@mui/system/colorManipulator';
 import { styled } from '../zero-styled';
 import memoTheme from '../utils/memoTheme';

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { isFragment } from 'react-is';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import integerPropType from '@mui/utils/integerPropType';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import resolveProps from '@mui/utils/resolveProps';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import refType from '@mui/utils/refType';
 import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -11,7 +11,7 @@ import {
   simulatePointerDevice,
   programmaticFocusTriggersFocusVisible,
 } from '@mui/internal-test-utils';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ButtonBase, { buttonBaseClasses as classes } from '@mui/material/ButtonBase';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/ButtonBase/Ripple.js
+++ b/packages/mui-material/src/ButtonBase/Ripple.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 
 /**

--- a/packages/mui-material/src/ButtonBase/TouchRipple.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { TransitionGroup } from 'react-transition-group';
 import clsx from 'clsx';
 import useTimeout from '@mui/utils/useTimeout';

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/Card/Card.js
+++ b/packages/mui-material/src/Card/Card.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/CardActionArea/CardActionArea.js
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/CardActions/CardActions.js
+++ b/packages/mui-material/src/CardActions/CardActions.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/CardContent/CardContent.js
+++ b/packages/mui-material/src/CardContent/CardContent.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/CardHeader/CardHeader.js
+++ b/packages/mui-material/src/CardHeader/CardHeader.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import composeClasses from '@mui/utils/composeClasses';
 import Typography, { typographyClasses } from '../Typography';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/CardMedia/CardMedia.js
+++ b/packages/mui-material/src/CardMedia/CardMedia.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/CardMedia/CardMedia.test.js
+++ b/packages/mui-material/src/CardMedia/CardMedia.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import CardMedia, { cardMediaClasses as classes } from '@mui/material/CardMedia';

--- a/packages/mui-material/src/Checkbox/Checkbox.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/CircularProgress/CircularProgress.js
+++ b/packages/mui-material/src/CircularProgress/CircularProgress.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/ClickAwayListener/ClickAwayListener.tsx
+++ b/packages/mui-material/src/ClickAwayListener/ClickAwayListener.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import {
   elementAcceptingRef,
   exactProp,

--- a/packages/mui-material/src/Collapse/Collapse.js
+++ b/packages/mui-material/src/Collapse/Collapse.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { Transition } from 'react-transition-group';
 import useTimeout from '@mui/utils/useTimeout';
 import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';

--- a/packages/mui-material/src/Container/Container.js
+++ b/packages/mui-material/src/Container/Container.js
@@ -1,5 +1,5 @@
 'use client';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createContainer } from '@mui/system';
 import capitalize from '../utils/capitalize';
 import styled from '../styles/styled';

--- a/packages/mui-material/src/CssBaseline/CssBaseline.js
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { globalCss } from '../zero-styled';
 import { useDefaultProps } from '../DefaultPropsProvider';
 

--- a/packages/mui-material/src/DefaultPropsProvider/DefaultPropsProvider.tsx
+++ b/packages/mui-material/src/DefaultPropsProvider/DefaultPropsProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import SystemDefaultPropsProvider, {
   useDefaultProps as useSystemDefaultProps,
 } from '@mui/system/DefaultPropsProvider';

--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import useId from '@mui/utils/useId';

--- a/packages/mui-material/src/DialogActions/DialogActions.js
+++ b/packages/mui-material/src/DialogActions/DialogActions.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/DialogContent/DialogContent.js
+++ b/packages/mui-material/src/DialogContent/DialogContent.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/DialogContentText/DialogContentText.js
+++ b/packages/mui-material/src/DialogContentText/DialogContentText.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import rootShouldForwardProp from '../styles/rootShouldForwardProp';

--- a/packages/mui-material/src/DialogTitle/DialogTitle.js
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import Typography from '../Typography';

--- a/packages/mui-material/src/Divider/Divider.js
+++ b/packages/mui-material/src/Divider/Divider.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/Drawer/Drawer.js
+++ b/packages/mui-material/src/Drawer/Drawer.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import integerPropType from '@mui/utils/integerPropType';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import ButtonBase from '../ButtonBase';

--- a/packages/mui-material/src/Fade/Fade.js
+++ b/packages/mui-material/src/Fade/Fade.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { Transition } from 'react-transition-group';
 import elementAcceptingRef from '@mui/utils/elementAcceptingRef';
 import getReactElementRef from '@mui/utils/getReactElementRef';

--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import deepmerge from '@mui/utils/deepmerge';
 import refType from '@mui/utils/refType';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import composeClasses from '@mui/utils/composeClasses';
 import InputBase from '../InputBase';
 import rootShouldForwardProp from '../styles/rootShouldForwardProp';

--- a/packages/mui-material/src/FormControl/FormControl.js
+++ b/packages/mui-material/src/FormControl/FormControl.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import refType from '@mui/utils/refType';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/FormGroup/FormGroup.js
+++ b/packages/mui-material/src/FormGroup/FormGroup.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/FormHelperText/FormHelperText.js
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import formControlState from '../FormControl/formControlState';

--- a/packages/mui-material/src/FormLabel/FormLabel.js
+++ b/packages/mui-material/src/FormLabel/FormLabel.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import formControlState from '../FormControl/formControlState';

--- a/packages/mui-material/src/FormLabel/FormLabel.test.js
+++ b/packages/mui-material/src/FormLabel/FormLabel.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { expect } from 'chai';
 import { act, createRenderer } from '@mui/internal-test-utils';
 import FormLabel, { formLabelClasses as classes } from '@mui/material/FormLabel';

--- a/packages/mui-material/src/GlobalStyles/GlobalStyles.js
+++ b/packages/mui-material/src/GlobalStyles/GlobalStyles.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { GlobalStyles as SystemGlobalStyles } from '@mui/system';
 import defaultTheme from '../styles/defaultTheme';
 import THEME_ID from '../styles/identifier';

--- a/packages/mui-material/src/Grid/Grid.tsx
+++ b/packages/mui-material/src/Grid/Grid.tsx
@@ -1,5 +1,5 @@
 'use client';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createGrid } from '@mui/system/Grid';
 import { SxProps, SystemProps } from '@mui/system';
 import { OverridableComponent, OverrideProps } from '@mui/types';

--- a/packages/mui-material/src/GridLegacy/GridLegacy.js
+++ b/packages/mui-material/src/GridLegacy/GridLegacy.js
@@ -10,7 +10,7 @@
 // Follow this flexbox Guide to better understand the underlying model:
 // - https://css-tricks.com/snippets/css/a-guide-to-flexbox/
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import {
   handleBreakpoints,

--- a/packages/mui-material/src/Grow/Grow.js
+++ b/packages/mui-material/src/Grow/Grow.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import useTimeout from '@mui/utils/useTimeout';
 import elementAcceptingRef from '@mui/utils/elementAcceptingRef';
 import getReactElementRef from '@mui/utils/getReactElementRef';

--- a/packages/mui-material/src/Icon/Icon.js
+++ b/packages/mui-material/src/Icon/Icon.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import capitalize from '../utils/capitalize';

--- a/packages/mui-material/src/IconButton/IconButton.js
+++ b/packages/mui-material/src/IconButton/IconButton.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createRenderer, reactMajor, screen, within } from '@mui/internal-test-utils';
 import capitalize from '@mui/utils/capitalize';
 import { ThemeProvider, createTheme } from '@mui/material/styles';

--- a/packages/mui-material/src/ImageList/ImageList.js
+++ b/packages/mui-material/src/ImageList/ImageList.js
@@ -2,7 +2,7 @@
 import composeClasses from '@mui/utils/composeClasses';
 import integerPropType from '@mui/utils/integerPropType';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import * as React from 'react';
 import { styled } from '../zero-styled';
 import { useDefaultProps } from '../DefaultPropsProvider';

--- a/packages/mui-material/src/ImageListItem/ImageListItem.js
+++ b/packages/mui-material/src/ImageListItem/ImageListItem.js
@@ -2,7 +2,7 @@
 import composeClasses from '@mui/utils/composeClasses';
 import integerPropType from '@mui/utils/integerPropType';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import * as React from 'react';
 import { isFragment } from 'react-is';
 import ImageListContext from '../ImageList/ImageListContext';

--- a/packages/mui-material/src/ImageListItemBar/ImageListItemBar.js
+++ b/packages/mui-material/src/ImageListItemBar/ImageListItemBar.js
@@ -1,7 +1,7 @@
 'use client';
 import composeClasses from '@mui/utils/composeClasses';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import * as React from 'react';
 import { styled } from '../zero-styled';
 import memoTheme from '../utils/memoTheme';

--- a/packages/mui-material/src/InitColorSchemeScript/InitColorSchemeScript.tsx
+++ b/packages/mui-material/src/InitColorSchemeScript/InitColorSchemeScript.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import SystemInitColorSchemeScript from '@mui/system/InitColorSchemeScript';
 
 export const defaultConfig = {

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import composeClasses from '@mui/utils/composeClasses';
 import deepmerge from '@mui/utils/deepmerge';
 import refType from '@mui/utils/refType';

--- a/packages/mui-material/src/InputAdornment/InputAdornment.js
+++ b/packages/mui-material/src/InputAdornment/InputAdornment.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import capitalize from '../utils/capitalize';

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';
 import refType from '@mui/utils/refType';

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen, reactMajor } from '@mui/internal-test-utils';

--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import composeClasses from '@mui/utils/composeClasses';
 import clsx from 'clsx';
 import formControlState from '../FormControl/formControlState';

--- a/packages/mui-material/src/InputLabel/InputLabel.test.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { expect } from 'chai';
 import { act, createRenderer } from '@mui/internal-test-utils';
 import { ClassNames } from '@emotion/react';

--- a/packages/mui-material/src/LinearProgress/LinearProgress.js
+++ b/packages/mui-material/src/LinearProgress/LinearProgress.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { darken, lighten } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/Link/Link.js
+++ b/packages/mui-material/src/Link/Link.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { alpha } from '@mui/system/colorManipulator';
 import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';

--- a/packages/mui-material/src/List/List.js
+++ b/packages/mui-material/src/List/List.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/ListItem/ListItem.js
+++ b/packages/mui-material/src/ListItem/ListItem.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';

--- a/packages/mui-material/src/ListItem/ListItem.test.js
+++ b/packages/mui-material/src/ListItem/ListItem.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createRenderer, reactMajor } from '@mui/internal-test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ListItemText from '@mui/material/ListItemText';

--- a/packages/mui-material/src/ListItemAvatar/ListItemAvatar.js
+++ b/packages/mui-material/src/ListItemAvatar/ListItemAvatar.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import ListContext from '../List/ListContext';

--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/ListItemIcon/ListItemIcon.js
+++ b/packages/mui-material/src/ListItemIcon/ListItemIcon.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.js
+++ b/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/ListItemText/ListItemText.js
+++ b/packages/mui-material/src/ListItemText/ListItemText.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import Typography, { typographyClasses } from '../Typography';

--- a/packages/mui-material/src/ListSubheader/ListSubheader.js
+++ b/packages/mui-material/src/ListSubheader/ListSubheader.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/Menu/Menu.js
+++ b/packages/mui-material/src/Menu/Menu.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { isFragment } from 'react-is';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import HTMLElementType from '@mui/utils/HTMLElementType';

--- a/packages/mui-material/src/MenuItem/MenuItem.js
+++ b/packages/mui-material/src/MenuItem/MenuItem.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/MenuList/MenuList.js
+++ b/packages/mui-material/src/MenuList/MenuList.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { isFragment } from 'react-is';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import ownerDocument from '../utils/ownerDocument';
 import List from '../List';
 import getScrollbarSize from '../utils/getScrollbarSize';

--- a/packages/mui-material/src/MobileStepper/MobileStepper.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import integerPropType from '@mui/utils/integerPropType';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/Modal/Modal.js
+++ b/packages/mui-material/src/Modal/Modal.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import HTMLElementType from '@mui/utils/HTMLElementType';
 import elementAcceptingRef from '@mui/utils/elementAcceptingRef';

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { act, createRenderer, fireEvent, within, screen } from '@mui/internal-test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Fade from '@mui/material/Fade';

--- a/packages/mui-material/src/NativeSelect/NativeSelect.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import composeClasses from '@mui/utils/composeClasses';
 import NativeSelectInput from './NativeSelectInput';
 import formControlState from '../FormControl/formControlState';

--- a/packages/mui-material/src/NativeSelect/NativeSelectInput.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelectInput.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import refType from '@mui/utils/refType';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/NoSsr/NoSsr.tsx
+++ b/packages/mui-material/src/NoSsr/NoSsr.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { exactProp, unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/utils';
 import { NoSsrProps } from './NoSsr.types';
 

--- a/packages/mui-material/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material/src/OutlinedInput/NotchedOutline.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import rootShouldForwardProp from '../styles/rootShouldForwardProp';
 import { styled } from '../zero-styled';
 import memoTheme from '../utils/memoTheme';

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import refType from '@mui/utils/refType';
 import composeClasses from '@mui/utils/composeClasses';
 import NotchedOutline from './NotchedOutline';

--- a/packages/mui-material/src/Pagination/Pagination.js
+++ b/packages/mui-material/src/Pagination/Pagination.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import integerPropType from '@mui/utils/integerPropType';

--- a/packages/mui-material/src/PaginationItem/PaginationItem.js
+++ b/packages/mui-material/src/PaginationItem/PaginationItem.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/Paper/Paper.js
+++ b/packages/mui-material/src/Paper/Paper.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import integerPropType from '@mui/utils/integerPropType';
 import chainPropTypes from '@mui/utils/chainPropTypes';

--- a/packages/mui-material/src/Paper/Paper.test.js
+++ b/packages/mui-material/src/Paper/Paper.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import {
   createRenderer,
   strictModeDoubleLoggingSuppressed,

--- a/packages/mui-material/src/PigmentContainer/PigmentContainer.tsx
+++ b/packages/mui-material/src/PigmentContainer/PigmentContainer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { OverridableComponent, OverrideProps } from '@mui/types';
 // @ts-ignore

--- a/packages/mui-material/src/PigmentGrid/PigmentGrid.tsx
+++ b/packages/mui-material/src/PigmentGrid/PigmentGrid.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { OverridableComponent, OverrideProps } from '@mui/types';
 import { SxProps } from '@mui/system';
 // @ts-ignore

--- a/packages/mui-material/src/PigmentStack/PigmentStack.tsx
+++ b/packages/mui-material/src/PigmentStack/PigmentStack.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { OverridableComponent, OverrideProps } from '@mui/types';
 // @ts-ignore

--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import HTMLElementType from '@mui/utils/HTMLElementType';

--- a/packages/mui-material/src/Popover/Popover.test.js
+++ b/packages/mui-material/src/Popover/Popover.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, match } from 'sinon';
 import { act, createRenderer, reactMajor, screen } from '@mui/internal-test-utils';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Modal, { modalClasses } from '@mui/material/Modal';
 import Paper, { paperClasses } from '@mui/material/Paper';
 import Popover, { popoverClasses as classes, PopoverPaper } from '@mui/material/Popover';

--- a/packages/mui-material/src/Popper/BasePopper.tsx
+++ b/packages/mui-material/src/Popper/BasePopper.tsx
@@ -9,7 +9,7 @@ import {
   unstable_useForkRef as useForkRef,
 } from '@mui/utils';
 import { createPopper, Instance, Modifier, Placement, State, VirtualElement } from '@popperjs/core';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import composeClasses from '@mui/utils/composeClasses';
 import useSlotProps from '@mui/utils/useSlotProps';
 import Portal from '../Portal';

--- a/packages/mui-material/src/Popper/Popper.tsx
+++ b/packages/mui-material/src/Popper/Popper.tsx
@@ -3,7 +3,7 @@ import { SxProps } from '@mui/system';
 import { useRtl } from '@mui/system/RtlProvider';
 import refType from '@mui/utils/refType';
 import HTMLElementType from '@mui/utils/HTMLElementType';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import * as React from 'react';
 import BasePopper from './BasePopper';
 import { PopperProps as BasePopperProps } from './BasePopper.types';

--- a/packages/mui-material/src/Portal/Portal.tsx
+++ b/packages/mui-material/src/Portal/Portal.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import {
   exactProp,
   HTMLElementType,

--- a/packages/mui-material/src/Radio/Radio.js
+++ b/packages/mui-material/src/Radio/Radio.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import refType from '@mui/utils/refType';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/Radio/RadioButtonIcon.js
+++ b/packages/mui-material/src/Radio/RadioButtonIcon.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import RadioButtonUncheckedIcon from '../internal/svg-icons/RadioButtonUnchecked';
 import RadioButtonCheckedIcon from '../internal/svg-icons/RadioButtonChecked';
 import rootShouldForwardProp from '../styles/rootShouldForwardProp';

--- a/packages/mui-material/src/RadioGroup/RadioGroup.js
+++ b/packages/mui-material/src/RadioGroup/RadioGroup.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import FormGroup from '../FormGroup';

--- a/packages/mui-material/src/RadioGroup/RadioGroup.test.js
+++ b/packages/mui-material/src/RadioGroup/RadioGroup.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import FormGroup from '@mui/material/FormGroup';
 import Radio from '@mui/material/Radio';

--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import clamp from '@mui/utils/clamp';
 import visuallyHidden from '@mui/utils/visuallyHidden';

--- a/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.js
+++ b/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/Select/Select.js
+++ b/packages/mui-material/src/Select/Select.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import deepmerge from '@mui/utils/deepmerge';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { isFragment } from 'react-is';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import useId from '@mui/utils/useId';

--- a/packages/mui-material/src/Skeleton/Skeleton.js
+++ b/packages/mui-material/src/Skeleton/Skeleton.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha, unstable_getUnit as getUnit, unstable_toUnitless as toUnitless } from '../styles';
 import { keyframes, css, styled } from '../zero-styled';

--- a/packages/mui-material/src/Slide/Slide.js
+++ b/packages/mui-material/src/Slide/Slide.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { Transition } from 'react-transition-group';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import HTMLElementType from '@mui/utils/HTMLElementType';

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { spy, stub } from 'sinon';
 import { expect } from 'chai';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';

--- a/packages/mui-material/src/Slider/SliderValueLabel.tsx
+++ b/packages/mui-material/src/Slider/SliderValueLabel.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { SliderValueLabelProps } from './SliderValueLabel.types';
 import sliderClasses from './sliderClasses';

--- a/packages/mui-material/src/Snackbar/Snackbar.js
+++ b/packages/mui-material/src/Snackbar/Snackbar.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import composeClasses from '@mui/utils/composeClasses';
 import useSnackbar from './useSnackbar';
 import ClickAwayListener from '../ClickAwayListener';

--- a/packages/mui-material/src/SnackbarContent/SnackbarContent.js
+++ b/packages/mui-material/src/SnackbarContent/SnackbarContent.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { emphasize } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/SpeedDial/SpeedDial.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { isFragment } from 'react-is';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import useTimeout from '@mui/utils/useTimeout';

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js
@@ -1,7 +1,7 @@
 'use client';
 // @inheritedComponent Tooltip
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { emphasize } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.js
+++ b/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/Stack/Stack.js
+++ b/packages/mui-material/src/Stack/Stack.js
@@ -1,5 +1,5 @@
 'use client';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createStack } from '@mui/system';
 import styled from '../styles/styled';
 import { useDefaultProps } from '../DefaultPropsProvider';

--- a/packages/mui-material/src/Step/Step.js
+++ b/packages/mui-material/src/Step/Step.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import integerPropType from '@mui/utils/integerPropType';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/StepButton/StepButton.js
+++ b/packages/mui-material/src/StepButton/StepButton.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/StepConnector/StepConnector.js
+++ b/packages/mui-material/src/StepConnector/StepConnector.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import capitalize from '../utils/capitalize';

--- a/packages/mui-material/src/StepContent/StepContent.js
+++ b/packages/mui-material/src/StepContent/StepContent.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/StepIcon/StepIcon.js
+++ b/packages/mui-material/src/StepIcon/StepIcon.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/StepLabel/StepLabel.js
+++ b/packages/mui-material/src/StepLabel/StepLabel.js
@@ -1,7 +1,7 @@
 'use client';
 import composeClasses from '@mui/utils/composeClasses';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import * as React from 'react';
 import StepContext from '../Step/StepContext';
 import StepIcon from '../StepIcon';

--- a/packages/mui-material/src/Stepper/Stepper.js
+++ b/packages/mui-material/src/Stepper/Stepper.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import integerPropType from '@mui/utils/integerPropType';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/SvgIcon/SvgIcon.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import capitalize from '../utils/capitalize';

--- a/packages/mui-material/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeArea.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { styled } from '../zero-styled';
 import memoTheme from '../utils/memoTheme';

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';
 import NoSsr from '../NoSsr';
 import Drawer, { getAnchor, isHorizontal } from '../Drawer/Drawer';

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { fireEvent, createRenderer, screen } from '@mui/internal-test-utils';
-import PropTypes, { checkPropTypes } from 'prop-types';
+import PropTypes, { checkPropTypes } from 'prop-types-compat';
 import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 import Drawer, { drawerClasses } from '@mui/material/Drawer';
 import { backdropClasses } from '@mui/material/Backdrop';

--- a/packages/mui-material/src/Switch/Switch.js
+++ b/packages/mui-material/src/Switch/Switch.js
@@ -1,7 +1,7 @@
 'use client';
 // @inheritedComponent IconButton
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import refType from '@mui/utils/refType';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/Tab/Tab.js
+++ b/packages/mui-material/src/Tab/Tab.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import ButtonBase from '../ButtonBase';

--- a/packages/mui-material/src/TabScrollButton/TabScrollButton.js
+++ b/packages/mui-material/src/TabScrollButton/TabScrollButton.js
@@ -1,7 +1,7 @@
 'use client';
 /* eslint-disable jsx-a11y/aria-role */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { useRtl } from '@mui/system/RtlProvider';

--- a/packages/mui-material/src/Table/Table.js
+++ b/packages/mui-material/src/Table/Table.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import TableContext from './TableContext';

--- a/packages/mui-material/src/TableBody/TableBody.js
+++ b/packages/mui-material/src/TableBody/TableBody.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import Tablelvl2Context from '../Table/Tablelvl2Context';

--- a/packages/mui-material/src/TableCell/TableCell.js
+++ b/packages/mui-material/src/TableCell/TableCell.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { darken, alpha, lighten } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/TableContainer/TableContainer.js
+++ b/packages/mui-material/src/TableContainer/TableContainer.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/TableFooter/TableFooter.js
+++ b/packages/mui-material/src/TableFooter/TableFooter.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import Tablelvl2Context from '../Table/Tablelvl2Context';

--- a/packages/mui-material/src/TableHead/TableHead.js
+++ b/packages/mui-material/src/TableHead/TableHead.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import Tablelvl2Context from '../Table/Tablelvl2Context';

--- a/packages/mui-material/src/TablePagination/TablePagination.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import integerPropType from '@mui/utils/integerPropType';
 import chainPropTypes from '@mui/utils/chainPropTypes';

--- a/packages/mui-material/src/TablePagination/TablePagination.test.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { fireEvent, createRenderer } from '@mui/internal-test-utils';
 import TableFooter from '@mui/material/TableFooter';
 import TableCell from '@mui/material/TableCell';

--- a/packages/mui-material/src/TablePagination/TablePaginationActions.js
+++ b/packages/mui-material/src/TablePagination/TablePaginationActions.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { useRtl } from '@mui/system/RtlProvider';
 import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '../internal/svg-icons/KeyboardArrowRight';

--- a/packages/mui-material/src/TableRow/TableRow.js
+++ b/packages/mui-material/src/TableRow/TableRow.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { alpha } from '@mui/system/colorManipulator';

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.js
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.js
@@ -1,7 +1,7 @@
 'use client';
 import composeClasses from '@mui/utils/composeClasses';
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import * as React from 'react';
 import ButtonBase from '../ButtonBase';
 import ArrowDownwardIcon from '../internal/svg-icons/ArrowDownward';

--- a/packages/mui-material/src/Tabs/ScrollbarSize.js
+++ b/packages/mui-material/src/Tabs/ScrollbarSize.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import debounce from '../utils/debounce';
 import { ownerWindow, unstable_useEnhancedEffect as useEnhancedEffect } from '../utils';
 

--- a/packages/mui-material/src/Tabs/Tabs.js
+++ b/packages/mui-material/src/Tabs/Tabs.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { isFragment } from 'react-is';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import refType from '@mui/utils/refType';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/TextField/TextField.js
+++ b/packages/mui-material/src/TextField/TextField.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import useId from '@mui/utils/useId';

--- a/packages/mui-material/src/TextareaAutosize/TextareaAutosize.tsx
+++ b/packages/mui-material/src/TextareaAutosize/TextareaAutosize.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import {
   unstable_debounce as debounce,
   unstable_useForkRef as useForkRef,

--- a/packages/mui-material/src/ToggleButton/ToggleButton.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.js
@@ -1,7 +1,7 @@
 'use client';
 // @inheritedComponent ButtonBase
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import resolveProps from '@mui/utils/resolveProps';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { isFragment } from 'react-is';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import getValidReactChildren from '@mui/utils/getValidReactChildren';

--- a/packages/mui-material/src/Toolbar/Toolbar.js
+++ b/packages/mui-material/src/Toolbar/Toolbar.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';

--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import useTimeout, { Timeout } from '@mui/utils/useTimeout';
 import elementAcceptingRef from '@mui/utils/elementAcceptingRef';

--- a/packages/mui-material/src/Typography/Typography.js
+++ b/packages/mui-material/src/Typography/Typography.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled, internal_createExtendSxProp } from '../zero-styled';

--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
@@ -1,7 +1,7 @@
 'use client';
 /* eslint-disable consistent-return, jsx-a11y/no-noninteractive-tabindex */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import {
   exactProp,
   elementAcceptingRef,

--- a/packages/mui-material/src/Zoom/Zoom.js
+++ b/packages/mui-material/src/Zoom/Zoom.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { Transition } from 'react-transition-group';
 import elementAcceptingRef from '@mui/utils/elementAcceptingRef';
 import getReactElementRef from '@mui/utils/getReactElementRef';

--- a/packages/mui-material/src/internal/SwitchBase.js
+++ b/packages/mui-material/src/internal/SwitchBase.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import refType from '@mui/utils/refType';
 import composeClasses from '@mui/utils/composeClasses';
 import capitalize from '../utils/capitalize';

--- a/packages/mui-material/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/mui-material/src/useMediaQuery/useMediaQuery.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import {
   act,
   createRenderer,

--- a/packages/mui-material/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/mui-material/src/useScrollTrigger/useScrollTrigger.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { expect } from 'chai';
 import { act, createRenderer, RenderCounter, screen } from '@mui/internal-test-utils';
 import useScrollTrigger from '@mui/material/useScrollTrigger';

--- a/packages/mui-material/test/integration/Menu.test.js
+++ b/packages/mui-material/test/integration/Menu.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { expect } from 'chai';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import Button from '@mui/material/Button';

--- a/packages/mui-private-theming/package.json
+++ b/packages/mui-private-theming/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@babel/runtime": "^7.27.0",
     "@mui/utils": "workspace:^",
-    "prop-types": "^15.8.1"
+    "prop-types-compat": "^15.8.2"
   },
   "devDependencies": {
     "@mui/internal-test-utils": "workspace:^",

--- a/packages/mui-private-theming/src/ThemeProvider/ThemeProvider.js
+++ b/packages/mui-private-theming/src/ThemeProvider/ThemeProvider.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { exactProp } from '@mui/utils';
 import ThemeContext from '../useTheme/ThemeContext';
 import useTheme from '../useTheme';

--- a/packages/mui-styled-engine-sc/package.json
+++ b/packages/mui-styled-engine-sc/package.json
@@ -41,7 +41,7 @@
     "@types/hoist-non-react-statics": "^3.3.6",
     "csstype": "^3.1.3",
     "hoist-non-react-statics": "^3.3.2",
-    "prop-types": "^15.8.1"
+    "prop-types-compat": "^15.8.2"
   },
   "devDependencies": {
     "@mui/internal-test-utils": "workspace:^",

--- a/packages/mui-styled-engine-sc/src/GlobalStyles/GlobalStyles.js
+++ b/packages/mui-styled-engine-sc/src/GlobalStyles/GlobalStyles.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createGlobalStyle } from 'styled-components';
 
 function isEmpty(obj) {

--- a/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js
+++ b/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 export default function StyledEngineProvider(props) {
   const { injectFirst, children } = props;

--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -43,7 +43,7 @@
     "@emotion/serialize": "^1.3.3",
     "@emotion/sheet": "^1.4.0",
     "csstype": "^3.1.3",
-    "prop-types": "^15.8.1"
+    "prop-types-compat": "^15.8.2"
   },
   "devDependencies": {
     "@emotion/react": "^11.13.5",

--- a/packages/mui-styled-engine/src/GlobalStyles/GlobalStyles.js
+++ b/packages/mui-styled-engine/src/GlobalStyles/GlobalStyles.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { Global } from '@emotion/react';
 
 function isEmpty(obj) {

--- a/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
+++ b/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
 import { StyleSheet } from '@emotion/sheet';

--- a/packages/mui-system/package.json
+++ b/packages/mui-system/package.json
@@ -54,7 +54,6 @@
     "@mui/internal-test-utils": "workspace:^",
     "@mui/system": "workspace:*",
     "@types/chai": "^4.3.20",
-    "@types/prop-types": "^15.7.14",
     "@types/react": "^19.1.2",
     "@types/sinon": "^17.0.4",
     "chai": "^4.5.0",

--- a/packages/mui-system/package.json
+++ b/packages/mui-system/package.json
@@ -46,7 +46,7 @@
     "@mui/utils": "workspace:^",
     "clsx": "^2.1.1",
     "csstype": "^3.1.3",
-    "prop-types": "^15.8.1"
+    "prop-types-compat": "^15.8.2"
   },
   "devDependencies": {
     "@emotion/react": "^11.13.5",

--- a/packages/mui-system/src/Box/Box.js
+++ b/packages/mui-system/src/Box/Box.js
@@ -1,5 +1,5 @@
 'use client';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import ClassNameGenerator from '@mui/utils/ClassNameGenerator';
 import createBox from '../createBox';
 import boxClasses from './boxClasses';

--- a/packages/mui-system/src/Container/Container.tsx
+++ b/packages/mui-system/src/Container/Container.tsx
@@ -1,5 +1,5 @@
 'use client';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import createContainer from './createContainer';
 
 /**

--- a/packages/mui-system/src/Container/createContainer.tsx
+++ b/packages/mui-system/src/Container/createContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { Interpolation, MUIStyledComponent as StyledComponent } from '@mui/styled-engine';
 import { OverridableComponent } from '@mui/types';

--- a/packages/mui-system/src/DefaultPropsProvider/DefaultPropsProvider.tsx
+++ b/packages/mui-system/src/DefaultPropsProvider/DefaultPropsProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import resolveProps from '@mui/utils/resolveProps';
 
 const PropsContext = React.createContext<Record<string, any> | undefined>(undefined);

--- a/packages/mui-system/src/GlobalStyles/GlobalStyles.tsx
+++ b/packages/mui-system/src/GlobalStyles/GlobalStyles.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { GlobalStyles as MuiGlobalStyles, Interpolation } from '@mui/styled-engine';
 import useTheme from '../useTheme';
 import { Theme as SystemTheme } from '../createTheme';

--- a/packages/mui-system/src/Grid/Grid.tsx
+++ b/packages/mui-system/src/Grid/Grid.tsx
@@ -1,5 +1,5 @@
 'use client';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import createGrid from './createGrid';
 /**
  *

--- a/packages/mui-system/src/Grid/createGrid.tsx
+++ b/packages/mui-system/src/Grid/createGrid.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
 import isMuiElement from '@mui/utils/isMuiElement';

--- a/packages/mui-system/src/RtlProvider/index.js
+++ b/packages/mui-system/src/RtlProvider/index.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 const RtlContext = React.createContext();
 

--- a/packages/mui-system/src/Stack/Stack.tsx
+++ b/packages/mui-system/src/Stack/Stack.tsx
@@ -1,5 +1,5 @@
 'use client';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import createStack from './createStack';
 /**
  *

--- a/packages/mui-system/src/Stack/createStack.tsx
+++ b/packages/mui-system/src/Stack/createStack.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
 import deepmerge from '@mui/utils/deepmerge';

--- a/packages/mui-system/src/ThemeProvider/ThemeProvider.js
+++ b/packages/mui-system/src/ThemeProvider/ThemeProvider.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import {
   ThemeProvider as MuiThemeProvider,
   useTheme as usePrivateTheme,

--- a/packages/mui-system/src/breakpoints/breakpoints.js
+++ b/packages/mui-system/src/breakpoints/breakpoints.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import deepmerge from '@mui/utils/deepmerge';
 import merge from '../merge';
 import { isCqShorthand, getContainerQuery } from '../cssContainerQueries';

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { GlobalStyles } from '@mui/styled-engine';
 import { useTheme as muiUseTheme } from '@mui/private-theming';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';

--- a/packages/mui-system/src/responsivePropType/responsivePropType.js
+++ b/packages/mui-system/src/responsivePropType/responsivePropType.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 const responsivePropType =
   process.env.NODE_ENV !== 'production'

--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -42,7 +42,7 @@
     "@mui/types": "workspace:^",
     "@types/prop-types": "^15.7.14",
     "clsx": "^2.1.1",
-    "prop-types": "^15.8.1",
+    "prop-types-compat": "^15.8.2",
     "react-is": "^19.1.0"
   },
   "devDependencies": {

--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@babel/runtime": "^7.27.0",
     "@mui/types": "workspace:^",
-    "@types/prop-types": "^15.7.14",
     "clsx": "^2.1.1",
     "prop-types-compat": "^15.8.2",
     "react-is": "^19.1.0"

--- a/packages/mui-utils/src/chainPropTypes/chainPropTypes.spec.tsx
+++ b/packages/mui-utils/src/chainPropTypes/chainPropTypes.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import chainPropTypes from './chainPropTypes';
 
 interface ChainProps {

--- a/packages/mui-utils/src/chainPropTypes/chainPropTypes.test.ts
+++ b/packages/mui-utils/src/chainPropTypes/chainPropTypes.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import chainPropTypes from './chainPropTypes';
 
 describe('chainPropTypes', () => {

--- a/packages/mui-utils/src/chainPropTypes/chainPropTypes.ts
+++ b/packages/mui-utils/src/chainPropTypes/chainPropTypes.ts
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 export default function chainPropTypes<A, B>(
   propType1: PropTypes.Validator<A>,

--- a/packages/mui-utils/src/deprecatedPropType/deprecatedPropType.test.ts
+++ b/packages/mui-utils/src/deprecatedPropType/deprecatedPropType.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import deprecatedPropType from '@mui/utils/deprecatedPropType';
 
 describe('deprecatedPropType', () => {

--- a/packages/mui-utils/src/deprecatedPropType/deprecatedPropType.ts
+++ b/packages/mui-utils/src/deprecatedPropType/deprecatedPropType.ts
@@ -1,4 +1,4 @@
-import { Validator } from 'prop-types';
+import { Validator } from 'prop-types-compat';
 
 export default function deprecatedPropType<T>(
   validator: Validator<T>,

--- a/packages/mui-utils/src/elementAcceptingRef/elementAcceptingRef.test.tsx
+++ b/packages/mui-utils/src/elementAcceptingRef/elementAcceptingRef.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prefer-stateless-function */
 import * as React from 'react';
 import { expect } from 'chai';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createRenderer, waitFor, reactMajor } from '@mui/internal-test-utils';
 import elementAcceptingRef from './elementAcceptingRef';
 

--- a/packages/mui-utils/src/elementAcceptingRef/elementAcceptingRef.ts
+++ b/packages/mui-utils/src/elementAcceptingRef/elementAcceptingRef.ts
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import chainPropTypes from '../chainPropTypes';
 
 function isClassComponent(elementType: Function) {

--- a/packages/mui-utils/src/elementTypeAcceptingRef/elementTypeAcceptingRef.test.tsx
+++ b/packages/mui-utils/src/elementTypeAcceptingRef/elementTypeAcceptingRef.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prefer-stateless-function */
 import * as React from 'react';
 import { expect } from 'chai';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { createRenderer, waitFor } from '@mui/internal-test-utils';
 import elementTypeAcceptingRef from './elementTypeAcceptingRef';
 

--- a/packages/mui-utils/src/elementTypeAcceptingRef/elementTypeAcceptingRef.ts
+++ b/packages/mui-utils/src/elementTypeAcceptingRef/elementTypeAcceptingRef.ts
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import chainPropTypes from '../chainPropTypes';
 
 function isClassComponent(elementType: Function) {

--- a/packages/mui-utils/src/exactProp/exactProp.test.ts
+++ b/packages/mui-utils/src/exactProp/exactProp.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import exactProp from './exactProp';
 
 describe('exactProp()', () => {

--- a/packages/mui-utils/src/exactProp/exactProp.ts
+++ b/packages/mui-utils/src/exactProp/exactProp.ts
@@ -1,4 +1,4 @@
-import { ValidationMap } from 'prop-types';
+import { ValidationMap } from 'prop-types-compat';
 // This module is based on https://github.com/airbnb/prop-types-exact repository.
 // However, in order to reduce the number of dependencies and to remove some extra safe checks
 // the module was forked.

--- a/packages/mui-utils/src/integerPropType/integerPropType.test.tsx
+++ b/packages/mui-utils/src/integerPropType/integerPropType.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unknown-property */
 import * as React from 'react';
 import { expect } from 'chai';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { integerPropType } from '@mui/utils';
 import { getTypeByValue } from './integerPropType';
 

--- a/packages/mui-utils/src/integerPropType/integerPropType.ts
+++ b/packages/mui-utils/src/integerPropType/integerPropType.ts
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 export function getTypeByValue(value: any): string {
   const valueType = typeof value;

--- a/packages/mui-utils/src/refType/refType.ts
+++ b/packages/mui-utils/src/refType/refType.ts
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 const refType = PropTypes.oneOfType([PropTypes.func, PropTypes.object]);
 

--- a/packages/mui-utils/src/requirePropFactory/requirePropFactory.test.tsx
+++ b/packages/mui-utils/src/requirePropFactory/requirePropFactory.test.tsx
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import { expect } from 'chai';
 import requirePropFactory from './requirePropFactory';
 

--- a/packages/mui-utils/src/requirePropFactory/requirePropFactory.ts
+++ b/packages/mui-utils/src/requirePropFactory/requirePropFactory.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 export default function requirePropFactory(
   componentNameInError: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1774,8 +1774,8 @@ importers:
         specifier: ^3.1.3
         version: 3.1.3
       prop-types-compat:
-        specifier: ^15.8.1
-        version: 15.8.1
+        specifier: ^15.8.2
+        version: 15.8.2
       react-is:
         specifier: ^19.1.0
         version: 19.1.0
@@ -11578,8 +11578,8 @@ packages:
     resolution: {integrity: sha512-2FPputGL+mP3jJ3UZg/Dl9YOkovB7DX0oOr+ck5QbZ5MtORtds8k/BZdn+02peDLI8/YWbmzx34k5fA+fHvCVQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  prop-types-compat@15.8.1:
-    resolution: {integrity: sha512-JfEoycMw6yTOHkhOOlS55BHv/2CaSadk+QziQp9/6C+3MhUnQr4Vxydzzh6tLv6c5aHBwjX5zz8A2ALkyvCVvw==}
+  prop-types-compat@15.8.2:
+    resolution: {integrity: sha512-eovxpslTPALbkXtfpIM6QuRf6NiQwy/Y66VhEzF686yqpUViRuaGMOyupviKHBR1qjRFUyyzcJGUpOs6S8E84w==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -25024,7 +25024,7 @@ snapshots:
     dependencies:
       read: 3.0.1
 
-  prop-types-compat@15.8.1:
+  prop-types-compat@15.8.2:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1773,7 +1773,7 @@ importers:
       csstype:
         specifier: ^3.1.3
         version: 3.1.3
-      prop-types:
+      prop-types-compat:
         specifier: ^15.8.1
         version: 15.8.1
       react-is:
@@ -11577,6 +11577,9 @@ packages:
   promzard@1.0.2:
     resolution: {integrity: sha512-2FPputGL+mP3jJ3UZg/Dl9YOkovB7DX0oOr+ck5QbZ5MtORtds8k/BZdn+02peDLI8/YWbmzx34k5fA+fHvCVQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  prop-types-compat@15.8.1:
+    resolution: {integrity: sha512-JfEoycMw6yTOHkhOOlS55BHv/2CaSadk+QziQp9/6C+3MhUnQr4Vxydzzh6tLv6c5aHBwjX5zz8A2ALkyvCVvw==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -25020,6 +25023,11 @@ snapshots:
   promzard@1.0.2:
     dependencies:
       read: 3.0.1
+
+  prop-types-compat@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
 
   prop-types@15.8.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -598,9 +598,9 @@ importers:
       playwright:
         specifier: ^1.51.1
         version: 1.51.1
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
+      prop-types-compat:
+        specifier: ^15.8.2
+        version: 15.8.2
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -841,9 +841,9 @@ importers:
       postcss-import:
         specifier: ^16.1.0
         version: 16.1.0(postcss@8.5.3)
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
+      prop-types-compat:
+        specifier: ^15.8.2
+        version: 15.8.2
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -956,9 +956,6 @@ importers:
       '@types/nprogress':
         specifier: ^0.2.3
         version: 0.2.3
-      '@types/prop-types':
-        specifier: ^15.7.14
-        version: 15.7.14
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.2
@@ -1175,9 +1172,9 @@ importers:
       playwright:
         specifier: ^1.51.1
         version: 1.51.1
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
+      prop-types-compat:
+        specifier: ^15.8.2
+        version: 15.8.2
       react:
         specifier: ^18.0.0 || ^19.0.0
         version: 19.1.0
@@ -1197,9 +1194,6 @@ importers:
       '@types/format-util':
         specifier: ^1.0.4
         version: 1.0.4
-      '@types/prop-types':
-        specifier: ^15.7.14
-        version: 15.7.14
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.2
@@ -1460,9 +1454,9 @@ importers:
       nprogress:
         specifier: ^0.2.0
         version: 0.2.0
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
+      prop-types-compat:
+        specifier: ^15.8.2
+        version: 15.8.2
     devDependencies:
       '@mui/icons-material':
         specifier: workspace:*
@@ -1476,9 +1470,6 @@ importers:
       '@types/node':
         specifier: ^20.17.30
         version: 20.17.30
-      '@types/prop-types':
-        specifier: ^15.7.14
-        version: 15.7.14
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.2
@@ -1622,9 +1613,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
+      prop-types-compat:
+        specifier: ^15.8.2
+        version: 15.8.2
     devDependencies:
       '@mui/internal-test-utils':
         specifier: workspace:^
@@ -1635,9 +1626,6 @@ importers:
       '@types/chai':
         specifier: ^4.3.20
         version: 4.3.20
-      '@types/prop-types':
-        specifier: ^15.7.14
-        version: 15.7.14
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.2
@@ -1696,9 +1684,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
+      prop-types-compat:
+        specifier: ^15.8.2
+        version: 15.8.2
     devDependencies:
       '@mui/internal-test-utils':
         specifier: workspace:^
@@ -1709,9 +1697,6 @@ importers:
       '@types/chai':
         specifier: ^4.3.20
         version: 4.3.20
-      '@types/prop-types':
-        specifier: ^15.7.14
-        version: 15.7.14
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.2
@@ -1795,9 +1780,6 @@ importers:
       '@types/chai':
         specifier: ^4.3.20
         version: 4.3.20
-      '@types/prop-types':
-        specifier: ^15.7.14
-        version: 15.7.14
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.2
@@ -1886,9 +1868,9 @@ importers:
       '@mui/utils':
         specifier: workspace:^
         version: link:../mui-utils/build
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
+      prop-types-compat:
+        specifier: ^15.8.2
+        version: 15.8.2
     devDependencies:
       '@mui/internal-test-utils':
         specifier: workspace:^
@@ -1927,9 +1909,9 @@ importers:
       csstype:
         specifier: ^3.1.3
         version: 3.1.3
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
+      prop-types-compat:
+        specifier: ^15.8.2
+        version: 15.8.2
     devDependencies:
       '@emotion/react':
         specifier: ^11.13.5
@@ -1971,9 +1953,9 @@ importers:
       hoist-non-react-statics:
         specifier: ^3.3.2
         version: 3.3.2
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
+      prop-types-compat:
+        specifier: ^15.8.2
+        version: 15.8.2
     devDependencies:
       '@mui/internal-test-utils':
         specifier: workspace:^
@@ -2018,9 +2000,9 @@ importers:
       csstype:
         specifier: ^3.1.3
         version: 3.1.3
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
+      prop-types-compat:
+        specifier: ^15.8.2
+        version: 15.8.2
     devDependencies:
       '@emotion/react':
         specifier: ^11.13.5
@@ -2037,9 +2019,6 @@ importers:
       '@types/chai':
         specifier: ^4.3.20
         version: 4.3.20
-      '@types/prop-types':
-        specifier: ^15.7.14
-        version: 15.7.14
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.2
@@ -2088,15 +2067,12 @@ importers:
       '@mui/types':
         specifier: workspace:^
         version: link:../mui-types/build
-      '@types/prop-types':
-        specifier: ^15.7.14
-        version: 15.7.14
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
+      prop-types-compat:
+        specifier: ^15.8.2
+        version: 15.8.2
       react-is:
         specifier: ^19.1.0
         version: 19.1.0
@@ -2255,9 +2231,9 @@ importers:
       playwright:
         specifier: ^1.51.1
         version: 1.51.1
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
+      prop-types-compat:
+        specifier: ^15.8.2
+        version: 15.8.2
       react:
         specifier: ^19.1.0
         version: 19.1.0

--- a/test/e2e/TestViewer.js
+++ b/test/e2e/TestViewer.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 
 function TestViewer(props) {
   const { children } = props;

--- a/test/package.json
+++ b/test/package.json
@@ -30,7 +30,7 @@
     "html-webpack-plugin": "^5.6.3",
     "lodash": "^4.17.21",
     "playwright": "^1.51.1",
-    "prop-types": "^15.8.1",
+    "prop-types-compat": "^15.8.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-is": "^19.1.0",

--- a/test/regressions/TestViewer.jsx
+++ b/test/regressions/TestViewer.jsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Box from '@mui/material/Box';
 import GlobalStyles from '@mui/material/GlobalStyles';
 import JoyBox from '@mui/joy/Box';

--- a/test/regressions/fixtures/Autocomplete/Virtualize.js
+++ b/test/regressions/fixtures/Autocomplete/Virtualize.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import TextField from '@mui/material/TextField';
 import Autocomplete, { autocompleteClasses } from '@mui/material/Autocomplete';
 import useMediaQuery from '@mui/material/useMediaQuery';

--- a/test/regressions/fixtures/Menu/MenuContentAnchors.js
+++ b/test/regressions/fixtures/Menu/MenuContentAnchors.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Grid from '@mui/material/Grid';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';

--- a/test/regressions/fixtures/SpeedDial/Directions.js
+++ b/test/regressions/fixtures/SpeedDial/Directions.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
 import SpeedDial from '@mui/material/SpeedDial';

--- a/test/regressions/index.jsx
+++ b/test/regressions/index.jsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types-compat';
 import * as ReactDOMClient from 'react-dom/client';
 import { BrowserRouter as Router, Routes, Route, Link, useNavigate } from 'react-router';
 import webfontloader from 'webfontloader';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #45432

Please read https://github.com/mui/material-ui/issues/45432#issuecomment-2818450537 for the explanation about the root cause.

## Solution

I fork React `prop-types` to [`prop-types-compat`](https://github.com/siriwatknp/prop-types-compat) and add some [changes](https://github.com/facebook/prop-types/compare/main...siriwatknp:prop-types-compat:main) to make it compat with React 19 (see the [test](https://github.com/facebook/prop-types/commit/8d076bd09a9859870a402aeeb549e2e3b7234d56#diff-c4e5da1bffd00c0893dd21ab6aa61335ebcd088d5bad6cdbe4bfe24f33b9f873)). It's released under package name `prop-types-compat`.

I choose this option so that it affects the core repo as least as possible.
Most changes in this PR are:

- replacing `prop-types` with `prop-types-compat`
- remove `prop-types` and `@types/prop-types` from package.json (the compat `prop-types-compat` comes with types)
- minor update on the `docs:api` script to trick react docgen to produce the same result.

## Result

**Before**: https://github.com/bartplay2499/mui_warnings
**After**: https://github.com/siriwatknp/mui-children-fix

## Review recommendation

Going through [commits](https://github.com/mui/material-ui/pull/45984/commits) is probably better than seeing the whole changes at once.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
