### PR TITLE
Add watch mode using chokidar in buildTypes script

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "chalk": "^5.4.1",
+    "chokidar": "^4.0.3",
     "compression-webpack-plugin": "^11.1.0",
     "concurrently": "^9.1.2",
     "cpy-cli": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
+      chokidar:
+        specifier: ^4.0.3
+        version: 4.0.3
       compression-webpack-plugin:
         specifier: ^11.1.0
         version: 11.1.0(webpack@5.99.8)
@@ -327,7 +330,7 @@ importers:
         version: 37.0.0(stylelint@16.19.1(typescript@5.8.3))
       terser-webpack-plugin:
         specifier: ^5.3.14
-        version: 5.3.14(webpack@5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8)))
+        version: 5.3.14(webpack@5.99.8)
       tsconfig-paths-webpack-plugin:
         specifier: ^4.2.0
         version: 4.2.0
@@ -348,7 +351,7 @@ importers:
         version: 0.7.1(vite@6.0.15(@types/node@20.17.48)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(vitest@3.1.3)
       webpack:
         specifier: ^5.99.8
-        version: 5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))
+        version: 5.99.8(webpack-cli@6.0.1)
       webpack-bundle-analyzer:
         specifier: ^4.10.2
         version: 4.10.2
@@ -2182,7 +2185,7 @@ importers:
         version: 11.3.0
       html-webpack-plugin:
         specifier: ^5.6.3
-        version: 5.6.3(webpack@5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8)))
+        version: 5.6.3(webpack@5.99.8(webpack-cli@6.0.1))
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -2221,7 +2224,7 @@ importers:
         version: 1.6.28
       webpack:
         specifier: ^5.99.8
-        version: 5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))
+        version: 5.99.8(webpack-cli@6.0.1)
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -18378,19 +18381,19 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))(webpack@5.99.8)':
+  '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.99.8)':
     dependencies:
-      webpack: 5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))
+      webpack: 5.99.8(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8)
 
-  '@webpack-cli/info@3.0.1(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))(webpack@5.99.8)':
+  '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.99.8)':
     dependencies:
-      webpack: 5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))
+      webpack: 5.99.8(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8)
 
-  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))(webpack@5.99.8)':
+  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack@5.99.8)':
     dependencies:
-      webpack: 5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))
+      webpack: 5.99.8(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8)
 
   '@whatwg-node/disposablestack@0.0.6':
@@ -18885,7 +18888,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.1
       find-up: 5.0.0
-      webpack: 5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))
+      webpack: 5.99.8(webpack-cli@6.0.1)
 
   babel-merge@3.0.0(@babel/core@7.27.1):
     dependencies:
@@ -19651,7 +19654,7 @@ snapshots:
     dependencies:
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
-      webpack: 5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))
+      webpack: 5.99.8(webpack-cli@6.0.1)
 
   compression@1.7.4:
     dependencies:
@@ -20819,7 +20822,7 @@ snapshots:
       lodash: 4.17.21
       resolve: 2.0.0-next.5
       semver: 5.7.2
-      webpack: 5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))
+      webpack: 5.99.8(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21982,7 +21985,7 @@ snapshots:
       readable-stream: 1.0.34
       through2: 0.4.2
 
-  html-webpack-plugin@5.6.3(webpack@5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))):
+  html-webpack-plugin@5.6.3(webpack@5.99.8(webpack-cli@6.0.1)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -21990,7 +21993,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))
+      webpack: 5.99.8(webpack-cli@6.0.1)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -22934,7 +22937,7 @@ snapshots:
     dependencies:
       glob: 7.2.3
       minimatch: 3.1.2
-      webpack: 5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))
+      webpack: 5.99.8(webpack-cli@6.0.1)
       webpack-merge: 4.2.2
 
   karma@6.4.4:
@@ -26907,14 +26910,14 @@ snapshots:
     dependencies:
       rimraf: 2.6.3
 
