### PR TITLE
Create MUI Symbols Library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ docs/public/static/blog/feed/*
 .nx/workspace-data
 screenshots
 packed
+
+# temp for clean diff in dev
+packages/mui-symbols-material/material-symbols
+packages/mui-symbols-material/lib

--- a/packages/mui-material/src/VariableIcon/VariableIcon.d.ts
+++ b/packages/mui-material/src/VariableIcon/VariableIcon.d.ts
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { OverridableStringUnion } from '@mui/types';
+import { Theme } from '../styles';
+import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { VariableIconClasses } from './variableIconClasses';
+
+export interface VariableIconPropsSizeOverrides {}
+
+export interface VariableIconPropsColorOverrides {}
+
+export interface VariableIconOwnProps {
+  /**
+   * Node passed into the icon element.
+   */
+  children?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<VariableIconClasses>;
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
+   * @default 'inherit'
+   */
+  color?: OverridableStringUnion<
+    | 'inherit'
+    | 'action'
+    | 'disabled'
+    | 'primary'
+    | 'secondary'
+    | 'error'
+    | 'info'
+    | 'success'
+    | 'warning',
+    VariableIconPropsColorOverrides
+  >;
+  /**
+   * The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.
+   * @default 'medium'
+   */
+  fontSize?: OverridableStringUnion<
+    'inherit' | 'larger' | 'large' | 'medium' | 'small',
+    VariableIconPropsSizeOverrides
+  >;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+  /**
+   * Provides a human-readable title for the element that contains it.
+   */
+  title?: string;
+  /**
+   * Indicates if the icon should be filled.
+   */
+  filled?: boolean;
+  /**
+   * Allows increasing or decreasing emphasis.
+   */
+  emphasis?: 'light' | 'regular' | 'heavy';
+}
+
+export interface VariableIconTypeMap<
+  AdditionalProps = {},
+  RootComponent extends React.ElementType = 'span',
+> {
+  props: AdditionalProps & VariableIconOwnProps;
+  defaultComponent: RootComponent;
+}
+/**
+ *
+ * Demos:
+ *
+ * - [Variable Icons](https://mui.com/material-ui/variable-icons/)
+ * - [Material Symbols](https://mui.com/material-ui/material-symbols/)
+ *
+ * API:
+ *
+ * - [VariableIcon API](https://mui.com/material-ui/api/variable-icon/)
+ */
+declare const VariableIcon: OverridableComponent<VariableIconTypeMap> & { muiName: string };
+
+export type VariableIconProps<
+  RootComponent extends React.ElementType = VariableIconTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<VariableIconTypeMap<AdditionalProps, RootComponent>, RootComponent> & {
+  component?: React.ElementType;
+};
+
+export default VariableIcon;

--- a/packages/mui-material/src/VariableIcon/VariableIcon.js
+++ b/packages/mui-material/src/VariableIcon/VariableIcon.js
@@ -1,0 +1,211 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import composeClasses from '@mui/utils/composeClasses';
+import capitalize from '../utils/capitalize';
+import { styled } from '../zero-styled';
+import memoTheme from '../utils/memoTheme';
+import { useDefaultProps } from '../DefaultPropsProvider';
+import { getVariableIconUtilityClass } from './variableIconClasses';
+
+export function fontSizes(theme) {
+  return (
+    {
+      props: { fontSize: 'small' },
+      style: { fontSize: theme.typography?.pxToRem?.(20) || '1.25rem' },
+    },
+    {
+      props: { fontSize: 'medium' },
+      style: { fontSize: theme.typography?.pxToRem?.(24) || '1.5rem' },
+    },
+    {
+      props: { fontSize: 'large' },
+      style: { fontSize: theme.typography?.pxToRem?.(40) || '2.5rem' },
+    },
+    {
+      props: { fontSize: 'larger' },
+      style: { fontSize: theme.typography?.pxToRem?.(48) || '3rem' },
+    }
+  );
+}
+
+const useUtilityClasses = (ownerState) => {
+  const { color, fontSize, classes } = ownerState;
+
+  const slots = {
+    root: [
+      'root',
+      color !== 'inherit' && `color${capitalize(color)}`,
+      `fontSize${capitalize(fontSize)}`,
+    ],
+  };
+
+  return composeClasses(slots, getVariableIconUtilityClass, classes);
+};
+
+const VariableIconRoot = styled('span', {
+  name: 'MuiVariableIcon',
+  slot: 'Root',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+
+    return [
+      styles.root,
+      ownerState.color !== 'inherit' && styles[`color${capitalize(ownerState.color)}`],
+      styles[`fontSize${capitalize(ownerState.fontSize)}`],
+    ];
+  },
+})(
+  memoTheme(({ theme }) => ({
+    userSelect: 'none',
+    width: '1em',
+    height: '1em',
+    display: 'inline-block',
+    flexShrink: 0,
+    transition: theme.transitions?.create?.('fill', {
+      duration: (theme.vars ?? theme).transitions?.duration?.shorter,
+    }),
+    variants: [
+      {
+        props: { fontSize: 'inherit' },
+        style: { fontSize: 'inherit' },
+      },
+      ...fontSizes(theme),
+      // TODO v5 deprecate color prop, v6 remove for sx
+      ...Object.entries((theme.vars ?? theme).palette)
+        .filter(([, value]) => value && value.main)
+        .map(([color]) => ({
+          props: { color },
+          style: { color: (theme.vars ?? theme).palette?.[color]?.main },
+        })),
+      {
+        props: { color: 'action' },
+        style: { color: (theme.vars ?? theme).palette?.action?.active },
+      },
+      {
+        props: { color: 'disabled' },
+        style: { color: (theme.vars ?? theme).palette?.action?.disabled },
+      },
+      {
+        props: { color: 'inherit' },
+        style: { color: undefined },
+      },
+    ],
+  })),
+);
+
+const VariableIcon = React.forwardRef(function VariableIcon(inProps, ref) {
+  const props = useDefaultProps({ props: inProps, name: 'MuiVariableIcon' });
+  const {
+    children,
+    className,
+    color = 'inherit',
+    component = 'span',
+    fontSize = 'medium',
+    title,
+    ...other
+  } = props;
+
+  const ownerState = {
+    ...props,
+    color,
+    component,
+    fontSize,
+    instanceFontSize: inProps.fontSize,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  return (
+    <VariableIconRoot
+      as={component}
+      className={clsx(classes.root, className)}
+      focusable="false"
+      aria-hidden={title ? undefined : true}
+      role={title ? 'img' : undefined}
+      aria-label={title}
+      ref={ref}
+      {...other}
+      ownerState={ownerState}
+    >
+      {children}
+    </VariableIconRoot>
+  );
+});
+
+VariableIcon.propTypes /* remove-proptypes */ = {
+  // ┌────────────────────────────── Warning ──────────────────────────────┐
+  // │ These PropTypes are generated from the TypeScript type definitions. │
+  // │    To update them, edit the d.ts file and run `pnpm proptypes`.     │
+  // └─────────────────────────────────────────────────────────────────────┘
+  /**
+   * Node passed into the icon element.
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
+   * @default 'inherit'
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf([
+      'inherit',
+      'action',
+      'disabled',
+      'primary',
+      'secondary',
+      'error',
+      'info',
+      'success',
+      'warning',
+    ]),
+    PropTypes.string,
+  ]),
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * Allows increasing or decreasing emphasis.
+   */
+  emphasis: PropTypes.oneOf(['heavy', 'light', 'regular']),
+  /**
+   * Indicates if the icon should be filled.
+   */
+  filled: PropTypes.bool,
+  /**
+   * The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.
+   * @default 'medium'
+   */
+  fontSize: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['inherit', 'larger', 'large', 'medium', 'small']),
+    PropTypes.string,
+  ]),
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * Provides a human-readable title for the element that contains it.
+   */
+  title: PropTypes.string,
+};
+
+VariableIcon.muiName = 'SvgIcon';
+
+export default VariableIcon;

--- a/packages/mui-material/src/VariableIcon/index.d.ts
+++ b/packages/mui-material/src/VariableIcon/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './VariableIcon';
+export * from './VariableIcon';
+
+export { default as variableIconClasses } from './variableIconClasses';
+export * from './variableIconClasses';

--- a/packages/mui-material/src/VariableIcon/index.js
+++ b/packages/mui-material/src/VariableIcon/index.js
@@ -1,0 +1,4 @@
+export { default } from './VariableIcon';
+
+export { default as variableIconClasses } from './variableIconClasses';
+export * from './variableIconClasses';

