### PR TITLE
[code-infra] Remove unnecessary ref from `HighlightedCode` component

### DIFF
--- a/packages/mui-docs/src/HighlightedCode/HighlightedCode.tsx
+++ b/packages/mui-docs/src/HighlightedCode/HighlightedCode.tsx
@@ -32,7 +32,7 @@ export interface HighlightedCodeProps {
   sx?: SxProps;
 }
 
-export const HighlightedCode = (props: HighlightedCodeProps) => {
+export function HighlightedCode(props: HighlightedCodeProps) {
   const {
     code,
     copyButtonHidden = false,
@@ -68,4 +68,4 @@ export const HighlightedCode = (props: HighlightedCodeProps) => {
       </div>
     </Component>
   );
-};
+}

--- a/packages/mui-docs/src/HighlightedCode/HighlightedCode.tsx
+++ b/packages/mui-docs/src/HighlightedCode/HighlightedCode.tsx
@@ -32,40 +32,40 @@ export interface HighlightedCodeProps {
   sx?: SxProps;
 }
 
-export const HighlightedCode = React.forwardRef<HTMLDivElement, HighlightedCodeProps>(
-  function HighlightedCode(props, ref) {
-    const {
-      code,
-      copyButtonHidden = false,
-      copyButtonProps,
-      language,
-      plainStyle,
-      parentComponent: Component = plainStyle ? React.Fragment : MarkdownElement,
-      preComponent: PreComponent = plainStyle ? Pre : 'pre',
-      ...other
-    } = props;
-    const renderedCode = React.useMemo(() => {
-      return prism(code.trim(), language);
-    }, [code, language]);
-    const handlers = useCodeCopy();
+export const HighlightedCode = (props: HighlightedCodeProps) => {
+  const {
+    code,
+    copyButtonHidden = false,
+    copyButtonProps,
+    language,
+    plainStyle,
+    parentComponent: Component = plainStyle ? React.Fragment : MarkdownElement,
+    preComponent: PreComponent = plainStyle ? Pre : 'pre',
+    ...other
+  } = props;
+  const renderedCode = React.useMemo(() => {
+    return prism(code.trim(), language);
+  }, [code, language]);
+  const handlers = useCodeCopy();
 
-    return (
-      <Component ref={ref} {...other}>
-        <div className="MuiCode-root" {...handlers} style={{ height: '100%' }}>
-          {copyButtonHidden ? null : (
-            <NoSsr>
-              <CodeCopyButton code={code} {...copyButtonProps} />
-            </NoSsr>
-          )}
-          <PreComponent>
-            <code
-              className={`language-${language}`}
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: renderedCode }}
-            />
-          </PreComponent>
-        </div>
-      </Component>
-    );
-  },
-);
+  const componentProps = !plainStyle ? other : undefined;
+
+  return (
+    <Component {...componentProps}>
+      <div className="MuiCode-root" {...handlers} style={{ height: '100%' }}>
+        {copyButtonHidden ? null : (
+          <NoSsr>
+            <CodeCopyButton code={code} {...copyButtonProps} />
+          </NoSsr>
+        )}
+        <PreComponent>
+          <code
+            className={`language-${language}`}
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: renderedCode }}
+          />
+        </PreComponent>
+      </div>
+    </Component>
+  );
+};


### PR DESCRIPTION
Fixes this warning in development mode:

![Screenshot (52)](https://github.com/user-attachments/assets/7707bbfc-05b6-4155-a062-f62bb5c6c438)

When `plainStyle` is true, the root becomes `React.Fragment`, which doesn't support the `ref` prop. 

Since no parent component uses a ref on `HighlightedCode`, I removed `forwardRef`. I also checked this in MUI X and Toolpad.

Also made sure `other` is spread only when using `MarkdownElement`.
