### PR TITLE
[docs][material-ui][Dialog] Remove deprecated TransitionComponent from demo

### DIFF
--- a/docs/data/material/components/dialogs/FullScreenDialog.js
+++ b/docs/data/material/components/dialogs/FullScreenDialog.js
@@ -36,7 +36,9 @@ export default function FullScreenDialog() {
         fullScreen
         open={open}
         onClose={handleClose}
-        TransitionComponent={Transition}
+        slots={{
+          transition: Transition,
+        }}
       >
         <AppBar sx={{ position: 'relative' }}>
           <Toolbar>

--- a/docs/data/material/components/dialogs/FullScreenDialog.tsx
+++ b/docs/data/material/components/dialogs/FullScreenDialog.tsx
@@ -42,7 +42,9 @@ export default function FullScreenDialog() {
         fullScreen
         open={open}
         onClose={handleClose}
-        TransitionComponent={Transition}
+        slots={{
+          transition: Transition,
+        }}
       >
         <AppBar sx={{ position: 'relative' }}>
           <Toolbar>


### PR DESCRIPTION
address feedback from slack https://mui-org.slack.com/archives/C0757QYLK7V/p1747584742023829