--- a/packages/mui-material/src/VariableIcon/variableIconClasses.ts
+++ b/packages/mui-material/src/VariableIcon/variableIconClasses.ts
@@ -1,0 +1,49 @@
+import generateUtilityClasses from '@mui/utils/generateUtilityClasses';
+import generateUtilityClass from '@mui/utils/generateUtilityClass';
+
+export interface VariableIconClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `color="primary"`. */
+  colorPrimary: string;
+  /** Styles applied to the root element if `color="secondary"`. */
+  colorSecondary: string;
+  /** Styles applied to the root element if `color="action"`. */
+  colorAction: string;
+  /** Styles applied to the root element if `color="error"`. */
+  colorError: string;
+  /** Styles applied to the root element if `color="disabled"`. */
+  colorDisabled: string;
+  /** Styles applied to the root element if `fontSize="inherit"`. */
+  fontSizeInherit: string;
+  /** Styles applied to the root element if `fontSize="small"`. */
+  fontSizeSmall: string;
+  /** Styles applied to the root element if `fontSize="medium"`. */
+  fontSizeMedium: string;
+  /** Styles applied to the root element if `fontSize="large"`. */
+  fontSizeLarge: string;
+  /** Styles applied to the root element if `fontSize="larger"`. */
+  fontSizeLarger: string;
+}
+
+export type VariableIconClassKey = keyof VariableIconClasses;
+
+export function getVariableIconUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiVariableIcon', slot);
+}
+
+const variableIconClasses: VariableIconClasses = generateUtilityClasses('MuiVariableIcon', [
+  'root',
+  'colorPrimary',
+  'colorSecondary',
+  'colorAction',
+  'colorError',
+  'colorDisabled',
+  'fontSizeInherit',
+  'fontSizeSmall',
+  'fontSizeMedium',
+  'fontSizeLarge',
+  'fontSizeLarger',
+]);
+
+export default variableIconClasses;

--- a/packages/mui-material/src/utils/createVariableIconFromSvg.d.ts
+++ b/packages/mui-material/src/utils/createVariableIconFromSvg.d.ts
@@ -1,0 +1,8 @@
+import VariableIcon from '../VariableIcon';
+import { Theme } from '../styles/createTheme';
+
+export default function createVariableIconFromSvg<P = Record<string, any>, T = Theme>(
+  variants: Record<string, React.ReactNode>,
+  propsToVariantName: (props: P, theme: T) => string,
+  displayName: string,
+): typeof VariableIcon;

--- a/packages/mui-material/src/utils/createVariableIconFromSvg.js
+++ b/packages/mui-material/src/utils/createVariableIconFromSvg.js
@@ -1,0 +1,99 @@
+'use client';
+
+import * as React from 'react';
+import VariableIcon, { fontSizes } from '../VariableIcon';
+import SvgIcon from '../SvgIcon';
+import { useTheme } from '../styles';
+
+function fontVariantsToPx(fontSize, fontVariants) {
+  if (!Number.isNaN(Number(fontSize))) {
+    return Number(fontSize);
+  }
+
+  if (fontSize.endsWith('px')) {
+    return Number(fontSize.slice(0, -2));
+  }
+
+  if (fontSize.endsWith('rem')) {
+    return Number(fontSize.slice(0, -3)) * 16;
+  }
+
+  if (fontSize === 'inherit') {
+    return -1;
+  }
+
+  const fontVariant = fontVariants.find((variant) => variant.props.fontSize === fontSize);
+  if (fontVariant) {
+    return Number(fontVariant.style.fontSize.slice(0, -3)) * 16;
+  }
+
+  // Fallback to default size
+  return 24;
+}
+
+function propsToVariantName(props, theme) {
+  let size;
+  if (props.fontSize < 22) {
+    size = '20px'; // small
+  } else if (props.fontSize < 31) {
+    size = '24px'; // medium
+  } else if (props.fontSize < 43) {
+    size = '40px'; // large
+  } else {
+    size = '48px'; // larger
+  }
+
+  let emphasis = ''; // regular
+  if (theme.colorSchemes.dark || props.emphasis === 'light') {
+    // If the theme is dark, we should lighten the icon to reduce glare.
+    // https://m3.material.io/styles/icons/applying-icons#9103e57b-6251-49b7-91d1-51a6069addb2
+    emphasis = '-light';
+  } else if (props.emphasis === 'heavy') {
+    emphasis = '-heavy';
+  }
+
+  let filled = '';
+  if (props.filled) {
+    filled = '-filled';
+  }
+
+  return `${size}${emphasis}${filled}`;
+}
+
+/**
+ * Private module reserved for @mui packages.
+ */
+export default function createVariableIconFromSvgPath(variants, displayName, viewBox) {
+  function Component(props, ref) {
+    const theme = useTheme();
+    const fontVariants = fontSizes(theme);
+    const size = fontVariantsToPx(props.fontSize, fontVariants);
+    const variantName = propsToVariantName({ ...props, fontSize: size }, theme);
+
+    const { title, ...variableIconProps } = props;
+
+    return (
+      <VariableIcon
+        data-testid={process.env.NODE_ENV !== 'production' ? `${displayName}Icon` : undefined}
+        data-variant={process.env.NODE_ENV !== 'production' ? variantName : undefined}
+        ref={ref}
+        {...variableIconProps}
+      >
+        <SvgIcon fontSize={`${size}px`} viewBox={viewBox || '0 -960 960 960'} titleAccess={title}>
+          <path d={variants[variantName]} />
+        </SvgIcon>
+      </VariableIcon>
+    );
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    // Need to set `displayName` on the inner component for React.memo.
+    // React prior to 16.14 ignores `displayName` on the wrapper.
+    Component.displayName = `${displayName}Icon`;
+  }
+
+  Component.muiName = VariableIcon.muiName;
+  Component.propTypes = VariableIcon.propTypes;
+
+  return React.memo(React.forwardRef(Component));
+}

--- a/packages/mui-symbols-material/.eslintrc.js
+++ b/packages/mui-symbols-material/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  rules: {
+    // needed for mustache and temp
+    'import/no-unresolved': 'off',
+    'import/extensions': 'off',
+  },
+};

