### PR TITLE
[styled-engine] Infer `ownerState` from props in `styled`

### DIFF
--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -106,7 +106,9 @@ export type Interpolation<Props> =
   | (CSSObject & {
       variants?: Array<{
         props:
-          | Partial<Props>
+          | (Props extends { ownerState: infer O }
+              ? Partial<Omit<Props, 'ownerState'> & O>
+              : Partial<Props>)
           | ((
               props: Partial<Props> & {
                 ownerState: Partial<Props>;

--- a/packages/mui-system/src/styled/styled.spec.ts
+++ b/packages/mui-system/src/styled/styled.spec.ts
@@ -1,0 +1,52 @@
+import { styled } from '@mui/system';
+
+type OwnerState = {
+  variant?: 'success' | 'error' | 'processing';
+  showChanges: boolean;
+};
+
+const VariantObjects = styled('div')<{ ownerState: OwnerState } & OwnerState>({
+  font: 'inherit',
+  color: 'inherit',
+  variants: [
+    {
+      props: { variant: 'success' },
+      style: {
+        color: 'red',
+      },
+    },
+    {
+      props: { showChanges: false },
+      style: {
+        background: 'red',
+      },
+    },
+  ],
+});
+
+const VariantCallbacks = styled('div')<{ ownerState: OwnerState } & OwnerState>({
+  font: 'inherit',
+  color: 'inherit',
+  variants: [
+    {
+      props: ({ ownerState }) => ownerState.showChanges,
+      style: {
+        color: 'red',
+      },
+    },
+  ],
+});
+
+// @ts-expect-error the props callback must return a boolean
+const VariantCallbacksError = styled('div')<{ ownerState: OwnerState } & OwnerState>({
+  font: 'inherit',
+  color: 'inherit',
+  variants: [
+    {
+      props: ({ ownerState }) => ownerState.variant,
+      style: {
+        color: 'red',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Issue

There is a bug from https://github.com/mui/material-ui/pull/45478.
The props is not inferred from the `ownerState` values

```js
type OwnerState = {
  variant?: 'success' | 'error' | 'processing';
  showChanges: boolean;
};

const VariantObjects = styled('div')<{ ownerState: OwnerState } & OwnerState>({
  font: 'inherit',
  color: 'inherit',
  variants: [
    {
      props: { variant: 'success' }, // ❌ variant is not inferred from the `ownerState`
      style: {
        color: 'red',
      },
    },
  ],
});
```

Found this when trying the master build on MUI X.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
