### PR TITLE
[docs-infra] Update feedback Node.js to v22

### DIFF
--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -192,18 +192,17 @@ async function getUserFeedback(id) {
 }
 
 async function submitFeedback(page, rating, comment, language, commentedSection, productId) {
-  const data = {
-    id: getCookie('feedbackId'),
-    page,
-    rating,
-    comment,
-    version: process.env.LIB_VERSION,
-    language,
-  };
+  const resultSlack = await postFeedbackOnSlack({ rating, comment, commentedSection, productId });
 
-  const resultSlack = await postFeedbackOnSlack({ ...data, productId, commentedSection });
   if (rating !== undefined) {
-    const resultVote = await postFeedback(data);
+    const resultVote = await postFeedback({
+      id: getCookie('feedbackId'),
+      page,
+      rating,
+      comment,
+      version: process.env.LIB_VERSION,
+      language,
+    });
     if (resultVote) {
       document.cookie = `feedbackId=${resultVote.id};path=/;max-age=31536000`;
       setTimeout(async () => {

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -9,8 +9,8 @@
     "claudia": "claudia --profile claudia",
     "test:dev": "curl -H \"Content-Type: application/json\" -X POST --data @example.json https://hgvi836wi8.execute-api.us-east-1.amazonaws.com/dev/rating",
     "setup": "claudia create --profile claudia --version dev --region us-east-1 --api-module index --policies policies --configure-table-dev --configure-table-prod --runtime 'nodejs22.x'",
-    "deploy:dev": "claudia update --profile claudia --version dev --runtime 'nodejs22.x'",
-    "deploy:prod": "claudia update --profile claudia --version dev --runtime 'nodejs22.x' && claudia --profile claudia set-version --version prod"
+    "deploy:dev": "claudia update --profile claudia --runtime 'nodejs22.x --no-optional-dependencies --version dev'",
+    "deploy:prod": "claudia update --profile claudia --runtime 'nodejs22.x' --no-optional-dependencies --version dev && claudia --profile claudia set-version --version prod"
   },
   "dependencies": {
     "claudia-api-builder": "^4.1.2",
@@ -18,5 +18,8 @@
   },
   "devDependencies": {
     "claudia": "^5.14.1"
+  },
+  "optionalDependencies": {
+    "aws-sdk": "^2.1692.0"
   }
 }

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,19 +1,16 @@
 {
   "name": "feedback",
   "private": true,
-  "description": "Store and retrieve page ratings and comments",
-  "main": "./index.js",
+  "//": "Version required by claudia",
+  "version": "0.0.0",
+  "description": "Store and retrieve page ratings and comments.",
   "license": "MIT",
-  "files": [
-    "*.js"
-  ],
   "scripts": {
     "claudia": "claudia --profile claudia",
-    "curl": "curl -H \"Content-Type: application/json\" -X POST --data @example.json https://hgvi836wi8.execute-api.us-east-1.amazonaws.com/dev/rating",
-    "setup": "claudia create --profile claudia --version dev --region us-east-1 --api-module index --policies policies --configure-table-dev --configure-table-prod --no-optional-dependencies",
-    "update": "claudia update --profile claudia --version dev --no-optional-dependencies",
-    "deploy": "claudia update --profile claudia --version dev --no-optional-dependencies && claudia --profile claudia set-version --version prod",
-    "reconfigure": "claudia update --profile claudia --configure-db"
+    "test:dev": "curl -H \"Content-Type: application/json\" -X POST --data @example.json https://hgvi836wi8.execute-api.us-east-1.amazonaws.com/dev/rating",
+    "setup": "claudia create --profile claudia --version dev --region us-east-1 --api-module index --policies policies --configure-table-dev --configure-table-prod --runtime 'nodejs22.x'",
+    "deploy:dev": "claudia update --profile claudia --version dev --runtime 'nodejs22.x'",
+    "deploy:prod": "claudia update --profile claudia --version dev --runtime 'nodejs22.x' && claudia --profile claudia set-version --version prod"
   },
   "dependencies": {
     "claudia-api-builder": "^4.1.2",
@@ -21,8 +18,5 @@
   },
   "devDependencies": {
     "claudia": "^5.14.1"
-  },
-  "optionalDependencies": {
-    "aws-sdk": "^2.1692.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1384,6 +1384,10 @@ importers:
       claudia:
         specifier: ^5.14.1
         version: 5.14.1
+    optionalDependencies:
+      aws-sdk:
+        specifier: ^2.1692.0
+        version: 2.1692.0
 
   packages/markdown:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1384,10 +1384,6 @@ importers:
       claudia:
         specifier: ^5.14.1
         version: 5.14.1
-    optionalDependencies:
-      aws-sdk:
-        specifier: ^2.1692.0
-        version: 2.1692.0
 
   packages/markdown:
     dependencies:


### PR DESCRIPTION
Similar to https://github.com/mui/mui-private/pull/858. Required for https://groups.google.com/a/mui.com/g/back-infra/c/t3EhZ2ssR0Q.

But actually, this feels quite outdated logic, https://www.notion.so/mui-org/docs-infra-Add-docs-page-feedback-rating-v2-1e8cbfe7b6608030ac27edc8c272ff83 created for the future.