### PR TITLE
[material-ui] Remove unnecessary clsx usages

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -476,7 +476,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
           onClick: handleDeleteIconClick,
         })
       ) : (
-        <CancelIcon className={clsx(classes.deleteIcon)} onClick={handleDeleteIconClick} />
+        <CancelIcon className={classes.deleteIcon} onClick={handleDeleteIconClick} />
       );
   }
 
@@ -518,7 +518,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
       {...other}
     >
       {avatar || icon}
-      <ChipLabel className={clsx(classes.label)} ownerState={ownerState}>
+      <ChipLabel className={classes.label} ownerState={ownerState}>
         {label}
       </ChipLabel>
       {deleteIcon}

--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -325,7 +325,7 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
     elementType: DialogContainer,
     externalForwardedProps,
     ownerState,
-    className: clsx(classes.container),
+    className: classes.container,
   });
 
   const [TransitionSlot, transitionSlotProps] = useSlot('transition', {

--- a/packages/mui-material/src/Slider/SliderValueLabel.tsx
+++ b/packages/mui-material/src/Slider/SliderValueLabel.tsx
@@ -33,7 +33,7 @@ export default function SliderValueLabel(props: SliderValueLabelProps) {
   return React.cloneElement(
     children,
     {
-      className: clsx(children.props.className),
+      className: children.props.className,
     },
     <React.Fragment>
       {children.props.children}


### PR DESCRIPTION
This pull request simplifies the codebase by removing unnecessary uses of the `clsx` utility in several components within the `material-ui` package