### PR TITLE
[joy-ui][Modal] Is it expected for actions to be presented inverted #42185

### DIFF
--- a/packages/mui-joy/src/DialogActions/DialogActions.tsx
+++ b/packages/mui-joy/src/DialogActions/DialogActions.tsx
@@ -43,7 +43,7 @@ const DialogActions = React.forwardRef(function DialogActions(inProps, ref) {
     component = 'div',
     children,
     buttonFlex,
-    orientation = 'horizontal-reverse',
+    orientation = 'horizontal',
     slots = {},
     slotProps = {},
     ...other
@@ -91,9 +91,9 @@ DialogActions.propTypes /* remove-proptypes */ = {
   component: PropTypes.elementType,
   /**
    * The component orientation.
-   * @default 'horizontal-reverse'
+   * @default 'horizontal'
    */
-  orientation: PropTypes.oneOf(['horizontal-reverse', 'horizontal', 'vertical']),
+  orientation: PropTypes.oneOf(['horizontal','horizontal-reverse', 'vertical']),
   /**
    * The props used for each slot inside.
    * @default {}


### PR DESCRIPTION
The current default behavior of the `DialogActions` component in Joy UI sets `orientation` to `'vertical'` if not specified, which can lead to inverted or unintuitive layouts — especially for common use cases like displaying multiple buttons (e.g., Cancel/Confirm). This can cause confusion in both visual flow and keyboard navigation.

This commit updates the default `orientation` of `DialogActions` to `'horizontal'`, which aligns better with standard dialog action layouts, improves accessibility, and prevents unexpected stacking of child components.

The change ensures:

- More intuitive visual alignment of components inside dialogs (left-to-right or right-to-left instead of top-to-bottom).
- Better accessibility and keyboard navigation for users relying on assistive technologies.
- Consistency with MUI Core’s Material Design guidelines for dialog actions.

BREAKING CHANGE: None

Closes: #42185
