### PR TITLE
[code-infra] Move `chai` to peerDep

### DIFF
--- a/packages-internal/test-utils/package.json
+++ b/packages-internal/test-utils/package.json
@@ -44,7 +44,6 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "chai": "^4.5.0",
     "chai-dom": "^1.12.1",
     "dom-accessibility-api": "^0.7.0",
     "format-util": "^1.0.5",
@@ -67,7 +66,8 @@
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "chai": "^4.5.0 || ^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages-internal/test-utils/src/chaiPlugin.ts
+++ b/packages-internal/test-utils/src/chaiPlugin.ts
@@ -1,6 +1,7 @@
 import { isInaccessible } from '@testing-library/dom';
 import { prettyDOM } from '@testing-library/react/pure';
-import chai, { AssertionError } from 'chai';
+import type chaiType from 'chai';
+import { AssertionError } from 'chai';
 import { computeAccessibleDescription, computeAccessibleName } from 'dom-accessibility-api';
 import formatUtil from 'format-util';
 import _ from 'lodash';
@@ -20,7 +21,7 @@ function elementToString(element: Element | null | undefined) {
   return String(element);
 }
 
-const chaiPlugin: Parameters<(typeof chai)['use']>[0] = (chaiAPI, utils) => {
+const chaiPlugin: Parameters<(typeof chaiType)['use']>[0] = (chaiAPI, utils) => {
   const blockElements = new Set([
     'html',
     'address',

--- a/packages-internal/test-utils/src/chaiPlugin.ts
+++ b/packages-internal/test-utils/src/chaiPlugin.ts
@@ -120,7 +120,9 @@ const chaiPlugin: Parameters<(typeof chai)['use']>[0] = (chaiAPI, utils) => {
   chaiAPI.Assertion.addMethod('toHaveAccessibleName', function hasAccessibleName(expectedName) {
     const root = utils.flag(this, 'object');
     // make sure it's an Element
-    new chai.Assertion(root.nodeType, `Expected an Element but got '${String(root)}'`).to.equal(1);
+    new chaiAPI.Assertion(root.nodeType, `Expected an Element but got '${String(root)}'`).to.equal(
+      1,
+    );
 
     const actualName = computeAccessibleName(root, {
       computedStyleSupportsPseudoElements: !isInJSDOM(),
@@ -143,9 +145,10 @@ const chaiPlugin: Parameters<(typeof chai)['use']>[0] = (chaiAPI, utils) => {
     function hasAccessibleDescription(expectedDescription) {
       const root = utils.flag(this, 'object');
       // make sure it's an Element
-      new chai.Assertion(root.nodeType, `Expected an Element but got '${String(root)}'`).to.equal(
-        1,
-      );
+      new chaiAPI.Assertion(
+        root.nodeType,
+        `Expected an Element but got '${String(root)}'`,
+      ).to.equal(1);
 
       const actualDescription = computeAccessibleDescription(root, {
         // in local development we pretend to be visible. full getComputedStyle is

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1089,7 +1089,7 @@ importers:
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
       chai:
-        specifier: ^4.5.0
+        specifier: ^4.5.0 || ^5.0.0
         version: 4.5.0
       chai-dom:
         specifier: ^1.12.1


### PR DESCRIPTION
This would allow X to move to chai v5 https://github.com/mui/mui-x/pull/17575

It is probably a more sane approach too