### PR TITLE
[docs][Grid] Remove direction `column` and `column-reverse` from the demo

### DIFF
--- a/docs/data/material/components/grid/InteractiveGrid.js
+++ b/docs/data/material/components/grid/InteractiveGrid.js
@@ -75,16 +75,6 @@ export default function InteractiveGrid() {
                     control={<Radio />}
                     label="row-reverse"
                   />
-                  <FormControlLabel
-                    value="column"
-                    control={<Radio />}
-                    label="column"
-                  />
-                  <FormControlLabel
-                    value="column-reverse"
-                    control={<Radio />}
-                    label="column-reverse"
-                  />
                 </RadioGroup>
               </FormControl>
             </Grid>

--- a/docs/data/material/components/grid/InteractiveGrid.tsx
+++ b/docs/data/material/components/grid/InteractiveGrid.tsx
@@ -93,16 +93,6 @@ export default function InteractiveGrid() {
                     control={<Radio />}
                     label="row-reverse"
                   />
-                  <FormControlLabel
-                    value="column"
-                    control={<Radio />}
-                    label="column"
-                  />
-                  <FormControlLabel
-                    value="column-reverse"
-                    control={<Radio />}
-                    label="column-reverse"
-                  />
                 </RadioGroup>
               </FormControl>
             </Grid>


### PR DESCRIPTION
Fixes #46110

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
