### PR TITLE
Joy UI chat template: move textAreaValue state inside MessageInput

### DIFF
--- a/docs/data/joy/getting-started/templates/messages/components/MessageInput.tsx
+++ b/docs/data/joy/getting-started/templates/messages/components/MessageInput.tsx
@@ -12,17 +12,16 @@ import FormatListBulletedRoundedIcon from '@mui/icons-material/FormatListBullete
 import SendRoundedIcon from '@mui/icons-material/SendRounded';
 
 export type MessageInputProps = {
-  textAreaValue: string;
-  setTextAreaValue: (value: string) => void;
-  onSubmit: () => void;
+  onSubmit: (textAreaValue: string) => void;
 };
 
 export default function MessageInput(props: MessageInputProps) {
-  const { textAreaValue, setTextAreaValue, onSubmit } = props;
+  const { onSubmit } = props;
+  const [textAreaValue, setTextAreaValue] = React.useState('');
   const textAreaRef = React.useRef<HTMLDivElement>(null);
   const handleClick = () => {
     if (textAreaValue.trim() !== '') {
-      onSubmit();
+      onSubmit(textAreaValue);
       setTextAreaValue('');
     }
   };

--- a/docs/data/joy/getting-started/templates/messages/components/MessagesPane.tsx
+++ b/docs/data/joy/getting-started/templates/messages/components/MessagesPane.tsx
@@ -15,7 +15,6 @@ type MessagesPaneProps = {
 export default function MessagesPane(props: MessagesPaneProps) {
   const { chat } = props;
   const [chatMessages, setChatMessages] = React.useState(chat.messages);
-  const [textAreaValue, setTextAreaValue] = React.useState('');
 
   React.useEffect(() => {
     setChatMessages(chat.messages);
@@ -65,9 +64,7 @@ export default function MessagesPane(props: MessagesPaneProps) {
         </Stack>
       </Box>
       <MessageInput
-        textAreaValue={textAreaValue}
-        setTextAreaValue={setTextAreaValue}
-        onSubmit={() => {
+        onSubmit={(textAreaValue) => {
           const newId = chatMessages.length + 1;
           const newIdString = newId.toString();
           setChatMessages([


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Storing `textAreaValue` state in MessagesPane component caused rerenders of the entire MessagesPane component (including all chat messages) every time the user typed a character, causing noticeable input lag.

This is fixed by storing state inside MessageInput, so typing only rerenders MessageInput, not all chat messages from MessagesPane. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
