### PR TITLE
[types] Fix variant props callback type to spread `ownerState`

### DIFF
--- a/packages/mui-material/src/styles/styled.spec.tsx
+++ b/packages/mui-material/src/styles/styled.spec.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable material-ui/no-empty-box */
 import * as React from 'react';
+import MuiPaper from '@mui/material/Paper';
 import { styled, css, ThemeProvider, createTheme } from '@mui/material/styles';
 
 const Box = styled('div')(({ theme }) => ({
@@ -236,6 +237,43 @@ const DateTimePickerToolbarTimeContainer = styled('div', {
         toolbarDirection === 'rtl',
       style: {
         flexDirection: 'column-reverse',
+      },
+    },
+  ],
+});
+
+interface PickerPopperOwnerState extends PickerOwnerState {
+  popperPlacement:
+    | 'top'
+    | 'bottom'
+    | 'left'
+    | 'right'
+    | 'top-start'
+    | 'top-end'
+    | 'bottom-start'
+    | 'bottom-end'
+    | 'left-start'
+    | 'left-end'
+    | 'right-start'
+    | 'right-end'
+    | 'auto'
+    | 'auto-start'
+    | 'auto-end';
+}
+
+const PickerPopperPaper = styled(MuiPaper, {
+  name: 'MuiPickerPopper',
+  slot: 'Paper',
+})<{
+  ownerState: PickerPopperOwnerState;
+}>({
+  outline: 0,
+  transformOrigin: 'top center',
+  variants: [
+    {
+      props: ({ popperPlacement }) => ['top', 'top-start', 'top-end'].includes(popperPlacement),
+      style: {
+        transformOrigin: 'bottom center',
       },
     },
   ],

--- a/packages/mui-material/src/styles/styled.spec.tsx
+++ b/packages/mui-material/src/styles/styled.spec.tsx
@@ -183,3 +183,60 @@ function variantsAPI() {
     ],
   });
 }
+
+type PickerOrientation = 'portrait' | 'landscape';
+
+type PickerVariant = 'mobile' | 'desktop';
+
+interface PickerOwnerState {
+  isPickerValueEmpty: boolean;
+  isPickerOpen: boolean;
+  isPickerDisabled: boolean;
+  isPickerReadOnly: boolean;
+  pickerVariant: PickerVariant;
+  pickerOrientation: PickerOrientation;
+}
+
+interface PickerToolbarOwnerState extends PickerOwnerState {
+  toolbarDirection: 'ltr' | 'rtl';
+}
+
+const DateTimePickerToolbarTimeContainer = styled('div', {
+  name: 'MuiDateTimePickerToolbar',
+  slot: 'TimeContainer',
+})<{ ownerState: PickerToolbarOwnerState; toolbarVariant: PickerVariant }>({
+  display: 'flex',
+  flexDirection: 'row',
+  variants: [
+    {
+      props: { toolbarDirection: 'rtl' },
+      style: {
+        flexDirection: 'row-reverse',
+      },
+    },
+    {
+      props: { toolbarVariant: 'desktop', pickerOrientation: 'portrait' },
+      style: {
+        gap: 9,
+        marginRight: 4,
+        alignSelf: 'flex-end',
+      },
+    },
+    {
+      props: ({ pickerOrientation, toolbarVariant }) =>
+        pickerOrientation === 'landscape' && toolbarVariant !== 'desktop',
+      style: {
+        flexDirection: 'column',
+      },
+    },
+    {
+      props: ({ pickerOrientation, toolbarVariant, toolbarDirection }) =>
+        pickerOrientation === 'landscape' &&
+        toolbarVariant !== 'desktop' &&
+        toolbarDirection === 'rtl',
+      style: {
+        flexDirection: 'column-reverse',
+      },
+    },
+  ],
+});

--- a/packages/mui-material/src/styles/styled.spec.tsx
+++ b/packages/mui-material/src/styles/styled.spec.tsx
@@ -271,7 +271,7 @@ const PickerPopperPaper = styled(MuiPaper, {
   transformOrigin: 'top center',
   variants: [
     {
-      props: ({ popperPlacement }) => ['top', 'top-start', 'top-end'].includes(popperPlacement),
+      props: ({ popperPlacement }) => new Set(['top', 'top-start', 'top-end']).has(popperPlacement),
       style: {
         transformOrigin: 'bottom center',
       },

--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -110,9 +110,7 @@ export type Interpolation<Props> =
               ? Partial<Omit<Props, 'ownerState'> & O>
               : Partial<Props>)
           | ((
-              props: Props extends { ownerState: infer O }
-                ? Partial<Props & O> & { ownerState: O }
-                : Partial<Props>,
+              props: Props extends { ownerState: infer O } ? Props & O & { ownerState: O } : Props,
             ) => boolean);
         style:
           | CSSObject

--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -110,9 +110,9 @@ export type Interpolation<Props> =
               ? Partial<Omit<Props, 'ownerState'> & O>
               : Partial<Props>)
           | ((
-              props: Partial<Props> & {
-                ownerState: Partial<Props>;
-              },
+              props: Props extends { ownerState: infer O }
+                ? Partial<Omit<Props, 'ownerState'> & O> & { ownerState: Partial<Props> }
+                : Partial<Props>,
             ) => boolean);
         style:
           | CSSObject

--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -111,7 +111,7 @@ export type Interpolation<Props> =
               : Partial<Props>)
           | ((
               props: Props extends { ownerState: infer O }
-                ? Partial<Omit<Props, 'ownerState'> & O> & { ownerState: Partial<Props> }
+                ? Partial<Props & O> & { ownerState: O }
                 : Partial<Props>,
             ) => boolean);
         style:

--- a/packages/mui-system/src/styled/styled.spec.ts
+++ b/packages/mui-system/src/styled/styled.spec.ts
@@ -29,7 +29,20 @@ const VariantCallbacks = styled('div')<{ ownerState: OwnerState } & OwnerState>(
   color: 'inherit',
   variants: [
     {
-      props: ({ ownerState }) => ownerState.showChanges,
+      props: ({ ownerState }) => !!ownerState.showChanges,
+      style: {
+        color: 'red',
+      },
+    },
+  ],
+});
+
+const VariantCallbackOwnerState = styled('div')<{ ownerState: OwnerState }>({
+  font: 'inherit',
+  color: 'inherit',
+  variants: [
+    {
+      props: ({ variant }) => variant === 'success',
       style: {
         color: 'red',
       },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Root cause

The pattern below is logically correct based on the [implementation](https://github.com/mui/material-ui/blob/master/packages/mui-system/src/createStyled/createStyled.js#L73) but failed on type check.

```js
const DateTimePickerToolbarTimeContainer = styled('div', {
  name: 'MuiDateTimePickerToolbar',
  slot: 'TimeContainer',
  shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'toolbarVariant',
})<{ ownerState: { pickerOrientation: 'landscape' | 'portrait'; toolbarVariant: PickerVariant }>({
  display: 'flex',
  flexDirection: 'row',
  variants: [
    {
      // ❌ error
      props: ({ pickerOrientation, toolbarVariant }) =>
        pickerOrientation === 'landscape' && toolbarVariant !== 'desktop',
      style: {
        flexDirection: 'column',
      },
    },
  ],
});
```

This PR fixes the issue above. A test (using MUI X pickers code) is added to ensure that it fixes the issue.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