--- a/packages/mui-symbols-material/README.md
+++ b/packages/mui-symbols-material/README.md
@@ -1,0 +1,35 @@
+# @mui/symbols-material
+
+<!-- #host-reference -->
+
+This package contains Google's [Material Symbols](https://fonts.google.com/icons?icon.set=Material+Symbols) converted to Material UI [SVG Icon](https://mui.com/material-ui/icons/#svgicon) components.
+
+## Installation
+
+The Material Icons package depends on Material UI—install both with the following command:
+
+<!-- #npm-tag-reference -->
+
+```bash
+npm install @mui/symbols-material @mui/material @emotion/styled @emotion/react
+```
+
+## Documentation
+
+<!-- #host-reference -->
+
+- Learn more about Material UI's [SVG Icon component](https://mui.com/material-ui/icons/#svgicon).
+- Browse the available icons on the [Material Symbols page](https://mui.com/material-ui/material-symbols/).
+
+## Contributing
+
+The Symbols package is updated via a script that reads through Google's Material Symbols set and extracts the SVG elements from there. Because of this, we don't accept new icons that diverge from the source.
+
+To update the `@mui/symbols-material` package with the latest Material Icons set, run the following commands:
+
+1. In the "mui-symbols-material" directory, run `pnpm src:download`
+2. In the "mui-symbols-material" directory, run `pnpm src:icons`
+3. In the root of the Material UI repo, run `pnpm docs:mdicons:synonyms`
+4. If the number of icons changes significantly, edit the icons/icons.md and material-icons/material-icons.md under docs/data/material/components and update the numbers.
+
+This process is performed by the maintainers on a quarterly basis.

--- a/packages/mui-symbols-material/README.md
+++ b/packages/mui-symbols-material/README.md
@@ -28,7 +28,7 @@ The Symbols package is updated via a script that reads through Google's Material
 To update the `@mui/symbols-material` package with the latest Material Icons set, run the following commands:
 
 1. In the "mui-symbols-material" directory, run `pnpm src:download`
-2. In the "mui-symbols-material" directory, run `pnpm src:icons`
+2. In the "mui-symbols-material" directory, run `pnpm src:symbols`
 3. In the root of the Material UI repo, run `pnpm docs:mdicons:synonyms`
 4. If the number of icons changes significantly, edit the icons/icons.md and material-icons/material-icons.md under docs/data/material/components and update the numbers.
 

--- a/packages/mui-symbols-material/builder.md
+++ b/packages/mui-symbols-material/builder.md
@@ -1,0 +1,37 @@
+# @mui/icons-material-builder
+
+This tool generates Material UI SvgIcon components for a set of svg icons.
+
+## Running the build
+
+The build script downloads and builds the Material Design Symbols.
+
+```bash
+pnpm install
+pnpm build
+cd build
+pnpm publish
+```
+
+## Generated folders
+
+The build script downloads Material Design SVG icons to the `material-symbols` folder,
+generates the appropriate `.js` files in the `build` folder, and creates a `package.json`.
+
+## Advanced usage and Custom builds
+
+`node build.js --help` can be used to display the options available for building.
+
+You can build your own SVG icons as well as collections like [game-icons](https://game-icons.net/)
+through command line options.
+
+- `--output-dir` - Directory to output generated components.
+- `--svg-dir` - Directory containing the source SVG icons.
+- `--inner-path` - "Reach into" subdirs, since libraries like material-design-icons
+  use arbitrary build directories to organize icons, for example "action/svg/production/".
+- `--file-suffix` - Process only files ending with the specified suffix/
+- `--variant-collector` - Merge variants into a single file that will be outputted. For example, with Material Symbols, we merge `optical_size`, `grade`, and `filled` variants into a single file.
+
+If you experience any issues building icons or would like a feature added,
+[file an issue](https://github.com/mui/material-ui/issues) and let us
+know.

--- a/packages/mui-symbols-material/builder.mjs
+++ b/packages/mui-symbols-material/builder.mjs
@@ -1,0 +1,209 @@
+import path from 'path';
+import fse from 'fs-extra';
+import yargs from 'yargs';
+import { rimrafSync } from 'rimraf';
+import Mustache from 'mustache';
+import globAsync from 'fast-glob';
+import { fileURLToPath } from 'url';
+import intersection from 'lodash/intersection.js';
+import { Queue } from '@mui/internal-waterfall';
+
+const currentDirectory = fileURLToPath(new URL('.', import.meta.url));
+
+export const RENAME_FILTER_DEFAULT = './renameFilters/default.mjs';
+
+/**
+ * Converts directory separators to slashes, so the path can be used in fast-glob.
+ * @param {string} pathToNormalize
+ * @returns
+ */
+function normalizePath(pathToNormalize) {
+  return pathToNormalize.replace(/\\/g, '/');
+}
+
+/**
+ * Return Pascal-Cased component name.
+ * @param {string} destPath
+ * @returns {string} class name
+ */
+export function getComponentName(destPath) {
+  const splitregex = new RegExp(`[\\${path.sep}-]+`);
+
+  const parts = destPath
+    .replace('.js', '')
+    .split(splitregex)
+    .map((part) => part.charAt(0).toUpperCase() + part.substring(1));
+
+  return parts.join('');
+}
+
+async function worker({ progress, outputFile, options, template }) {
+  progress();
+
+  const { fileName, variants } = outputFile;
+
+  const outputFileDir = path.dirname(path.join(options.outputDir, fileName));
+  await fse.ensureDir(outputFileDir);
+
+  const SVGs = await Promise.all(
+    Object.keys(variants).map(async (variant) => {
+      const svgPath = variants[variant];
+      const SVG = await fse.readFile(svgPath, { encoding: 'utf8' });
+      const data = SVG.replace(/<svg\b[^>]*><path d="/i, '') // strip opening tag
+        .replace(/"\/><\/svg>/i, '') // strip closing tag
+        .trim();
+
+      // we don't need to clean the SVGs singe we assume that Google has done a good job at this already
+      // cleaning may result in some kind of distortion considering they have optimized for perfect pixel placement
+
+      return { variant, data };
+    }),
+  );
+
+  let variantsData = '{\n';
+  SVGs.forEach((svg) => {
+    const { variant, data } = svg;
+    variantsData += `    '${variant}': '${data}',\n`;
+  });
+  variantsData += '  }';
+
+  const componentName = getComponentName(fileName.split(path.sep).pop());
+
+  const fileString = Mustache.render(template, {
+    variantsData,
+    componentName,
+  });
+
+  const absDestPath = path.join(options.outputDir, fileName);
+  await fse.writeFile(absDestPath, fileString);
+}
+
+export async function handler(options) {
+  const progress = options.disableLog ? () => {} : () => process.stdout.write('.');
+
+  rimrafSync(`${options.outputDir}/*.js`, { glob: true }); // Clean old files
+
+  let variantCollector = options.variantCollector;
+  if (typeof variantCollector === 'string') {
+    const variantCollectorModule = await import(variantCollector);
+    variantCollector = variantCollectorModule.default;
+  }
+  if (typeof variantCollector !== 'function') {
+    throw new Error('variantCollector must be a function');
+  }
+
+  let renameFilter = options.renameFilter;
+  if (typeof renameFilter === 'string') {
+    const renameFilterModule = await import(renameFilter);
+    renameFilter = renameFilterModule.default;
+  }
+  if (typeof renameFilter !== 'function') {
+    throw new Error('renameFilter must be a function');
+  }
+
+  await fse.ensureDir(options.outputDir);
+
+  if (!variantCollector) {
+    throw new Error('variantCollector is required');
+  }
+
+  const [paths, template] = await Promise.all([
+    globAsync(normalizePath(path.join(options.svgDir, options.glob))),
+    fse.readFile(path.join(currentDirectory, 'templateVariableIconFromSvg.js'), {
+      encoding: 'utf8',
+    }),
+  ]);
+
+  const outputFiles = variantCollector(paths, options.svgDir);
+
+  const queue = new Queue(
+    (outputFile) =>
+      worker({
+        progress,
+        outputFile,
+        options,
+        template,
+      }),
+    { concurrency: 8 },
+  );
+
+  queue.push(outputFiles);
+  await queue.wait({ empty: true });
+
+  let legacyFiles = await globAsync(normalizePath(path.join(currentDirectory, '/legacy', '*.js')));
+  legacyFiles = legacyFiles.map((file) => path.basename(file));
+  let generatedFiles = await globAsync(normalizePath(path.join(options.outputDir, '*.js')));
+  generatedFiles = generatedFiles.map((file) => path.basename(file));
+
+  const duplicatedIconsLegacy = intersection(legacyFiles, generatedFiles);
+  if (duplicatedIconsLegacy.length > 0) {
+    throw new Error(
+      `Duplicated icons in legacy folder. Either \n` +
+        `1. Remove these from the /legacy folder\n` +
+        `2. Add them to the blacklist to keep the legacy version\n` +
+        `The following icons are duplicated: \n${duplicatedIconsLegacy.join('\n')}`,
+    );
+  }
+
+  await fse.copy(path.join(currentDirectory, '/legacy'), options.outputDir);
+  await fse.copy(path.join(currentDirectory, '/custom'), options.outputDir);
+
+  // TOOD: generate barrel files
+}
+
+const nodePath = path.resolve(process.argv[1]);
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const isRunningDirectlyViaCLI = nodePath === modulePath;
+
+if (isRunningDirectlyViaCLI) {
+  yargs(process.argv.slice(2))
+    .command({
+      command: '$0>',
+      description: "Build JSX components from SVG's.",
+      handler,
+      builder: (command) => {
+        command
+          .option('output-dir', {
+            required: true,
+            type: 'string',
+            describe: 'Directory to output jsx components',
+          })
+          .option('svg-dir', {
+            required: true,
+            type: 'string',
+            describe: 'Directory to output jsx components',
+          })
+          .option('glob', {
+            type: 'string',
+            describe: 'Glob to match inside of --svg-dir',
+            default: '**/*.svg',
+          })
+          .option('inner-path', {
+            type: 'string',
+            describe:
+              '"Reach into" subdirs, since libraries like material-design-symbols' +
+              ' use arbitrary build directories to organize icons' +
+              ' e.g. "action/svg/production/icon_3d_rotation_24px.svg"',
+            default: '',
+          })
+          .option('file-suffix', {
+            type: 'string',
+            describe:
+              'Filter only files ending with a suffix (pretty much only for @mui/symbols-material)',
+          })
+          .option('variant-collector', {
+            type: 'string',
+            describe: 'Path to JS module used to collect variants into a single path.',
+          })
+          .option('disable-log', {
+            type: 'boolean',
+            describe: 'If true, does not produce any output in STDOUT.',
+            default: false,
+          });
+      },
+    })
+    .help()
+    .strict(true)
+    .version(false)
+    .parse();
+}

--- a/packages/mui-symbols-material/package.json
+++ b/packages/mui-symbols-material/package.json
@@ -1,0 +1,111 @@
+{
+  "name": "@mui/symbols-material",
+  "version": "7.1.0",
+  "author": "MUI Team",
+  "description": "Material Design symbols distributed as SVG React components.",
+  "main": "./src/index.js",
+  "keywords": [
+    "react",
+    "react-component",
+    "mui",
+    "material-ui",
+    "material design",
+    "icons",
+    "symbols"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mui/material-ui.git",
+    "directory": "packages/mui-symbols-material"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mui/material-ui/issues"
+  },
+  "homepage": "https://mui.com/material-ui/material-symbols/",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/mui-org"
+  },
+  "scripts": {
+    "build": "shx cp -r lib/ build/ && pnpm build:copy-files && pnpm build:typings && pnpm build:esm-pkg",
+    "build:esm-pkg": "node ./scripts/create-esm-package-json.mjs",
+    "build:lib": "pnpm build:node && pnpm build:stable",
+    "build:lib:clean": "rimraf lib/ && pnpm build:lib",
+    "build:node": "node ../../scripts/build.mjs node --largeFiles --outDir lib",
+    "build:stable": "node ../../scripts/build.mjs stable --largeFiles --outDir lib --skipEsmPkg",
+    "build:copy-files": "node ../../scripts/copyFiles.mjs",
+    "build:typings": "node ./scripts/create-typings.mjs",
+    "prebuild": "rimraf build",
+    "release": "pnpm build && pnpm publish",
+    "src:download": "node ./scripts/download.mjs",
+    "src:symbols": "cross-env UV_THREADPOOL_SIZE=64 node ./builder.mjs --output-dir src --svg-dir material-symbols --variant-collector ./variantCollectors/material-design-symbols.mjs && pnpm build:lib:clean",
+    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-symbols-material/**/*.test.?(c|m)[jt]s?(x)'",
+    "typescript": "tsc -p tsconfig.json",
+    "attw": "attw --pack ./build --exclude-entrypoints esm --include-entrypoints Close"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.27.1"
+  },
+  "devDependencies": {
+    "@mui/internal-waterfall": "workspace:^",
+    "@mui/material": "workspace:^",
+    "@mui/symbols-material": "workspace:*",
+    "@types/chai": "^4.3.20",
+    "@types/react": "^19.1.4",
+    "chai": "^4.5.0",
+    "chalk": "^5.4.1",
+    "cross-fetch": "^4.1.0",
+    "fast-glob": "^3.3.3",
+    "fs-extra": "^11.3.0",
+    "lodash": "^4.17.21",
+    "mustache": "^4.2.0",
+    "proper-lockfile": "^4.1.2",
+    "react": "^19.1.0",
+    "rimraf": "^6.0.1",
+    "shx": "^0.4.0",
+    "yargs": "^17.7.2"
+  },
+  "peerDependencies": {
+    "@mui/material": "workspace:^",
+    "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "directory": "build"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./esm/index.d.ts",
+        "default": "./esm/index.js"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      }
+    },
+    "./*": {
+      "import": {
+        "types": "./esm/*.d.ts",
+        "default": "./esm/*.js"
+      },
+      "require": {
+        "types": "./*.d.ts",
+        "default": "./*.js"
+      }
+    },
+    "./esm": null,
+    "./utils/*": null
+  }
+}

--- a/packages/mui-symbols-material/scripts/create-esm-package-json.mjs
+++ b/packages/mui-symbols-material/scripts/create-esm-package-json.mjs
@@ -1,0 +1,17 @@
+import path from 'path';
+import * as fs from 'fs/promises';
+import url from 'url';
+
+const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
+
+const TARGET_DIR_ESM = path.resolve(currentDirectory, '../build/esm');
+
+async function run() {
+  await fs.writeFile(
+    path.resolve(TARGET_DIR_ESM, 'package.json'),
+    JSON.stringify({ type: 'module', sideEffects: false }),
+    'utf8',
+  );
+}
+
+run();

--- a/packages/mui-symbols-material/scripts/create-typings.mjs
+++ b/packages/mui-symbols-material/scripts/create-typings.mjs
@@ -1,0 +1,78 @@
+/* eslint-disable no-console */
+import path from 'path';
+import chalk from 'chalk';
+import * as fs from 'fs/promises';
+import glob from 'fast-glob';
+import url from 'url';
+
+const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
+
+const SRC_DIR = path.resolve(currentDirectory, '../lib/esm');
+const TARGET_DIR = path.resolve(currentDirectory, '../build');
+const TARGET_DIR_ESM = path.resolve(currentDirectory, '../build/esm');
+
+function normalizeFileName(file) {
+  return path.parse(file).name;
+}
+
+async function createIconTypings(targetDir, files) {
+  const contents = `export { default } from '@mui/material/SvgIcon';`;
+
+  let index = 0;
+  const filesIterable = {
+    [Symbol.iterator]: () => ({
+      next() {
+        if (index >= files.length) {
+          return { done: true };
+        }
+        const nextFile = files[index];
+        index += 1;
+        return { value: nextFile, done: false };
+      },
+    }),
+  };
+
+  const createWorker = async () => {
+    for (const file of filesIterable) {
+      const iconName = normalizeFileName(file);
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(path.resolve(targetDir, `${iconName}.d.ts`), contents, 'utf8');
+    }
+  };
+
+  const concurrency = 50;
+  const workers = Array.from({ length: concurrency }, createWorker);
+
+  await Promise.all(workers);
+}
+
+async function createIndexTyping(targetDir, files) {
+  const contents = `
+import SvgIcon from '@mui/material/SvgIcon';
+
+type SvgIconComponent = typeof SvgIcon;
+
+${files.map((file) => `export const ${normalizeFileName(file)}: SvgIconComponent;`).join('\n')}
+`;
+
+  await fs.writeFile(path.resolve(targetDir, 'index.d.ts'), contents, 'utf8');
+}
+
+// Generate TypeScript.
+async function run() {
+  await Promise.all([
+    fs.mkdir(TARGET_DIR, { recursive: true }),
+    fs.mkdir(TARGET_DIR_ESM, { recursive: true }),
+  ]);
+  console.log(`\u{1f52c}  Searching for modules inside "${chalk.dim(SRC_DIR)}".`);
+  const files = await glob('!(index)*.js', { cwd: SRC_DIR });
+  await Promise.all([
+    createIconTypings(TARGET_DIR, files),
+    createIndexTyping(TARGET_DIR, files),
+    createIconTypings(TARGET_DIR_ESM, files),
+    createIndexTyping(TARGET_DIR_ESM, files),
+  ]);
+  console.log(`\u{1F5C4}  Written typings to ${chalk.dim(TARGET_DIR)}.`);
+}
+
+run();

--- a/packages/mui-symbols-material/scripts/download.mjs
+++ b/packages/mui-symbols-material/scripts/download.mjs
@@ -1,0 +1,292 @@
+/* eslint-disable no-console */
+import fetch from 'cross-fetch';
+import fse from 'fs-extra';
+import path from 'path';
+import yargs from 'yargs';
+import { fileURLToPath } from 'url';
+import { Queue, sleep, retry } from '@mui/internal-waterfall';
+import lockfile from 'proper-lockfile';
+
+const currentDirectory = fileURLToPath(new URL('.', import.meta.url));
+const versionFile = path.join(currentDirectory, '../meta/versions.json');
+
+// Icons we don't publish.
+// This is just a list of new icons.
+// In the future we might change what icons we want to exclude (for example by popularity)
+const ignoredIconNames = new Set([
+  // TODO v6: Whatsapp duplicates with WhatsApp
+  // We don't need it https://fonts.google.com/icons?icon.set=Material+Icons&icon.query=whatsapp
+  // 'whatsapp'
+  '123',
+  '6_ft_apart',
+  'add_chart', // Leads to inconsistent casing with `Addchart`
+  'exposure_neg_1', // Google product
+  'exposure_neg_2', // Google product
+  'exposure_plus_1', // Google product
+  'exposure_plus_2', // Google product
+  'exposure_zero', // Google product
+  'horizontal_distribute', // Advanced text editor
+  'motion_photos_on', // Google product
+  'motion_photos_pause', // Google product
+  'motion_photos_paused', // Google product
+  'polymer', // Legacy brand
+  'vertical_distribute', // Advanced text editor
+]);
+
+const legacyIconNames = new Set([]);
+
+const themes = ['outlined', 'rounded', 'sharp'];
+const familyMap = {
+  outlined: 'Material Symbols Outlined',
+  rounded: 'Material Symbols Rounded',
+  sharp: 'Material Symbols Sharp',
+};
+
+const variants = {
+  weight: [100, 200, 300, 400, 500, 600, 700],
+  grade: [-25, 0, 200],
+  fill: [true, false],
+  opticalSize: [20, 24, 40, 48],
+};
+
+const skipCombinations = [
+  // "Don't use the lightest weight for standard-size (24dp) icons. The minimum weight for the size is 200."
+  // source: https://m3.material.io/styles/icons/applying-icons#6136ec4a-296f-4b9c-b90d-4ff2896d1ce7
+  { weight: 100, opticalSize: 20 },
+  { weight: 100, opticalSize: 24 },
+];
+
+function generateVariants() {
+  const result = [];
+
+  variants.weight.forEach((weight) => {
+    variants.grade.forEach((grade) => {
+      variants.fill.forEach((fill) => {
+        variants.opticalSize.forEach((opticalSize) => {
+          const combo = { fill, weight, grade, opticalSize };
+
+          // if ANY skip rule fully matches this combo, skip it
+          const shouldSkip = skipCombinations.some((skip) =>
+            Object.entries(skip).every(([key, val]) => combo[key] === val),
+          );
+          if (shouldSkip) {
+            return;
+          }
+
+          // build the filename prefix
+          let prefix = '';
+          if (weight !== 400) {
+            prefix += `wght${weight}`;
+          }
+          if (grade !== 0) {
+            prefix += `grad${grade < 0 ? `N${Math.abs(grade)}` : grade}`;
+          }
+          if (fill) {
+            prefix += 'fill1';
+          }
+
+          // default when nothing else applied
+          let isDefault = false;
+          if (!prefix) {
+            isDefault = true;
+            prefix = 'default';
+          }
+
+          const url = `${prefix}/${opticalSize}px.svg`;
+          result.push({ fill, weight, grade, opticalSize, url, prefix, isDefault });
+        });
+      });
+    });
+  });
+
+  return result;
+}
+
+const variantsList = generateVariants();
+
+/**
+ * Updates the metadata json files
+ * @param {Object[]} icons - The list of icons to update metadata for.
+ * @param {string} icons[].name - The name of the icon.
+ * @param {number} icons[].popularity - The popularity of the icon.
+ * @param {number[]} icons[].sizes_px - The available sizes of the icon in pixels.
+ * @param {string[]} icons[].tags - The tags associated with the icon.
+ * @param {string[]} icons[].categories - The categories of the icon.
+ * @returns {Promise<void[]>} A promise that resolves when the metadata is updated.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function updateMetadata(icons) {
+  // TODO: Are we able to use this data? It's not explicitly licensed
+  // https://github.com/google/material-design-icons/issues/1332#issuecomment-1258053181
+  const iconsSortedPopularity = [...icons]
+    .sort((a, b) => {
+      // the larger the number, the more popular
+      return b.popularity - a.popularity;
+    })
+    .map((icon) => ({
+      name: icon.name,
+      popularity: icon.popularity,
+      sizes: icon.sizes_px,
+      tags: icon.tags,
+      categories: icon.categories,
+    }));
+
+  const iconsByCategory = {};
+  const iconsByTag = {};
+  icons.forEach((icon) => {
+    icon.categories.forEach((tag) => {
+      if (iconsByCategory[tag]) {
+        iconsByCategory[tag].push(icon.name);
+      } else {
+        iconsByCategory[tag] = [icon.name];
+      }
+    });
+
+    icon.tags.forEach((tag) => {
+      if (iconsByTag[tag]) {
+        iconsByTag[tag].push(icon.name);
+      } else {
+        iconsByTag[tag] = [icon.name];
+      }
+    });
+  });
+
+  await Promise.all([
+    fse.writeJson(path.join(currentDirectory, '../meta/icons.json'), iconsSortedPopularity, {
+      spaces: 2,
+    }),
+    fse.writeJson(path.join(currentDirectory, '../meta/categories.json'), iconsByCategory, {
+      spaces: 2,
+    }),
+    fse.writeJson(path.join(currentDirectory, '../meta/tags.json'), iconsByTag, { spaces: 2 }),
+  ]);
+}
+
+/**
+ * Downloads an icon in various themes and variants and saves it as an SVG file.
+ *
+ * @param {Object} icon - The icon object.
+ * @param {string} icon.name - The name of the icon.
+ * @param {number} icon.version - The version of the icon.
+ * @param {number} icon.popularity - The popularity of the icon.
+ * @param {number} icon.codepoint - The codepoint of the icon.
+ * @param {string[]} icon.unsupported_families - The unsupported families of the icon.
+ * @param {string[]} icon.categories - The categories of the icon.
+ * @param {string[]} icon.tags - The tags associated with the icon.
+ * @param {number[]} icon.sizes_px - The available sizes of the icon in pixels.
+ * @returns {Promise<void[]>} A promise that resolves when all icons are downloaded and saved.
+ */
+async function downloadIconVariants(icon) {
+  console.log(`downloadIconVariants ${icon.index}: ${icon.name}`);
+
+  await Promise.all(
+    themes.map(async (theme) => {
+      const family = familyMap[theme];
+      if (icon.unsupported_families.includes(family)) {
+        return;
+      }
+
+      const queue = new Queue(
+        async (variant) => {
+          await retry(async ({ tries }) => {
+            await sleep((tries - 1) * 100);
+
+            const fileUrl = `https://fonts.gstatic.com/s/i/short-term/release/materialsymbols${theme}/${icon.name}/${variant.url}`;
+            const response = await fetch(fileUrl);
+            if (response.status !== 200) {
+              throw new Error(`status ${response.status} for ${fileUrl}`);
+            }
+            const SVG = await response.text();
+
+            // output the SVG, mirror the same structure as the material repo in case we move to submodules
+            // https://github.com/google/material-design-icons/tree/master/symbols/web
+            const directory = path.join(
+              currentDirectory,
+              `../material-symbols/${icon.name}/${theme}`,
+            );
+            const svgPath = `${directory}/${icon.name}${!variant.isDefault ? `_${variant.prefix}` : ''}_${variant.opticalSize}px.svg`;
+            await fse.ensureDir(directory);
+            await fse.writeFile(svgPath, SVG);
+          });
+        },
+        { concurrency: 5 },
+      );
+      queue.push(variantsList);
+      await queue.wait({ empty: true });
+    }),
+  );
+
+  // update the version file after all icons have been successfully downloaded
+  const release = await lockfile.lock(versionFile, { retries: 10 });
+  const versions = await fse.readJSON(versionFile);
+  versions[icon.name] = icon.version;
+  await fse.writeJSON(versionFile, versions, { spaces: 2 });
+  release();
+}
+
+async function run() {
+  try {
+    const argv = yargs(process.argv.slice(2))
+      .usage('Download the SVG from material.io/resources/icons')
+      .describe('start-after', 'Resume at the following index').argv;
+    console.log('run', argv);
+
+    await fse.ensureDir(path.join(currentDirectory, '../material-symbols'));
+    await fse.ensureDir(path.join(currentDirectory, '../meta'));
+    const response = await fetch(
+      'https://fonts.google.com/metadata/icons?key=material_symbols&incomplete=true',
+    );
+    const text = await response.text();
+    // Use same parsing method as material repo:
+    // https://github.com/google/material-design-icons/blob/941fa95d7f6084a599a54ca71bc565f48e7c6d9e/update/update_symbols.py#L90
+    const data = JSON.parse(text.substring(5));
+    let icons = data.icons;
+
+    const supportedSet = new Set(Object.values(familyMap));
+    icons = icons.filter((icon) => {
+      return (
+        !icon.unsupported_families.some((family) => supportedSet.has(family)) &&
+        !ignoredIconNames.has(icon.name) &&
+        !legacyIconNames.has(icon.name)
+      );
+    });
+
+    // TODO: investigate licensing issues
+    // await updateMetadata(icons);
+
+    const totalIcons = icons.length;
+    console.log(`total icons: ${totalIcons}`);
+
+    // allow resuming the download at a given index
+    icons = icons.map((icon, index) => ({ index, ...icon }));
+    icons = icons.splice(argv.startAfter || 0);
+
+    // we don't need to download the icons that haven't been updated
+    // since the last time we downloaded them
+    const versions = await fse.readJSON(versionFile).catch(() => {
+      console.log('version file not found, creating a new one');
+      fse.writeJSON(versionFile, {});
+      return {};
+    });
+    icons = icons.filter((icon) => icon.version !== versions[icon.name]);
+
+    console.log(`${icons.length} icons to download`);
+
+    const queue = new Queue(
+      async (icon) => {
+        await retry(async ({ tries }) => {
+          await sleep((tries - 1) * 100);
+          await downloadIconVariants(icon);
+        });
+      },
+      { concurrency: 5 },
+    );
+    queue.push(icons);
+    await queue.wait({ empty: true });
+  } catch (err) {
+    console.log('err', err);
+    throw err;
+  }
+}
+
+run();

--- a/packages/mui-symbols-material/scripts/download.mjs
+++ b/packages/mui-symbols-material/scripts/download.mjs
@@ -41,6 +41,11 @@ const familyMap = {
   rounded: 'Material Symbols Rounded',
   sharp: 'Material Symbols Sharp',
 };
+const familyDirMap = {
+  outlined: 'materialsymbolsoutlined',
+  rounded: 'materialsymbolsrounded',
+  sharp: 'materialsymbolssharp',
+};
 
 const variants = {
   weight: [100, 200, 300, 400, 500, 600, 700],
@@ -202,7 +207,7 @@ async function downloadIconVariants(icon) {
             // https://github.com/google/material-design-icons/tree/master/symbols/web
             const directory = path.join(
               currentDirectory,
-              `../material-symbols/${icon.name}/${theme}`,
+              `../material-symbols/${icon.name}/${familyDirMap[theme]}`,
             );
             const svgPath = `${directory}/${icon.name}${!variant.isDefault ? `_${variant.prefix}` : ''}_${variant.opticalSize}px.svg`;
             await fse.ensureDir(directory);

--- a/packages/mui-symbols-material/src/icon.d.ts
+++ b/packages/mui-symbols-material/src/icon.d.ts
@@ -1,0 +1,1 @@
+export { default } from '@mui/material/SvgIcon';

--- a/packages/mui-symbols-material/src/utils/createVariableIconFromSvg.js
+++ b/packages/mui-symbols-material/src/utils/createVariableIconFromSvg.js
@@ -1,0 +1,2 @@
+'use client';
+export { createVariableIconFromSvg as default } from '@mui/material/utils';

--- a/packages/mui-symbols-material/templateVariableIconFromSvg.js
+++ b/packages/mui-symbols-material/templateVariableIconFromSvg.js
@@ -1,0 +1,6 @@
+"use client";
+import createVariableIconFromSvg from '../utils/createVariableIconFromSvg';
+
+export default createVariableIconFromSvg(
+  {{{variantsData}}}
+, '{{componentName}}');

--- a/packages/mui-symbols-material/tsconfig.build.json
+++ b/packages/mui-symbols-material/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": false,
+    "noEmit": false,
+    "emitDeclarationOnly": false,
+    "outDir": "build/esm",
+    "rootDir": "./lib"
+  },
+  "include": ["lib/**/*.*"]
+}

--- a/packages/mui-symbols-material/tsconfig.json
+++ b/packages/mui-symbols-material/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  "include": ["src/**/*"]
+}

--- a/packages/mui-symbols-material/variantCollectors/material-design-symbols.mjs
+++ b/packages/mui-symbols-material/variantCollectors/material-design-symbols.mjs
@@ -1,0 +1,180 @@
+const singleDigitNumbers = [
+  'Zero',
+  'One',
+  'Two',
+  'Three',
+  'Four',
+  'Five',
+  'Six',
+  'Seven',
+  'Eight',
+  'Nine',
+];
+const twoDigitNumbers1 = [
+  'Ten',
+  'Eleven',
+  'Twelve',
+  'Thirteen',
+  'Fourteen',
+  'Fifteen',
+  'Sixteen',
+  'Seventeen',
+  'Eighteen',
+  'Nineteen',
+];
+
+const familyDirMap = {
+  materialsymbolsoutlined: 'outlined',
+  materialsymbolsrounded: 'rounded',
+  materialsymbolssharp: 'sharp',
+};
+
+function rewriteName(fileName) {
+  fileName = fileName.replace(/(^.)|(_)(.)/g, (match, p1, p2, p3) => (p1 || p3).toUpperCase());
+
+  if (fileName.startsWith('3dRotation')) {
+    return `ThreeD${fileName.slice(2)}`;
+  }
+
+  if (fileName.startsWith('3p')) {
+    return `ThreeP${fileName.slice(2)}`;
+  }
+
+  if (fileName.startsWith('30fps')) {
+    return `ThirtyFps${fileName.slice(5)}`;
+  }
+  if (fileName.startsWith('60fps')) {
+    return `SixtyFps${fileName.slice(5)}`;
+  }
+  if (fileName.startsWith('360')) {
+    return `ThreeSixty${fileName.slice(3)}`;
+  }
+
+  if (/\dFt/.test(fileName)) {
+    return `${singleDigitNumbers[fileName[0]]}${fileName.slice(1)}`;
+  }
+
+  if (/\dk/.test(fileName)) {
+    return `${singleDigitNumbers[fileName[0]]}K${fileName.slice(2)}`;
+  }
+
+  if (/^\dmp/.test(fileName)) {
+    return `${singleDigitNumbers[fileName[0]]}M${fileName.slice(2)}`;
+  }
+  if (/^1\dmp/.test(fileName)) {
+    return `${twoDigitNumbers1[fileName[1]]}M${fileName.slice(3)}`;
+  }
+  if (/^2\dmp/.test(fileName)) {
+    return `Twenty${singleDigitNumbers[fileName[1]]}M${fileName.slice(3)}`;
+  }
+
+  if (fileName.startsWith('1x')) {
+    return `TimesOne${fileName.slice(2)}`;
+  }
+
+  if (fileName.startsWith('3g')) {
+    return `ThreeG${fileName.slice(2)}`;
+  }
+  if (fileName.startsWith('4g')) {
+    return `FourG${fileName.slice(2)}`;
+  }
+  if (fileName.startsWith('5g')) {
+    return `FiveG${fileName.slice(2)}`;
+  }
+
+  // All other names starting with a number between 10 and 19
+  if (/^1\d/.test(fileName)) {
+    return `${twoDigitNumbers1[fileName[1]]}${fileName.slice(2)}`;
+  }
+
+  return fileName;
+}
+
+function stripDir(path, dir) {
+  return path.startsWith(dir) ? path.slice(dir.length) : path;
+}
+
+function parseVariantPath(path, dir) {
+  path = stripDir(path, dir);
+
+  if (path.startsWith('/')) {
+    path = path.slice(1);
+  }
+
+  const [rawName, rawTheme, fileWithExt] = path.split('/');
+  if (!fileWithExt) {
+    throw new Error(`Invalid path format: ${path}`);
+  }
+
+  const name = rewriteName(rawName);
+  const theme = familyDirMap[rawTheme];
+
+  const basename = fileWithExt.replace(/\.svg$/, '');
+  const lastUnd = basename.lastIndexOf('_');
+  if (lastUnd < 0) {
+    throw new Error(`No "_" before size in "${basename}"`);
+  }
+
+  const sizePart = basename.slice(lastUnd + 1); // "48px"
+  const opticalSize = Number(sizePart.replace(/px$/, ''));
+  if (Number.isNaN(opticalSize)) {
+    throw new Error(`Cannot parse size from "${sizePart}"`);
+  }
+
+  const before = basename.slice(0, lastUnd);
+  const variantMatch = before.match(/(wght\d+)?(gradN?\d+)?(fill1)?$/);
+  const variant = variantMatch ? variantMatch[0] : '';
+
+  let weight = 400;
+  let grade = 0;
+  let fill = false;
+
+  if (variant) {
+    const w = variant.match(/wght(\d+)/);
+    if (w) {
+      weight = Number(w[1]);
+    }
+
+    const g = variant.match(/grad(N?)(\d+)/);
+    if (g) {
+      grade = (g[1] === 'N' ? -1 : 1) * Number(g[2]);
+    }
+
+    fill = variant.includes('fill1');
+  }
+
+  let emphasis = '';
+  if (grade === -25) {
+    emphasis = '-light';
+  } else if (grade === 200) {
+    emphasis = '-heavy';
+  }
+
+  const fileName = `symbols${theme === 'outlined' ? '' : `-${theme}`}${weight === 400 ? '' : `-${weight}`}/${name}.js`;
+  const variantName = `${opticalSize}px${emphasis}${fill ? '-filled' : ''}`;
+
+  return { fileName, variantName, name, theme, weight, emphasis, fill, opticalSize };
+}
+
+function collectVariants(paths, dir) {
+  const variants = {};
+
+  paths.forEach((path) => {
+    const variant = parseVariantPath(path, dir);
+
+    if (!variants[variant.fileName]) {
+      variants[variant.fileName] = {};
+    }
+
+    variants[variant.fileName][variant.variantName] = path;
+  });
+
+  const outputs = [];
+  Object.keys(variants).forEach((fileName) => {
+    outputs.push({ fileName, variants: variants[fileName] });
+  });
+
+  return outputs;
+}
+
+export default collectVariants;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1929,6 +1929,65 @@ importers:
         version: 6.1.18(patch_hash=383c648dfdb5dfc82fbe414d54027d8c982a01c6320370f0ecfdb387e753c09f)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     publishDirectory: build
 
+  packages/mui-symbols-material:
+    dependencies:
+      '@babel/runtime':
+        specifier: ^7.27.1
+        version: 7.27.1
+    devDependencies:
+      '@mui/internal-waterfall':
+        specifier: workspace:^
+        version: link:../waterfall
+      '@mui/material':
+        specifier: workspace:^
+        version: link:../mui-material/build
+      '@mui/symbols-material':
+        specifier: workspace:*
+        version: link:build
+      '@types/chai':
+        specifier: ^4.3.20
+        version: 4.3.20
+      '@types/react':
+        specifier: ^19.1.4
+        version: 19.1.4
+      chai:
+        specifier: ^4.5.0
+        version: 4.5.0
+      chalk:
+        specifier: ^5.4.1
+        version: 5.4.1
+      cross-fetch:
+        specifier: ^4.1.0
+        version: 4.1.0(encoding@0.1.13)
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
+      fs-extra:
+        specifier: ^11.3.0
+        version: 11.3.0
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      mustache:
+        specifier: ^4.2.0
+        version: 4.2.0
+      proper-lockfile:
+        specifier: ^4.1.2
+        version: 4.1.2
+      react:
+        specifier: ^19.1.0
+        version: 19.1.0
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+      shx:
+        specifier: ^0.4.0
+        version: 0.4.0
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
+    publishDirectory: build
+
   packages/mui-system:
     dependencies:
       '@babel/runtime':
@@ -11656,6 +11715,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   protocols@2.0.1:
     resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}
