### PR TITLE
[material-ui][FormControlHelperText] Add `size` prop to FormControlHelperTextProps

### DIFF
--- a/packages/mui-material/src/FormHelperText/FormHelperText.d.ts
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.d.ts
@@ -6,6 +6,7 @@ import { Theme } from '../styles';
 import { FormHelperTextClasses } from './formHelperTextClasses';
 
 export interface FormHelperTextPropsVariantOverrides {}
+export interface FormHelperTextPropsSizeOverrides {}
 
 export interface FormHelperTextOwnProps {
   /**
@@ -43,6 +44,11 @@ export interface FormHelperTextOwnProps {
    * If `true`, the helper text should use required classes key.
    */
   required?: boolean;
+  /**
+   * The size of the component.
+   * @default 'medium'
+   */
+  size?: OverridableStringUnion<'small' | 'medium', FormHelperTextPropsSizeOverrides>;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/mui-material/src/FormHelperText/FormHelperText.spec.tsx
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.spec.tsx
@@ -56,6 +56,12 @@ const TestComponent = () => {
           expectType<React.FormEvent<HTMLSpanElement>, typeof event>(event);
         }}
       />
+      <FormHelperText size="small" />
+      <FormHelperText size="medium" />
+      {
+        // @ts-expect-error invalid size
+        <FormHelperText size="large" />
+      }
     </React.Fragment>
   );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
