### PR TITLE
[core] Add comment that lab should be in alpha

### DIFF
--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@mui/lab",
+  "//": "version should be 'alpha' at all time",
   "version": "7.0.0-beta.12",
   "author": "MUI Team",
   "description": "Laboratory for new Material UI modules.",


### PR DESCRIPTION
I don't know what happened, but the lab should be in the "alpha" per https://www.notion.so/mui-org/React-Major-version-release-process-0178410ef26941e6a4f333f80ded127a?pvs=4#76b607ce98cf45a49730f2af04e18dd3. It's not the case https://www.npmjs.com/package/@mui/lab?activeTab=versions. Adding a comment for Material UI v8. 

(The // is from https://stackoverflow.com/questions/14221579/how-do-i-add-comments-to-package-json-for-npm-install)

A bit related to #40662.
