### PR TITLE
[docs-infra][Draft] Refactor max-width implementation

### DIFF
--- a/docs/src/modules/components/AppContainer.js
+++ b/docs/src/modules/components/AppContainer.js
@@ -5,10 +5,7 @@ import Container from '@mui/material/Container';
 const StyledAppContainer = styled(Container)(({ theme }) => {
   return {
     paddingTop: `calc(var(--MuiDocs-header-height) + ${theme.spacing(4)})`,
-    // We're mostly hosting text content so max-width by px does not make sense considering font-size is system-adjustable.
-    // 105ch ≈ 930px
     fontFamily: 'Arial',
-    maxWidth: '105ch',
     [theme.breakpoints.up('lg')]: {
       paddingLeft: theme.spacing(8),
       paddingRight: theme.spacing(8),

--- a/docs/src/modules/components/AppFrame.tsx
+++ b/docs/src/modules/components/AppFrame.tsx
@@ -198,6 +198,9 @@ export default function AppFrame(props: AppFrameProps) {
             styles={{
               ':root': {
                 '--MuiDocs-header-height': `${HEIGHT}px`,
+                // We're mostly hosting text content so max-width by px does not make sense considering font-size is system-adjustable.
+                // 59rem ≈ 930px
+                '--MuiDocs-content-max-width': '59rem',
               },
             }}
           />

--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -67,8 +67,7 @@ const StyledAppContainer = styled(AppContainer, {
       {
         props: ({ disableToc }) => disableToc,
         style: {
-          // 105ch ≈ 930px
-          maxWidth: `calc(105ch + ${TOC_WIDTH / 2}px)`,
+          '--MuiDocs-text-width': `calc(var(--MuiDocs-content-max-width) + ${TOC_WIDTH / 2}px)`,
         },
       },
       {
@@ -76,8 +75,7 @@ const StyledAppContainer = styled(AppContainer, {
         style: {
           // We're mostly hosting text content so max-width by px does not make sense considering font-size is system-adjustable.
           fontFamily: 'Arial',
-          // 105ch ≈ 930px
-          maxWidth: '105ch',
+          '--MuiDocs-text-width': `calc(var(--MuiDocs-content-max-width))`,
         },
       },
       {

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -394,7 +394,11 @@ export default function AppLayoutDocsFooter(props) {
 
   return (
     <React.Fragment>
-      <Stack component="footer" direction="column" sx={{ my: 4 }}>
+      <Stack
+        component="footer"
+        direction="column"
+        sx={{ my: 4, mx: 'auto', maxWidth: 'var(--MuiDocs-text-width)' }}
+      >
         <Stack
           direction={{ xs: 'column', sm: 'row' }}
           spacing={{ xs: 3, sm: 1 }}

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -147,11 +147,15 @@ function useDemoElement({ demoData, editorCode, setDebouncedError, liveDemoActiv
 
 const Root = styled('div')(({ theme }) => ({
   marginBottom: 24,
+
+  // Take full width on mobile
   marginLeft: theme.spacing(-2),
   marginRight: theme.spacing(-2),
   [theme.breakpoints.up('sm')]: {
-    marginLeft: 0,
-    marginRight: 0,
+    // Same width as the text on larger screen
+    maxWidth: 'var(--MuiDocs-text-width)',
+    marginLeft: 'auto',
+    marginRight: 'auto',
   },
 }));
 

--- a/docs/src/modules/components/RichMarkdownElement.js
+++ b/docs/src/modules/components/RichMarkdownElement.js
@@ -41,17 +41,33 @@ export default function RichMarkdownElement(props) {
       additionalProps.activeTab = activeTab;
     }
 
-    return <Component {...renderedMarkdownOrDemo} {...additionalProps} markdown={localizedDoc} />;
+    return (
+      <div
+        style={{
+          maxWidth: 'var(--MuiDocs-text-width)',
+          margin: 'auto',
+        }}
+      >
+        <Component {...renderedMarkdownOrDemo} {...additionalProps} markdown={localizedDoc} />
+      </div>
+    );
   }
 
   if (renderedMarkdownOrDemo.type === 'codeblock') {
     return (
-      <HighlightedCodeWithTabs
-        tabs={renderedMarkdownOrDemo.data}
-        storageKey={
-          renderedMarkdownOrDemo.storageKey && `codeblock-${renderedMarkdownOrDemo.storageKey}`
-        }
-      />
+      <div
+        style={{
+          maxWidth: 'var(--MuiDocs-text-width)',
+          margin: 'auto',
+        }}
+      >
+        <HighlightedCodeWithTabs
+          tabs={renderedMarkdownOrDemo.data}
+          storageKey={
+            renderedMarkdownOrDemo.storageKey && `codeblock-${renderedMarkdownOrDemo.storageKey}`
+          }
+        />
+      </div>
     );
   }
 

--- a/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
+++ b/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
@@ -7,6 +7,8 @@ import { brandingDarkTheme as darkTheme, brandingLightTheme as lightTheme } from
 const Root = styled('div')(
   ({ theme }) => ({
     ...lightTheme.typography.body1,
+    maxWidth: 'var(--MuiDocs-text-width)',
+    margin: 'auto',
     lineHeight: 1.625, // Rounds up to 26px－increased compared to the 1.5 default to make the docs easier to read.
     color: `var(--muidocs-palette-text-primary, ${lightTheme.palette.text.primary})`,
     '& :focus-visible': {


### PR DESCRIPTION
This PR experiment the impact of moving the `max-width` from the container to the items of the content.

The goal is to allow some docs like data grid or scheduler to have larger demo.

The current proposal increase the max-width of the content because the `MuiContainer-root` has a paddingLeft/Right of `60px` in addition to the `max-width: 105ch`.

I replaced the `ch` value by `rem` because `ch` is impacted by the element `font-size`. This makes the footer smaller than the body because of its smaller font size.