-  terser-webpack-plugin@5.3.14(webpack@5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))):
+  terser-webpack-plugin@5.3.14(webpack@5.99.8):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.39.0
-      webpack: 5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))
+      webpack: 5.99.8(webpack-cli@6.0.1)
 
   terser@5.39.0:
     dependencies:
@@ -27587,9 +27590,9 @@ snapshots:
   webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8):
     dependencies:
       '@discoveryjs/json-ext': 0.6.3
-      '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))(webpack@5.99.8)
-      '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))(webpack@5.99.8)
-      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))(webpack@5.99.8)
+      '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1)(webpack@5.99.8)
+      '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1)(webpack@5.99.8)
+      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1)(webpack@5.99.8)
       colorette: 2.0.20
       commander: 12.1.0
       cross-spawn: 7.0.6
@@ -27598,7 +27601,7 @@ snapshots:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8))
+      webpack: 5.99.8(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
@@ -27617,7 +27620,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8)):
+  webpack@5.99.8(webpack-cli@6.0.1):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.7
@@ -27640,7 +27643,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.2
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.14(webpack@5.99.8(webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.99.8)))
+      terser-webpack-plugin: 5.3.14(webpack@5.99.8)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/scripts/buildTypes.mts
+++ b/scripts/buildTypes.mts
@@ -5,6 +5,7 @@ import yargs from 'yargs';
 import { $ } from 'execa';
 import * as babel from '@babel/core';
 import { parse } from 'jsonc-parser';
+import chokidar from 'chokidar';
 
 const $$ = $({ stdio: 'inherit' });
 
@@ -57,15 +58,10 @@ async function copyDeclarations(sourceDirectory: string, destinationDirectory: s
   await fs.cp(fullSourceDirectory, fullDestinationDirectory, {
     recursive: true,
     filter: async (src) => {
-      if (src.startsWith('.')) {
-        // ignore dotfiles
-        return false;
-      }
+      // eslint-disable-next-line curly
+      if (src.startsWith('.')) return false;
       const stats = await fs.stat(src);
-      if (stats.isDirectory()) {
-        return true;
-      }
-      return src.endsWith('.d.ts');
+      return stats.isDirectory() || src.endsWith('.d.ts');
     },
   });
 }
@@ -74,6 +70,7 @@ interface HandlerArgv {
   skipTsc: boolean;
   copy: string[];
   removeCss: boolean;
+  watch?: boolean;
 }
 
 async function main(argv: HandlerArgv) {
@@ -139,9 +136,50 @@ yargs(process.argv.slice(2))
           type: 'boolean',
           default: false,
           describe: 'Set to `true` if you want to remove the css imports in the type definitions',
+        })
+        .option('watch', {
+          type: 'boolean',
+          default: false,
+          describe: 'Watch mode: rebuild when source files change',
         });
     },
-    main,
+    async (argv) => {
+      if (argv.watch) {
+        // eslint-disable-next-line no-console
+        console.log('[watch] Starting in watch mode...');
+
+        let isBuilding = false;
+        const build = async () => {
+          // eslint-disable-next-line curly
+          if (isBuilding) return;
+          isBuilding = true;
+          try {
+            await main(argv);
+            // eslint-disable-next-line no-console
+            console.log('[watch] Build complete');
+          } catch (err) {
+            console.error('[watch] Build failed:', err);
+          } finally {
+            isBuilding = false;
+          }
+        };
+
+        await build();
+
+        chokidar
+          .watch(['src/**/*.ts', 'src/**/*.d.ts'], {
+            ignoreInitial: true,
+          })
+          // eslint-disable-next-line @typescript-eslint/no-shadow
+          .on('all', async (event, path) => {
+            // eslint-disable-next-line no-console
+            console.log(`[watch] ${event}: ${path}`);
+            await build();
+          });
+      } else {
+        await main(argv);
+      }
+    },
   )
   .help()
   .strict(true)


### PR DESCRIPTION
Implement watch mode to rebuild when source files change by integrating chokidar into the buildTypes script. This enhancement allows for more efficient development by automatically rebuilding on file changes.

This pull request is to implement `pnpm dev` in the MUI Toolpad repo.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).