### PR TITLE
[material-ui][Backdrop] Fix handling of `component` prop

### DIFF
--- a/packages/mui-material/src/Backdrop/Backdrop.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.js
@@ -80,6 +80,7 @@ const Backdrop = React.forwardRef(function Backdrop(inProps, ref) {
   };
   const backwardCompatibleSlotProps = { ...componentsProps, ...slotProps };
   const externalForwardedProps = {
+    component,
     slots: backwardCompatibleSlots,
     slotProps: backwardCompatibleSlotProps,
   };

--- a/packages/mui-material/src/Backdrop/Backdrop.test.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.test.js
@@ -24,7 +24,7 @@ describe('<Backdrop />', () => {
         testWithElement: null,
       },
     },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentsProp'],
   }));
 
   it('should render a backdrop div with content of nested children', () => {


### PR DESCRIPTION
closes https://github.com/mui/material-ui/issues/46264