### PR TITLE
[InputBase] Allow `undefined` in onBlur event type

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.d.ts
+++ b/packages/mui-material/src/InputBase/InputBase.d.ts
@@ -144,7 +144,7 @@ export interface InputBaseProps
    *
    * Notice that the first argument (event) might be undefined.
    */
-  onBlur?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  onBlur?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement> | undefined;
   /**
    * Callback fired when the value is changed.
    *


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes #45982: Add `undefined` to `onBlur` event type in `InputBase`

**Problem**:  
`InputBase` calls `onBlur` with `undefined` in some cases (e.g., when disabled), but the type didn’t reflect this.

**Solution**:  
Updated the type to:  
```ts
onBlur?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement> | undefined;
```

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