@@ -25293,6 +25355,12 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
 
   protocols@2.0.1: {}
 


### PR DESCRIPTION
> This PR is a draft and still a work in progress.

## Concerns

### Optical Size

Optical size needs to be set based on the actual icon size so that the icon is consistent with other icons of different sizes. For example, if you used a large icon on a page with many small icons, the large icon would look much bolder than the small icons. Google has a helpful animation that shows this effect [here](https://m3.material.io/styles/icons/applying-icons#66e5cad7-5003-441c-a304-8060ac4dff4f).

Another benefit of the optical size is 20px icons are slightly simplified compared to 24px icons to be sharper on the screen and avoid aliasing. The docs in the material symbols repo says "What is currently not available in Material Symbols? only the 20 and 24 px versions are designed with perfect pixel-grid alignment" This alludes that 40px and 48px icons will eventually be pixel perfect. Justifying us using these sizes are default values for `large` and `larger` icons to increase sharpness. It's worth noting that today with the `SVGIcon` component, `large` translates to 35px and `larger` doesn't exist. I think we should make this change before it would be breaking for `@mui/symbols` users.

To quote someone from the Google team, "Also, no stroking change can correctly take you from the 24 px master to the 20 px master or vice versa, when each of them is manually designed to fall precisely on the pixel grid. If you are taking a skeleton and stroking it, and generating as SVGs, either all your 24 px icons will look fuzzy, or all your 20 px icons will look fuzzy. We just spent a big chunk of the last eight months or so revising the 20 px masters to be grid-snapped based on manually tweaked pixel patterns and outlines."
[Source](https://github.com/google/material-design-icons/issues/1360#issuecomment-1763180947)

For the sizes that are not exactly the same as the optical size, Google's [icon selector](https://fonts.google.com/icons) automatically switches the optical size based on these ranges:

- 0-22px: optical size of 20 (small)
- 23-31px: optical size of 24 (medium)
- 32-43px: optical size of 40 (large)
- 44px+: optical size of 48 (larger)

If the size is in rem, how do we know what the optical size should be? We could set the optical size based on a base font size of 16px, but if a user increases their font size, they would effectively be increasing the **weight** of the icons as well. This seems like an ok tradeoff. We could possibly use `getComputedStyle` to get the font size of the element and calculate the optical size based on that, but that would complicate the possibility of server rendering SVGs. If a user has their font size increased, they would see a flash of a bold icon before the react tree hydrates and rerenders based on `getComputedStyle`.

If animating the size, when do we switch the optical size? Before or after the animation, or would we recommend using `requestAnimationFrame` to switch at the threshold Google uses? If animating the size, it might make sense to keep a static optical size to avoid the icon slightly changing during the animation. Given the SVG icon size can't be easily animated because of this, would this make a case for having a separate icon file for each optical size? Then again, including the size in the import makes the user grapple with "what is an optical size?" If the size is in the import, I would recommend only allowing the `fontSize` to be set within the range shown above. This would enable small growth or shrinking animations for emphasis, but not a full size change.

### Weight

Weights 100-700 are available.

In the Material 3 spec, weight 100 is not allowed to be used with icons that are smaller than 24px. [Source](https://m3.material.io/styles/icons/applying-icons#6136ec4a-296f-4b9c-b90d-4ff2896d1ce7)

The spec also forbids mixing weights within a set of icons, so it wouldn't make sense to use weight as a indicator of which icon is selected. [Source](https://m3.material.io/styles/icons/applying-icons#b2989a73-c60b-4ee0-9566-bafa5ca2fe19)

It also seems using `stroke-weight` instead of individual SVGs is not feasible. [Source](https://github.com/google/material-design-icons/issues/1360#issuecomment-1763143234)

### Grade

We have -25, 0, 200 for grades. It gives even more variance on weight. It seems the intended use of this would be to take a theme weight of 400, and allow "light", "regular", and "heavy" variants of the icon. This makes me think `weight` is a theme property, and `grade` is an icon property based on the context of the icon.

In the Material Symbol docs, it mentions, "To highlight a symbol, increase the positive grade." [Source](https://developers.google.com/fonts/docs/material_symbols#grad_axis)

It's worth noting that the Material 3 spec recommends using `-25` grade when in dark mode to reduce glare. This would justify bundling grade in a single component as it is dependant on context. [Source](https://m3.material.io/styles/icons/applying-icons#9103e57b-6251-49b7-91d1-51a6069addb2)

### Fill

`fill` is a variable that was not mentioned in [#42704](https://github.com/mui/material-ui/issues/42704). If following the recommendation of that issue, it seems we would export `/variants/sharp/100/neg25/filled` (with combined optical size of 20, 24, 40, 48 in one file).

In the Material 3 spec, fill is mentioned as an indicator to show it has been selected ([Source](https://m3.material.io/styles/icons/applying-icons#750a6f13-39d8-4fe5-a035-047b88a16514)). In the icon font, the switching between `fill` and `unfilled` has a deliberate animation. The employee from Google mentioned that these animations cannot be achieved with SVGs. Would that make a case for having filled and unfilled icons in the same file? Having no animation support for icons means there is a serious benefit to using the icon font.

Mentioned in the Material 3 spec, it says, "A fill attribute can be used to convey a state of transition, such as unfilled and filled states. Values range from 0 to 1, with 1 being completely filled." That seems to allude that you could set fill to `0.5` and it would have a half-filled icon. This further justifies that fill would be an icon property, not a theme property.

### Editor Autocomplete

If I type `<Home />` into my editor, it would be nice to autocomplete the import according to the icon theme I am using. We could achieve this by installing only one theme at a time. Instead of installing `@mui/symbols`, we could ask the users to install `@mui/symbols-rounded-300` or `@mui/symbols-rounded`. If two weights were desired, the user would only see two options for `Home` instead of all the theme variants.

I think it also make sense to call the module `@mui/symbols` instead of `@mui/symbols-material` so that it is shorter. It seems we intend on adding our own icons and removing some that don't work well, so it would make sense to deviate a little in the name as well.

### Module Size

Someone from the Google team mentioned that all the possible variants add up to more than a million SVG files. [Source](https://github.com/google/material-design-icons/issues/1360#issuecomment-1211102471)

By my count, there are `468` SVG files per icon with `156` files for each style (`Rounded|Outlined|Sharp`). With `3618` icons, that's `1,693,224` SVG files.

This might not scale very well and could drastically increase the install time of the module. We should consider splitting into multiple packages like mentioned above, or reducing the number of files by combining the parameters that depend on the context of the icon.

### Checking Files into Git

Are we able to check 1.6 million SVG files into git? It seems for `@mui/icons-material` there are also CommonJS and ESM versions for each SVG file. If we use the same pattern for Material Symbols, that's `5,079,672` files checked into git. Is this for monorepo reasons?

It seems clear that we need to combine some of these SVG files into a bundled file, see recommendations below. I also think git should only contain one version of either the SVG or JS file, instead of duplicating three times. The build output itself should be stored on NPM only.

I understand that each version of the icons may need to be available through git, so maybe the solution here would be to use the Google repo as a submodule.

## API Recommendations

There is clearly a benefit to using the icon font, so I don't think we can recommend using SVGs in all cases. To put the decision in the hands of the user, I would recommend creating a unified API surface between the icon font and SVGs. The user would learn a single way of adding icons to their app, and switching between SVGs and the icon font would be as simple as changing the import. If using the icon font, they would gain animations seamlessly. If using SVGs, icons would render instantly on the first load. It's worth noting that the icon font can still "code-split" the icons at build time with the right tooling. I think it would also be fair for applications that have dynamic icon usage (e.g. user-defined category tagging), icon fonts would be a better solution.

Differentiating between "theme" properties and "icon" properties would be the solution here. In my opinion, `weight` and `rounded|outlined|sharp` would be theme properties defined at an app level in most cases.

The user would import their icons like this on the most basic level to use our given theme defaults:

```js
import SearchIcon from '@mui/symbols/Search';
```

A customized theme would look like this:

```js
import SearchIcon from '@mui/symbols-sharp-300/Search';
```

This could be enforced by a linter rule. An import alias could also be used to have `@symbols/Search` point to `@mui/symbols-sharp-300/Search`.

Further customizations (`size`, `fill`, `grade`) of the icon would occur based on context.

```js
import BellIcon from '@mui/symbols/Bell';

export default function NotificationButton({ hasNotifications }) {
  return (
    <IconButton>
      <BellIcon fontSize="large" emphasis="heavy" filled={hasNotifications} />
    </IconButton>
  );
}
```

`emphasis="heavy"` would translate to `grade` being set to `200`.
`emphasis="light"` would translate to `grade` being set to `-25`.
`emphasis="regular"` (default) would translate to `grade` being set to `0`.

`filled=true` would translate to `fill` being set to `1`.
`filled=false` would translate to `fill` being set to `0`.
`filled=0.5` would translate to `fill` being set to `0.5` for the icon font and 1 for SVGs.

`fontSize=small` would translate to a size of `20px`
`fontSize=medium` would translate to a size of `24px`
`fontSize=large` would translate to a size of `40px`
`fontSize=larger` would translate to a size of `48px` (I suggest `larger` because `xlarge` shows up as a typo in my code editor)

`fontSize=16px` would translate to a size of `16px` and `optical-size` of `20px` (calculated by range)
`fontSize=2rem` would translate to a size of `32px` and `optical-size` of `40x` (calculated by range)
`fontSize=3rem` would translate to a size of `48px` and `optical-size` of `48x` (exact match will be sharpest, but rem units susceptible to a flash of boldness before hydration)

Switching to the icon font could be as simple as changing the import statement (or updating the import alias):

```js
import SearchIcon from '@mui/symbols-font/Search';
```

This requires a new icon component: `VariableIcon`. It abstracts away the complexities of `SVGIcon` to allow the user to choose between the icon font or SVGs. When using Material Symbols, I don't think it makes sense for users to use advanced SVG configurations. We should handle that for them.

To generate these `VariableIcon` components, we have a helper function `createVariableIconFromSvg` which wraps the `VariableIcon` component and passed a `SVGIcon` component to it (so we still benefit from the optimizations there). In the future, we can add a `createVariableIconFromFontString` function that would create the component using a string instead of the SVG.

### Pros

- Unified API surface between the icon font and SVGs
- Separate "theme" properties and "context" properties for a more intuitive DX
- Allows more intelligent runtime handling
- Simple and intuitive animations when using the icon font
- Encourages the use of `fill` and `unfilled` to convey state
- Slightly improves understanding of the `grade` property
- The user doesn't need to know about the optical size, it is automatically set based on the size of the icon
- Working autocomplete for icon names
- More difficult to accidentally mix weights
- Shorter import paths
- When using the icon font, allows filling the icon according to progress (e.g. `fill={progress}`) instead of using a separate icon for each state

### Cons

- The user would need to learn a new API surface compared to `@mui/icons-material`. Given Material Surfaces is not Material Icons v2, I think this is acceptable.
- A user might want more fine grained control, but I would argue they could always use the SVGs from the Google repo directly with the `SVGIcon` component.
- Barrel files may become large, but this could be further optimized and icon level imports are encouraged anyway.
- The SVG component would bundle 4 optical sizes, 3 grades, and 2 fills (24 SVGs per component)
  - SVGs are relatively light, and given we are already code-splitting by the icon. I would argue this is not a big deal and allows us to optimize the experience.
  - The 4 optical sizes could be used in the import reducing to 6 SVGs per component (e.e.`@mui/symbols-sharp-300/SearchSmall`), but this would reduce our ability to automatically switch the optical size based on the size of the icon. This might be acceptable given it doesn't easily animate. It would reduce the usefulness of autocomplete. It might be confusing to users why they have a "optical size" and a "font size".
  - Alternatively, it could be reduced by making "bold" and "fine" import properties to make 8 SVGs per component (e.g. `@mui/symbols-sharp-300/SearchBold`). This would limit our ability to automatically use `-25` grade when in dark mode.
  - It's worth noting if these properties are in the import statement, it makes it impossible to animate between them when using the icon font.

### Scale

As proposed, this would result in `75,978` Javascript files built. If the package is split by `rounded|outlined|sharp` (e.g. `@mui/symbols-sharp`), that would be `25,326` files. If also split by `weight` (e.g. `@mui/symbols-sharp-300`), each module would only have as many files as icons (`3618`). This is a lot more manageable than `1,693,224` files and additional weights could be installed as needed making it modular.

## Results

I selected an icon (`TwoKPlus`) to test the impacts on size:

- A single icon in `@mui/icons-material` around `470 bytes` (`440 bytes` compressed)
- With `optical-size` + `grade` + `fill`, it results in a size of `12,400 bytes` (`4,000 bytes` compressed)
- With `grade` + `fill`, it results in a size of `3,027 bytes` (`1092 bytes` compressed)
- With `optical-size` + `fill`, it results in a size of `3,852 bytes` (`1528 bytes` compressed)
- Split `grade`
  - With `optical-size` + `grade:regular|light` + `fill`, it results in a size of `8,154 bytes` (`3144 bytes` compressed)
  - With `optical-size` + `grade:heavy` + `fill`,  it results in a size of `4,392 bytes` (`1732 bytes` compressed)

It's worth noting that this would be the added weight on the Javascript bundle, not the initial HTML payload. Only a single SVG would be rendered in the HTML. These bundled SVGs benefit a lot from gzip compression which makes sense because each variant is very similar. It's safe to assume any modern application will be using gzip compression for the JS bundles. Unfortunately, the npm packages would not be compressed, so splitting the packages would be essential to keep install times quick.

[More analysis to come]

## TODO

- [x] Create `mui-symbols` package
- [x] Create script that downloads Material Symbols from Google Fonts
- [x] Create script that combines the SVG variants into a single file (`@mui/symbols/Search`)
- [x] Create `VariableIcon` component
- [x] Create `createVariableIconFromSvg` function
- [x] Create the `/material-ui/api/variable-icon/` api page
- [ ] Add script that generates the types for each symbol
- [ ] Create barrel file at `@mui/symbols` (and other package roots)
- [ ] Create the `/material-ui/material-symbols/` docs page
- [ ] Create the `/material-ui/icons/#variableicon` docs page
- [ ] Create `createVariableIconFromFontString` function
- [ ] Create script that builds the `@mui/symbols-font` version of the icons
- [ ] Get publishing working
- [ ] Figure out what files should be checked into git
- [ ] Update `/material-ui/icons/#font-vs-svgs-which-approach-to-use` to detail `VariableIcon`
- [ ] Add tests for the `VariableIcon` component
- [ ] Add tests for the build script
- [ ] Complete bundle size analysis and decide on stable API surface
- [ ] Add `getComputedStyle` computation for `optical-size` when using `rem` units
- [ ] Experiment with `requestAnimationFrame` computation for `optical-size` when animating
