### PR TITLE
[docs] Add Testing section to Rating component doc

### DIFF
--- a/docs/data/material/components/rating/rating.md
+++ b/docs/data/material/components/rating/rating.md
@@ -77,8 +77,6 @@ The read only rating is not focusable.
 
 ## Testing
 
-**User interaction limitations in test environments**
-
 When testing the `Rating` component in environments such as **Jest + jsdom**, certain user interactions—especially **hover-based interactions**—may not behave as expected. This is because the component relies on `getBoundingClientRect()` to calculate the position of each icon and determine which icon is currently being hovered. In `jsdom`, `getBoundingClientRect()` returns `0` values by default, which can lead to incorrect behavior such as `NaN` being passed to the `onChange` handler.
 
 To avoid this issue in your test suite:

--- a/docs/data/material/components/rating/rating.md
+++ b/docs/data/material/components/rating/rating.md
@@ -75,7 +75,7 @@ Because the rating component uses radio buttons, keyboard interaction follows th
 
 The read only rating is not focusable.
 
-### Testing caveats
+## Testing
 
 **User interaction limitations in test environments**
 

--- a/docs/data/material/components/rating/rating.md
+++ b/docs/data/material/components/rating/rating.md
@@ -74,3 +74,35 @@ The read only rating has a role of "img", and an aria-label that describes the d
 Because the rating component uses radio buttons, keyboard interaction follows the native browser behavior. Tab will focus the current rating, and cursor keys control the selected rating.
 
 The read only rating is not focusable.
+
+### Testing caveats
+
+**User interaction limitations in test environments**
+
+When testing the `Rating` component in environments such as **Jest + jsdom**, certain user interactions—especially **hover-based interactions**—may not behave as expected. This is because the component relies on `getBoundingClientRect()` to calculate the position of each icon and determine which icon is currently being hovered. In `jsdom`, `getBoundingClientRect()` returns `0` values by default, which can lead to incorrect behavior such as `NaN` being passed to the `onChange` handler.
+
+To avoid this issue in your test suite:
+
+- Prefer `fireEvent` over `userEvent` when simulating click events.
+- Avoid relying on hover behavior to trigger changes.
+- If needed, mock `getBoundingClientRect()` manually for more advanced interactions.
+
+```tsx
+// @vitest-environment jsdom
+
+import { Rating } from '@mui/material';
+import { render, fireEvent, screen } from '@testing-library/react';
+
+import { describe, test, vi } from 'vitest';
+
+describe('Rating', () => {
+  test('should update rating on click', () => {
+    const handleChange = vi.fn();
+    render(<Rating onChange={(_, newValue) => handleChange(newValue)} />);
+
+    fireEvent.click(screen.getByLabelText('2 Stars'));
+
+    expect(handleChange).toHaveBeenCalledWith(2);
+  });
+});
+```

--- a/docs/data/material/components/rating/rating.md
+++ b/docs/data/material/components/rating/rating.md
@@ -77,7 +77,9 @@ The read only rating is not focusable.
 
 ## Testing
 
-When testing the `Rating` component in environments such as **Jest + jsdom**, certain user interactions—especially **hover-based interactions**—may not behave as expected. This is because the component relies on `getBoundingClientRect()` to calculate the position of each icon and determine which icon is currently being hovered. In `jsdom`, `getBoundingClientRect()` returns `0` values by default, which can lead to incorrect behavior such as `NaN` being passed to the `onChange` handler.
+When testing the Rating component in environments such as Jest with jsdom, certain user interactions—especially hover-based interactions—may not behave as expected.
+This is because the component relies on `getBoundingClientRect()` to calculate the position of each icon and determine which icon is currently being hovered.
+In jsdom, `getBoundingClientRect()` returns `0` values by default, which can lead to incorrect behavior such as `NaN` being passed to the `onChange` handler.
 
 To avoid this issue in your test suite:
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This PR adds a new "Testing" section to the Rating component documentation.

Closes #38828 

### Motivation
When testing the Rating component in environments like Jest + jsdom, certain user interactions (e.g., hover-based selection) may not behave as expected. This is due to `getBoundingClientRect()` returning `0` values by default in jsdom, which can cause issues such as `NaN` being passed to the `onChange` handler.

### What’s included
- A warning about the limitation in test environments that do not fully implement layout behavior.
- A recommended test pattern using `fireEvent` instead of `userEvent`.
- A note on potential pitfalls when using `userEvent.click()` in such contexts.

### Example
```tsx
fireEvent.click(screen.getByLabelText("2 Stars"));
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
