### PR TITLE
[SnackbarContent] Fix error when theme value is CSS variable

### DIFF
--- a/packages/mui-material/src/SnackbarContent/SnackbarContent.js
+++ b/packages/mui-material/src/SnackbarContent/SnackbarContent.js
@@ -28,14 +28,15 @@ const SnackbarContentRoot = styled(Paper, {
 })(
   memoTheme(({ theme }) => {
     const emphasis = theme.palette.mode === 'light' ? 0.8 : 0.98;
-    const backgroundColor = emphasize(theme.palette.background.default, emphasis);
 
     return {
       ...theme.typography.body2,
       color: theme.vars
         ? theme.vars.palette.SnackbarContent.color
-        : theme.palette.getContrastText(backgroundColor),
-      backgroundColor: theme.vars ? theme.vars.palette.SnackbarContent.bg : backgroundColor,
+        : theme.palette.getContrastText(emphasize(theme.palette.background.default, emphasis)),
+      backgroundColor: theme.vars
+        ? theme.vars.palette.SnackbarContent.bg
+        : emphasize(theme.palette.background.default, emphasis),
       display: 'flex',
       alignItems: 'center',
       flexWrap: 'wrap',

--- a/packages/mui-material/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/mui-material/src/SnackbarContent/SnackbarContent.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { createRenderer } from '@mui/internal-test-utils';
 import Paper from '@mui/material/Paper';
 import SnackbarContent, { snackbarContentClasses as classes } from '@mui/material/SnackbarContent';
-import { ThemeProvider, extendTheme } from '@mui/material/styles';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import describeConformance from '../../test/describeConformance';
 
 describe('<SnackbarContent />', () => {
@@ -63,7 +63,7 @@ describe('<SnackbarContent />', () => {
 
   describe('CSS vars', () => {
     it('should not throw when background.default is a CSS variable', () => {
-      const theme = extendTheme();
+      const theme = createTheme({ cssVariables: true });
       theme.palette = theme.colorSchemes.light.palette;
       theme.palette.background.default = 'var(--mui-palette-background-default)';
       expect(() =>

--- a/packages/mui-material/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/mui-material/src/SnackbarContent/SnackbarContent.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { createRenderer } from '@mui/internal-test-utils';
 import Paper from '@mui/material/Paper';
 import SnackbarContent, { snackbarContentClasses as classes } from '@mui/material/SnackbarContent';
+import { ThemeProvider, extendTheme } from '@mui/material/styles';
 import describeConformance from '../../test/describeConformance';
 
 describe('<SnackbarContent />', () => {
@@ -57,6 +58,21 @@ describe('<SnackbarContent />', () => {
         <SnackbarContent message="alertdialog message" role="alertdialog" />,
       );
       expect(queryByRole('alertdialog')).to.have.text('alertdialog message');
+    });
+  });
+
+  describe('CSS vars', () => {
+    it('should not throw when background.default is a CSS variable', () => {
+      const theme = extendTheme();
+      theme.palette = theme.colorSchemes.light.palette;
+      theme.palette.background.default = 'var(--mui-palette-background-default)';
+      expect(() =>
+        render(
+          <ThemeProvider theme={theme}>
+            <SnackbarContent message="CSS var test" />
+          </ThemeProvider>,
+        ),
+      ).not.to.throw();
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Summary

This PR fixes #46192 by the SnackbarContentRoot from applying the emphasize color function to `theme.palette.background.default`, ensuring correct theming behavior when using background defaults. Also added a test case to verify correct application of the CSS variable

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
