### PR TITLE
do not reuse the emotion cache across SSR requests

### DIFF
--- a/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
+++ b/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
@@ -103,7 +103,7 @@ export default function StyledEngineProvider(props) {
   const { injectFirst, enableCssLayer, children } = props;
   const cache = React.useMemo(() => {
     const cacheKey = `${injectFirst}-${enableCssLayer}`;
-    if (cacheMap.has(cacheKey)) {
+    if (typeof document === 'object' && cacheMap.has(cacheKey)) {
       return cacheMap.get(cacheKey);
     }
     const fresh = getCache(injectFirst, enableCssLayer);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

When performing SSR, subsequent requests cannot reuse the same emotion cache, as it will think the style nodes have already been injected. This gates the cache reuse to only happening in a DOM environment (browser or jest).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
