### PR TITLE
[docs][material-ui][Grid] Update grid migration guide

### DIFF
--- a/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
+++ b/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
@@ -338,11 +338,11 @@ If you need the grid to grow to the full width, you can use the `sx` prop:
 
 ```diff
 -<Grid container>
-+<Grid2 container sx={{ width: '100%' }}>
++<Grid container sx={{ width: '100%' }}>
 
  // alternatively, if the Grid's parent is a flex container:
 -<Grid container>
-+<Grid2 container sx={{ flexGrow: 1 }}>
++<Grid container sx={{ flexGrow: 1 }}>
 ```
 
 ### ListItem

--- a/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
+++ b/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
@@ -331,6 +331,20 @@ These updates may lead to unexpected changes to your app's layout.
 Still, we strongly recommend adopting this new behavior rather than trying to replicate the old pattern, as the new version is more predictable and modern.
 :::
 
+#### Container width
+
+The updated Grid component doesn't grow to the full width of the container by default.
+If you need the grid to grow to the full width, you can use the `sx` prop:
+
+```diff
+-<Grid container>
++<Grid2 container sx={{ width: '100%' }}>
+
+ // alternatively, if the Grid's parent is a flex container:
+-<Grid container>
++<Grid2 container sx={{ flexGrow: 1 }}>
+```
+
 ### ListItem
 
 `ListItem`'s props `autoFocus`, `button`, `disabled`, and `selected`, deprecated in v5, have been removed. To replace the `button` prop, use `ListItemButton` instead. The other removed props are available in the `ListItemButton` component as well.


### PR DESCRIPTION
related to https://github.com/mui/material-ui/issues/44201#issuecomment-2844946485

This PR updates the migration guide to version 6 (`upgrade-to-v6.md`) by adding details about changes to the default behavior of the Grid component.

### Documentation updates:

* **Grid Component Behavior**: Added a new section explaining that the updated Grid component no longer grows to the full width of the container by default. 

Above section is already present in https://mui.com/material-ui/migration/upgrade-to-grid-v2/#container-width but missing in https://mui.com/material-ui/migration/upgrade-to-v6/#grid2

preview: https://deploy-preview-46057--material-ui.netlify.app/material-ui/migration/upgrade-to-v6/#grid2