### PR TITLE
[docs] Ease migration to v5

### DIFF
--- a/docs/data/joy/getting-started/installation/installation.md
+++ b/docs/data/joy/getting-started/installation/installation.md
@@ -7,6 +7,7 @@
 Run one of the following commands to add Joy UI to your project:
 
 <codeblock storageKey="package-manager">
+
 ```bash npm
 npm install @mui/joy @emotion/react @emotion/styled
 ```
@@ -45,6 +46,7 @@ Add it to your project via [Fontsource](https://fontsource.org/), or with the Go
 Run one of the following commands to add Inter through Fontsource to your Joy UI project:
 
 <codeblock storageKey="package-manager">
+
 ```bash npm
 npm install @fontsource/inter
 ```

--- a/docs/data/material/components/about-the-lab/about-the-lab.md
+++ b/docs/data/material/components/about-the-lab/about-the-lab.md
@@ -22,15 +22,15 @@ To install and save in your `package.json` dependencies, run one of the followin
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/lab @mui/material
+npm install @mui/lab@^5.0.0-alpha @mui/material@^5.0.0
 ```
 
 ```bash yarn
-yarn add @mui/lab @mui/material
+yarn add @mui/lab@^5.0.0-alpha @mui/material@^5.0.0
 ```
 
 ```bash pnpm
-pnpm add @mui/lab @mui/material
+pnpm add @mui/lab@^5.0.0-alpha @mui/material@^5.0.0
 ```
 
 </codeblock>

--- a/docs/data/material/components/icons/icons.md
+++ b/docs/data/material/components/icons/icons.md
@@ -27,16 +27,17 @@ You can [search the full list of these icons](/material-ui/material-icons/).
 Run one of the following commands to install it and save it to your `package.json` dependencies:
 
 <codeblock storageKey="package-manager">
+
 ```bash npm
-npm install @mui/icons-material
+npm install @mui/icons-material@^5.0.0
 ```
 
 ```bash yarn
-yarn add @mui/icons-material
+yarn add @mui/icons-material@^5.0.0
 ```
 
 ```bash pnpm
-pnpm add @mui/icons-material
+pnpm add @mui/icons-material@^5.0.0
 ```
 
 </codeblock>

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -21,15 +21,15 @@ Use one of the following commands to install it:
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/icons-material @mui/material @emotion/styled @emotion/react
+npm install @mui/icons-material@^5.0.0 @mui/material@^5.0.0 @emotion/styled @emotion/react
 ```
 
 ```bash yarn
-yarn add @mui/icons-material @mui/material @emotion/styled @emotion/react
+yarn add @mui/icons-material@^5.0.0 @mui/material@^5.0.0 @emotion/styled @emotion/react
 ```
 
 ```bash pnpm
-pnpm add @mui/icons-material @mui/material @emotion/styled @emotion/react
+pnpm add @mui/icons-material@^5.0.0 @mui/material@^5.0.0 @emotion/styled @emotion/react
 ```
 
 </codeblock>

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -9,18 +9,20 @@ Run one of the following commands to add Material UI to your project:
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/material @emotion/react @emotion/styled
+npm install @mui/material@^5.0.0 @emotion/react @emotion/styled
 ```
 
 ```bash yarn
-yarn add @mui/material @emotion/react @emotion/styled
+yarn add @mui/material@^5.0.0 @emotion/react @emotion/styled
 ```
 
 ```bash pnpm
-pnpm add @mui/material @emotion/react @emotion/styled
+pnpm add @mui/material@^5.0.0 @emotion/react @emotion/styled
 ```
 
 </codeblock>
+
+If you wish to use the latest version, remove the `@^5.0.0` suffix.
 
 ### Peer dependencies
 

--- a/docs/data/material/integrations/nextjs/nextjs.md
+++ b/docs/data/material/integrations/nextjs/nextjs.md
@@ -14,15 +14,15 @@ Then, run one of the following commands to install the dependencies:
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/material-nextjs @emotion/cache
+npm install @mui/material-nextjs@^5.0.0 @emotion/cache
 ```
 
 ```bash yarn
-yarn add @mui/material-nextjs @emotion/cache
+yarn add @mui/material-nextjs@^5.0.0 @emotion/cache
 ```
 
 ```bash pnpm
-pnpm add @mui/material-nextjs @emotion/cache
+pnpm add @mui/material-nextjs@^5.0.0 @emotion/cache
 ```
 
 </codeblock>
@@ -156,15 +156,15 @@ Then, run one of the following commands to install the dependencies:
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/material-nextjs @emotion/cache @emotion/server
+npm install @mui/material-nextjs@^5.0.0 @emotion/cache @emotion/server
 ```
 
 ```bash yarn
-yarn add @mui/material-nextjs @emotion/cache @emotion/server
+yarn add @mui/material-nextjs@^5.0.0 @emotion/cache @emotion/server
 ```
 
 ```bash pnpm
-pnpm add @mui/material-nextjs @emotion/cache @emotion/server
+pnpm add @mui/material-nextjs@^5.0.0 @emotion/cache @emotion/server
 ```
 
 </codeblock>

--- a/docs/data/material/migration/migration-v4/migration-v4.md
+++ b/docs/data/material/migration/migration-v4/migration-v4.md
@@ -148,12 +148,13 @@ Make sure that your application is still running without errors, and commit the 
 Install the Material UI v5 packages.
 
 <codeblock storageKey="package-manager">
+
 ```bash npm
-npm install @mui/material @mui/styles
+npm install @mui/material@^5.0.0 @mui/styles@^5.0.0
 ```
 
 ```bash yarn
-yarn add @mui/material @mui/styles
+yarn add @mui/material@^5.0.0 @mui/styles@^5.0.0
 ```
 
 </codeblock>
@@ -163,12 +164,13 @@ If you're using `@material-ui/lab` or `@material-ui/icons`, you will need to ins
 ### `@material-ui/lab`
 
 <codeblock storageKey="package-manager">
+
 ```bash npm
-npm install @mui/lab
+npm install @mui/lab@^5.0.0-alpha
 ```
 
 ```bash yarn
-yarn add @mui/lab
+yarn add @mui/lab@^5.0.0-alpha
 ```
 
 </codeblock>
@@ -176,12 +178,13 @@ yarn add @mui/lab
 ### `@material-ui/icons`
 
 <codeblock storageKey="package-manager">
+
 ```bash npm
-npm install @mui/icons-material
+npm install @mui/icons-material@^5.0.0
 ```
 
 ```bash yarn
-yarn add @mui/icons-material
+yarn add @mui/icons-material@^5.0.0
 ```
 
 </codeblock>

--- a/docs/data/system/getting-started/installation/installation.md
+++ b/docs/data/system/getting-started/installation/installation.md
@@ -9,15 +9,15 @@ Run one of the following commands to add MUI System to your project:
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/system @emotion/react @emotion/styled
+npm install @mui/system@^5.0.0 @emotion/react @emotion/styled
 ```
 
 ```bash yarn
-yarn add @mui/system @emotion/react @emotion/styled
+yarn add @mui/system@^5.0.0 @emotion/react @emotion/styled
 ```
 
 ```bash pnpm
-pnpm add @mui/system @emotion/react @emotion/styled
+pnpm add @mui/system@^5.0.0 @emotion/react @emotion/styled
 ```
 
 </codeblock>
@@ -42,15 +42,15 @@ If you want to use [styled-components](https://styled-components.com/) instead, 
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/system @mui/styled-engine-sc styled-components
+npm install @mui/system@^5.0.0 @mui/styled-engine-sc@^5.0.0 styled-components
 ```
 
 ```bash yarn
-yarn add @mui/system @mui/styled-engine-sc styled-components
+yarn add @mui/system@^5.0.0 @mui/styled-engine-sc@^5.0.0 styled-components
 ```
 
 ```bash pnpm
-pnpm add @mui/system @mui/styled-engine-sc styled-components
+pnpm add @mui/system@^5.0.0 @mui/styled-engine-sc@^5.0.0 styled-components
 ```
 
 </codeblock>


### PR DESCRIPTION
https://mui-org.slack.com/archives/C041SDSF32L/p1745416149123639

Reproduce: https://v6.mui.com/material-ui/getting-started/installation/

In HEAD, we should be good: https://github.com/mui/material-ui/blob/4a9d277e94c540daaed7466c4d821ff72f6b9b41/docs/data/material/getting-started/installation/installation.md?plain=1#L9

Preview: https://deploy-preview-45991--material-ui.netlify.app/material-ui/getting-started/installation/