### PR TITLE
[material-nextjs][system] Backport CSS layers to v6

### DIFF
--- a/docs/data/material/customization/css-layers/CssLayersCaveat.js
+++ b/docs/data/material/customization/css-layers/CssLayersCaveat.js
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Typography from '@mui/material/Typography';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import Box from '@mui/material/Box';
+import Switch from '@mui/material/Switch';
+
+export default function CssLayersCaveat() {
+  const [cssLayers, setCssLayers] = React.useState(false);
+  const theme = React.useMemo(() => {
+    return createTheme({
+      modularCssLayers: cssLayers,
+      cssVariables: true,
+      components: {
+        MuiAccordion: {
+          styleOverrides: {
+            root: {
+              margin: 0,
+            },
+          },
+        },
+      },
+    });
+  }, [cssLayers]);
+  return (
+    <div>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginBottom: '16px',
+        }}
+      >
+        <Typography
+          component="span"
+          sx={{ marginRight: '8px', fontSize: '14px', color: 'text.secondary' }}
+        >
+          No CSS Layers
+        </Typography>
+        <Switch checked={cssLayers} onChange={() => setCssLayers(!cssLayers)} />
+        <Typography
+          component="span"
+          sx={{ marginLeft: '8px', fontSize: '14px', color: 'text.secondary' }}
+        >
+          With CSS Layers
+        </Typography>
+      </Box>
+      <ThemeProvider theme={theme}>
+        <div>
+          <Accordion defaultExpanded>
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              aria-controls="panel1-content"
+              id="panel1-header"
+            >
+              <Typography component="span">Accordion 1</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+              malesuada lacus ex, sit amet blandit leo lobortis eget.
+            </AccordionDetails>
+          </Accordion>
+          <Accordion>
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              aria-controls="panel2-content"
+              id="panel2-header"
+            >
+              <Typography component="span">Accordion 2</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+              malesuada lacus ex, sit amet blandit leo lobortis eget.
+            </AccordionDetails>
+          </Accordion>
+        </div>
+      </ThemeProvider>
+    </div>
+  );
+}

--- a/docs/data/material/customization/css-layers/CssLayersCaveat.tsx
+++ b/docs/data/material/customization/css-layers/CssLayersCaveat.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Typography from '@mui/material/Typography';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import Box from '@mui/material/Box';
+import Switch from '@mui/material/Switch';
+
+export default function CssLayersCaveat() {
+  const [cssLayers, setCssLayers] = React.useState(false);
+  const theme = React.useMemo(() => {
+    return createTheme({
+      modularCssLayers: cssLayers,
+      cssVariables: true,
+      components: {
+        MuiAccordion: {
+          styleOverrides: {
+            root: {
+              margin: 0,
+            },
+          },
+        },
+      },
+    });
+  }, [cssLayers]);
+  return (
+    <div>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginBottom: '16px',
+        }}
+      >
+        <Typography
+          component="span"
+          sx={{ marginRight: '8px', fontSize: '14px', color: 'text.secondary' }}
+        >
+          No CSS Layers
+        </Typography>
+        <Switch checked={cssLayers} onChange={() => setCssLayers(!cssLayers)} />
+        <Typography
+          component="span"
+          sx={{ marginLeft: '8px', fontSize: '14px', color: 'text.secondary' }}
+        >
+          With CSS Layers
+        </Typography>
+      </Box>
+      <ThemeProvider theme={theme}>
+        <div>
+          <Accordion defaultExpanded>
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              aria-controls="panel1-content"
+              id="panel1-header"
+            >
+              <Typography component="span">Accordion 1</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+              malesuada lacus ex, sit amet blandit leo lobortis eget.
+            </AccordionDetails>
+          </Accordion>
+          <Accordion>
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              aria-controls="panel2-content"
+              id="panel2-header"
+            >
+              <Typography component="span">Accordion 2</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+              malesuada lacus ex, sit amet blandit leo lobortis eget.
+            </AccordionDetails>
+          </Accordion>
+        </div>
+      </ThemeProvider>
+    </div>
+  );
+}

--- a/docs/data/material/customization/css-layers/CssLayersInput.js
+++ b/docs/data/material/customization/css-layers/CssLayersInput.js
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import FormHelperText from '@mui/material/FormHelperText';
+
+const theme = createTheme({
+  modularCssLayers: true,
+  cssVariables: true,
+});
+
+export default function CssLayersInput() {
+  return (
+    <ThemeProvider theme={theme}>
+      <FormControl variant="outlined">
+        <InputLabel
+          shrink
+          htmlFor="css-layers-input"
+          sx={{
+            width: 'fit-content',
+            transform: 'none',
+            position: 'relative',
+            mb: 0.25,
+            fontWeight: 'medium',
+            pointerEvents: 'auto',
+          }}
+        >
+          Label
+        </InputLabel>
+        <OutlinedInput
+          id="css-layers-input"
+          placeholder="Type something"
+          slotProps={{
+            input: {
+              sx: { py: 1.5, height: '2.5rem', boxSizing: 'border-box' },
+            },
+          }}
+        />
+        <FormHelperText sx={{ marginLeft: 0 }}>Helper text goes here</FormHelperText>
+      </FormControl>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/css-layers/CssLayersInput.tsx
+++ b/docs/data/material/customization/css-layers/CssLayersInput.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import FormHelperText from '@mui/material/FormHelperText';
+
+const theme = createTheme({
+  modularCssLayers: true,
+  cssVariables: true,
+});
+
+export default function CssLayersInput() {
+  return (
+    <ThemeProvider theme={theme}>
+      <FormControl variant="outlined">
+        <InputLabel
+          shrink
+          htmlFor="css-layers-input"
+          sx={{
+            width: 'fit-content',
+            transform: 'none',
+            position: 'relative',
+            mb: 0.25,
+            fontWeight: 'medium',
+            pointerEvents: 'auto',
+          }}
+        >
+          Label
+        </InputLabel>
+        <OutlinedInput
+          id="css-layers-input"
+          placeholder="Type something"
+          slotProps={{
+            input: {
+              sx: { py: 1.5, height: '2.5rem', boxSizing: 'border-box' },
+            },
+          }}
+        />
+        <FormHelperText sx={{ marginLeft: 0 }}>Helper text goes here</FormHelperText>
+      </FormControl>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/css-layers/css-layers.md
+++ b/docs/data/material/customization/css-layers/css-layers.md
@@ -1,0 +1,287 @@
+# CSS Layers
+
+<p class="description">Learn how to generate Material UI styles with cascade layers.</p>
+
+## What are cascade layers?
+
+Cascade layers are an advanced CSS feature that make it possible to control the order in which styles are applied to elements.
+If you're not familiar with cascade layers, visit the [MDN documentation](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Cascade_layers) for a detailed overview.
+
+Benefits of using cascade layers include:
+
+- **Improved specificity**: Cascade layers let you control the order of the styles, which can help avoid specificity conflicts. For example, you can theme a component without hitting the default specificity of the styles.
+- **Better integration with CSS frameworks**: With cascade layers, you can use Tailwind CSS v4 utility classes to override Material UI styles without the need for the `!important` directive.
+- **Better debuggability**: Cascade layers appear in the browser's dev tools, making it easier to see which styles are applied and in what order.
+
+## Implementing a single cascade layer
+
+This method creates a single layer, namely `@layer mui`, for all Material UI components and global styles.
+This is suitable for integrating with other styling solutions, such as Tailwind CSS v4, that use the `@layer` directive.
+
+### Next.js App Router
+
+Start by configuring Material UI with Next.js in the [App Router integration guide](/material-ui/integrations/nextjs/#app-router).
+Then follow these steps:
+
+1. Enable the [CSS layer feature](/material-ui/integrations/nextjs/#using-other-styling-solutions) in the root layout:
+
+```tsx title="src/app/layout.tsx"
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
+
+export default function RootLayout() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <AppRouterCacheProvider options={{ enableCssLayer: true }}>
+          {/* Your app */}
+        </AppRouterCacheProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+2. Configure the layer order at the top of a CSS file to work with Tailwind CSS v4:
+
+```css title="src/app/globals.css"
+@layer theme, base, mui, components, utilities;
+```
+
+### Next.js Pages Router
+
+Start by configuring Material UI with Next.js in the [Pages Router integration guide](/material-ui/integrations/nextjs/#pages-router).
+Then follow these steps:
+
+1. Enable the [CSS layer feature](/material-ui/integrations/nextjs/#configuration-2) in a custom `_document`:
+
+```tsx title="pages/_document.tsx"
+import {
+  createCache,
+  documentGetInitialProps,
+} from '@mui/material-nextjs/v15-pagesRouter';
+
+// ...
+
+MyDocument.getInitialProps = async (ctx: DocumentContext) => {
+  const finalProps = await documentGetInitialProps(ctx, {
+    emotionCache: createCache({ enableCssLayer: true }),
+  });
+  return finalProps;
+};
+```
+
+2. Configure the layer order with the `GlobalStyles` component to work with Tailwind CSS v4—it must be the first child of the `AppCacheProvider`:
+
+```tsx title="pages/_app.tsx"
+import { AppCacheProvider } from '@mui/material-nextjs/v15-pagesRouter';
+import GlobalStyles from '@mui/material/GlobalStyles';
+
+export default function MyApp(props: AppProps) {
+  const { Component, pageProps } = props;
+  return (
+    <AppCacheProvider {...props}>
+      <GlobalStyles styles="@layer theme, base, mui, components, utilities;" />
+      <Component {...pageProps} />
+    </AppCacheProvider>
+  );
+}
+```
+
+### Vite or any other SPA
+
+Make the following changes in `src/main.tsx`:
+
+1. Pass the `enableCssLayer` prop to the `StyledEngineProvider` component.
+2. Configure the layer order with the `GlobalStyles` component to work with Tailwind CSS v4.
+
+```tsx title="main.tsx"
+import { StyledEngineProvider } from '@mui/material/styles';
+import GlobalStyles from '@mui/material/GlobalStyles';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <StyledEngineProvider enableCssLayer>
+      <GlobalStyles styles="@layer theme, base, mui, components, utilities;" />
+      {/* Your app */}
+    </StyledEngineProvider>
+  </React.StrictMode>,
+);
+```
+
+## Implementing multiple cascade layers
+
+After you've set up a [single cascade layer](#implementing-a-single-cascade-layer), you can split the styles into multiple layers to better organize them within Material UI.
+This makes it simpler to apply theming and override styles with the `sx` prop.
+
+First, follow the steps from the [previous section](#implementing-a-single-cascade-layer) to enable the CSS layer feature.
+Then, create a new file and export the component that wraps the `ThemeProvider` from Material UI.
+Finally, pass the `modularCssLayers: true` option to the `createTheme` function:
+
+```tsx title="src/theme.tsx"
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+const theme = createTheme({
+  modularCssLayers: true,
+});
+
+export default function AppTheme({ children }: { children: ReactNode }) {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}
+```
+
+{{"demo": "CssLayersInput.js"}}
+
+When this feature is enabled, Material UI generates these layers:
+
+- `@layer mui.global`: Global styles from the `GlobalStyles` and `CssBaseline` components.
+- `@layer mui.components`: Base styles for all Material UI components.
+- `@layer mui.theme`: Theme styles for all Material UI components.
+- `@layer mui.custom`: Custom styles for non-Material UI styled components.
+- `@layer mui.sx`: Styles from the `sx` prop.
+
+The sections below demonstrate how to set up multiple cascade layers for Material UI with common React frameworks.
+
+### Next.js App Router
+
+```tsx title="src/theme.tsx"
+'use client';
+import React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+const theme = createTheme({
+  modularCssLayers: true,
+});
+
+export default function AppTheme({ children }: { children: React.ReactNode }) {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}
+```
+
+```tsx title="src/app/layout.tsx"
+import AppTheme from '../theme';
+
+export default function RootLayout() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <AppRouterCacheProvider options={{ enableCssLayer: true }}>
+          <AppTheme>{/* Your app */}</AppTheme>
+        </AppRouterCacheProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+### Next.js Pages Router
+
+```tsx title="src/theme.tsx"
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+const theme = createTheme({
+  modularCssLayers: true,
+});
+
+export default function AppTheme({ children }: { children: ReactNode }) {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}
+```
+
+```tsx title="pages/_app.tsx"
+import AppTheme from '../src/theme';
+
+export default function MyApp(props: AppProps) {
+  const { Component, pageProps } = props;
+  return (
+    <AppCacheProvider {...props}>
+      <AppTheme>
+        <Component {...pageProps} />
+      </AppTheme>
+    </AppCacheProvider>
+  );
+}
+```
+
+```tsx title="pages/_document.tsx"
+import {
+  createCache,
+  documentGetInitialProps,
+} from '@mui/material-nextjs/v15-pagesRouter';
+
+MyDocument.getInitialProps = async (ctx: DocumentContext) => {
+  const finalProps = await documentGetInitialProps(ctx, {
+    emotionCache: createCache({ enableCssLayer: true }),
+  });
+  return finalProps;
+};
+```
+
+### Vite or any other SPA
+
+```tsx title="src/theme.tsx"
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+const theme = createTheme({
+  modularCssLayers: true,
+});
+
+export default function AppTheme({ children }: { children: ReactNode }) {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}
+```
+
+```tsx title="src/main.tsx"
+import AppTheme from './theme';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <StyledEngineProvider enableCssLayer>
+      <AppTheme>{/* Your app */}</AppTheme>
+    </StyledEngineProvider>
+  </React.StrictMode>,
+);
+```
+
+### Usage with other styling solutions
+
+To integrate with other styling solutions, such as Tailwind CSS v4, replace the boolean value for `modularCssLayers` with a string specifying the layer order.
+Material UI will look for the `mui` identifier and generate the layers in the correct order:
+
+```diff title="src/theme.tsx"
+ const theme = createTheme({
+-  modularCssLayers: true,
++  modularCssLayers: '@layer theme, base, mui, components, utilities;',
+ });
+```
+
+The generated CSS will look like this:
+
+```css
+@layer theme, base, mui.global, mui.components, mui.theme, mui.custom, mui.sx, components, utilities;
+```
+
+### Caveats
+
+If you enable `modularCssLayers` in an app that already has custom styles and theme overrides applied to it, you may observe unexpected changes to the look and feel of the UI due to the differences in specificity before and after.
+
+For example, if you have the following [theme style overrides](/material-ui/customization/theme-components/#theme-style-overrides) for the [Accordion](/material-ui/react-accordion/) component:
+
+```js
+const theme = createTheme({
+  components: {
+    MuiAccordion: {
+      styleOverrides: {
+        root: {
+          margin: 0,
+        },
+      },
+    },
+  },
+});
+```
+
+By default, the margin from the theme does _not_ take precedence over the default margin styles when the accordion is expanded, because it has higher specificity than the theme styles—so this code has no effect.
+
+After enabling the `modularCssLayers` option, the margin from the theme _does_ take precedence because the theme layer comes after the components layer in the cascade order—so the style override is applied and the accordion has no margins when expanded.
+
+{{"demo": "CssLayersCaveat.js"}}

--- a/docs/data/material/integrations/nextjs/nextjs.md
+++ b/docs/data/material/integrations/nextjs/nextjs.md
@@ -118,7 +118,7 @@ Finally, in `src/app/layout.tsx`, pass the theme to the `ThemeProvider`:
 
 To learn more about theming, check out the [theming guide](/material-ui/customization/theming/) page.
 
-#### CSS theme variables
+### CSS theme variables
 
 To use [CSS theme variables](/material-ui/customization/css-theme-variables/overview/), enable the `cssVariables` flag:
 
@@ -241,6 +241,40 @@ To use a custom [Emotion cache](https://emotion.sh/docs/@emotion/cache), pass it
    });
    return finalProps;
  };
+```
+
+#### Cascade layers (optional)
+
+To enable [cascade layers](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Cascade_layers) (`@layer`), create a new cache with `enableCssLayer: true` and pass it to the `emotionCache` property in both `_document.tsx` and `_app.tsx`:
+
+```diff title="pages/_document.tsx"
++import { createEmotionCache } from '@mui/material-nextjs/v15-pagesRouter';
+ ...
+
+ MyDocument.getInitialProps = async (ctx) => {
+   const finalProps = await documentGetInitialProps(ctx, {
++    emotionCache: createEmotionCache({ enableCssLayer: true }),
+   });
+   return finalProps;
+ };
+```
+
+```diff title="pages/_app.tsx"
++import { createEmotionCache } from '@mui/material-nextjs/v15-pagesRouter';
+  ...
+
+const clientCache = createEmotionCache({ enableCssLayer: true });
+
++ export default function MyApp({ emotionCache = clientCache }) {
+    return (
++     <AppCacheProvider emotionCache={emotionCache}>
+        <Head>
+          ...
+        </Head>
+        ...
+      </AppCacheProvider>
+    );
+  }
 ```
 
 #### App enhancement (optional)

--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -232,6 +232,18 @@ const pages: MuiPage[] = [
           },
         ],
       },
+      {
+        pathname: '/material-ui/customization/styles',
+        subheader: '/material-ui/customization/styles',
+        title: 'Styles',
+        children: [
+          {
+            pathname: '/material-ui/customization/css-layers',
+            title: 'Cascade layers',
+            newFeature: true,
+          },
+        ],
+      },
     ],
   },
   {

--- a/docs/pages/material-ui/customization/css-layers.js
+++ b/docs/pages/material-ui/customization/css-layers.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docs/data/material/customization/css-layers/css-layers.md?muiMarkdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -242,6 +242,8 @@
     "/material-ui/customization/css-theme-variables/overview": "Overview",
     "/material-ui/customization/css-theme-variables/usage": "Basic usage",
     "/material-ui/customization/css-theme-variables/configuration": "Advanced configuration",
+    "/material-ui/customization/styles": "Styles",
+    "/material-ui/customization/css-layers": "Cascade layers",
     "/material-ui/guides": "How-to guides",
     "/material-ui/guides/minimizing-bundle-size": "Minimizing bundle size",
     "/material-ui/guides/server-rendering": "Server rendering",

--- a/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
+++ b/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
@@ -38,7 +38,7 @@ export default function AppRouterCacheProvider(props: AppRouterCacheProviderProp
     let inserted: { name: string; isGlobal: boolean }[] = [];
     // Override the insert method to support streaming SSR with flush().
     cache.insert = (...args) => {
-      if (options?.enableCssLayer && !args[1].styles.startsWith('@layer')) {
+      if (options?.enableCssLayer && !args[1].styles.match(/^@layer\s+[^{]*$/)) {
         args[1].styles = `@layer mui {${args[1].styles}}`;
       }
       const [selector, serialized] = args;

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/createCache.ts
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/createCache.ts
@@ -23,8 +23,8 @@ export default function createEmotionCache(
   if (enableCssLayer) {
     const prevInsert = emotionCache.insert;
     emotionCache.insert = (...args) => {
-      if (!args[1].styles.startsWith('@layer')) {
-        // avoid nested @layer
+      // ignore styles that contain layer order (`@layer ...` without `{`)
+      if (!args[1].styles.match(/^@layer\s+[^{]*$/)) {
         args[1].styles = `@layer mui {${args[1].styles}}`;
       }
       return prevInsert(...args);

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/createCache.ts
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/createCache.ts
@@ -5,7 +5,9 @@ const isBrowser = typeof document !== 'undefined';
 // On the client side, Create a meta tag at the top of the <head> and set it as insertionPoint.
 // This assures that MUI styles are loaded first.
 // It allows developers to easily override MUI styles with other styling solutions, like CSS modules.
-export default function createEmotionCache() {
+export default function createEmotionCache(
+  options?: { enableCssLayer?: boolean } & Parameters<typeof createCache>[0],
+) {
   let insertionPoint;
 
   if (isBrowser) {
@@ -15,5 +17,18 @@ export default function createEmotionCache() {
     insertionPoint = emotionInsertionPoint ?? undefined;
   }
 
-  return createCache({ key: 'mui', insertionPoint });
+  const { enableCssLayer, ...rest } = options ?? {};
+
+  const emotionCache = createCache({ key: 'mui', insertionPoint, ...rest });
+  if (enableCssLayer) {
+    const prevInsert = emotionCache.insert;
+    emotionCache.insert = (...args) => {
+      if (!args[1].styles.startsWith('@layer')) {
+        // avoid nested @layer
+        args[1].styles = `@layer mui {${args[1].styles}}`;
+      }
+      return prevInsert(...args);
+    };
+  }
+  return emotionCache;
 }

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/index.ts
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/index.ts
@@ -1,2 +1,3 @@
 export * from './pagesRouterV13Document';
 export * from './pagesRouterV13App';
+export { default as createEmotionCache } from './createCache';

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
@@ -99,14 +99,23 @@ export async function documentGetInitialProps(
         const { styles } = extractCriticalToChunks(initialProps.html);
         return {
           ...initialProps,
-          emotionStyleTags: styles.map((style) => (
-            <style
-              data-emotion={`${style.key} ${style.ids.join(' ')}`}
-              key={style.key}
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: style.css }}
-            />
-          )),
+          emotionStyleTags: styles.map((style) => {
+            if (!style.css.trim()) {
+              return null;
+            }
+            const isLayerOrderRule = style.css.startsWith('@layer') && !style.css.match(/\{.*\}/);
+            return (
+              <style
+                // If the style is a layer order rule, prefix with the cache key to let Emotion hydrate this node.
+                // Otherwise, Emotion will hydrate only the non-global styles and they will override the layer order rule.
+                data-emotion={`${isLayerOrderRule ? `${cache.key} ` : ''}${style.key} ${style.ids.join(' ')}`}
+                key={style.key}
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{ __html: style.css }}
+                nonce={cache.nonce}
+              />
+            );
+          }),
         };
       },
     },

--- a/packages/mui-material/src/Breadcrumbs/BreadcrumbCollapsed.js
+++ b/packages/mui-material/src/Breadcrumbs/BreadcrumbCollapsed.js
@@ -7,7 +7,9 @@ import memoTheme from '../utils/memoTheme';
 import MoreHorizIcon from '../internal/svg-icons/MoreHoriz';
 import ButtonBase from '../ButtonBase';
 
-const BreadcrumbCollapsedButton = styled(ButtonBase)(
+const BreadcrumbCollapsedButton = styled(ButtonBase, {
+  name: 'MuiBreadcrumbCollapsed',
+})(
   memoTheme(({ theme }) => ({
     display: 'flex',
     marginLeft: `calc(${theme.spacing(1)} * 0.5)`,

--- a/packages/mui-material/src/NativeSelect/NativeSelectInput.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelectInput.js
@@ -20,7 +20,9 @@ const useUtilityClasses = (ownerState) => {
   return composeClasses(slots, getNativeSelectUtilityClasses, classes);
 };
 
-export const StyledSelectSelect = styled('select')(({ theme }) => ({
+export const StyledSelectSelect = styled('select', {
+  name: 'MuiNativeSelect',
+})(({ theme }) => ({
   // Reset
   MozAppearance: 'none',
   // Reset
@@ -99,7 +101,9 @@ const NativeSelectSelect = styled(StyledSelectSelect, {
   },
 })({});
 
-export const StyledSelectIcon = styled('svg')(({ theme }) => ({
+export const StyledSelectIcon = styled('svg', {
+  name: 'MuiNativeSelect',
+})(({ theme }) => ({
   // We use a position absolute over a flexbox in order to forward the pointer events
   // to the input and to support wrapping tags..
   position: 'absolute',

--- a/packages/mui-material/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material/src/OutlinedInput/NotchedOutline.js
@@ -5,7 +5,10 @@ import rootShouldForwardProp from '../styles/rootShouldForwardProp';
 import { styled } from '../zero-styled';
 import memoTheme from '../utils/memoTheme';
 
-const NotchedOutlineRoot = styled('fieldset', { shouldForwardProp: rootShouldForwardProp })({
+const NotchedOutlineRoot = styled('fieldset', {
+  name: 'MuiNotchedOutlined',
+  shouldForwardProp: rootShouldForwardProp,
+})({
   textAlign: 'left',
   position: 'absolute',
   bottom: 0,
@@ -22,7 +25,10 @@ const NotchedOutlineRoot = styled('fieldset', { shouldForwardProp: rootShouldFor
   minWidth: '0%',
 });
 
-const NotchedOutlineLegend = styled('legend', { shouldForwardProp: rootShouldForwardProp })(
+const NotchedOutlineLegend = styled('legend', {
+  name: 'MuiNotchedOutlined',
+  shouldForwardProp: rootShouldForwardProp,
+})(
   memoTheme(({ theme }) => ({
     float: 'unset', // Fix conflict with bootstrap
     width: 'auto', // Fix conflict with bootstrap

--- a/packages/mui-material/src/Radio/RadioButtonIcon.js
+++ b/packages/mui-material/src/Radio/RadioButtonIcon.js
@@ -7,17 +7,24 @@ import rootShouldForwardProp from '../styles/rootShouldForwardProp';
 import { styled } from '../zero-styled';
 import memoTheme from '../utils/memoTheme';
 
-const RadioButtonIconRoot = styled('span', { shouldForwardProp: rootShouldForwardProp })({
+const RadioButtonIconRoot = styled('span', {
+  name: 'MuiRadioButtonIcon',
+  shouldForwardProp: rootShouldForwardProp,
+})({
   position: 'relative',
   display: 'flex',
 });
 
-const RadioButtonIconBackground = styled(RadioButtonUncheckedIcon)({
+const RadioButtonIconBackground = styled(RadioButtonUncheckedIcon, {
+  name: 'MuiRadioButtonIcon',
+})({
   // Scale applied to prevent dot misalignment in Safari
   transform: 'scale(1)',
 });
 
-const RadioButtonIconDot = styled(RadioButtonCheckedIcon)(
+const RadioButtonIconDot = styled(RadioButtonCheckedIcon, {
+  name: 'MuiRadioButtonIcon',
+})(
   memoTheme(({ theme }) => ({
     left: 0,
     position: 'absolute',

--- a/packages/mui-material/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeArea.js
@@ -8,7 +8,10 @@ import rootShouldForwardProp from '../styles/rootShouldForwardProp';
 import capitalize from '../utils/capitalize';
 import { isHorizontal } from '../Drawer/Drawer';
 
-const SwipeAreaRoot = styled('div', { shouldForwardProp: rootShouldForwardProp })(
+const SwipeAreaRoot = styled('div', {
+  name: 'MuiSwipeArea',
+  shouldForwardProp: rootShouldForwardProp,
+})(
   memoTheme(({ theme }) => ({
     position: 'fixed',
     top: 0,

--- a/packages/mui-material/src/internal/SwitchBase.js
+++ b/packages/mui-material/src/internal/SwitchBase.js
@@ -23,7 +23,9 @@ const useUtilityClasses = (ownerState) => {
   return composeClasses(slots, getSwitchBaseUtilityClass, classes);
 };
 
-const SwitchBaseRoot = styled(ButtonBase)({
+const SwitchBaseRoot = styled(ButtonBase, {
+  name: 'MuiSwitchBase',
+})({
   padding: 9,
   borderRadius: '50%',
   variants: [
@@ -60,7 +62,10 @@ const SwitchBaseRoot = styled(ButtonBase)({
   ],
 });
 
-const SwitchBaseInput = styled('input', { shouldForwardProp: rootShouldForwardProp })({
+const SwitchBaseInput = styled('input', {
+  name: 'MuiSwitchBase',
+  shouldForwardProp: rootShouldForwardProp,
+})({
   cursor: 'inherit',
   position: 'absolute',
   opacity: 0,

--- a/packages/mui-material/src/styles/createThemeNoVars.d.ts
+++ b/packages/mui-material/src/styles/createThemeNoVars.d.ts
@@ -42,6 +42,7 @@ export interface ThemeOptions extends Omit<SystemThemeOptions, 'zIndex'>, CssVar
   zIndex?: ZIndexOptions;
   unstable_strictMode?: boolean;
   unstable_sxConfig?: SxConfig;
+  modularCssLayers?: boolean | string;
 }
 
 export interface BaseTheme extends SystemTheme {

--- a/packages/mui-material/src/styles/extendTheme.test.js
+++ b/packages/mui-material/src/styles/extendTheme.test.js
@@ -865,4 +865,11 @@ describe('extendTheme', () => {
       ]);
     });
   });
+
+  it('should not generate vars for modularCssLayers', () => {
+    const theme = extendTheme({
+      modularCssLayers: '@layer mui,utilities;',
+    });
+    expect(theme.vars.modularCssLayers).to.equal(undefined);
+  });
 });

--- a/packages/mui-material/src/styles/shouldSkipGeneratingVar.ts
+++ b/packages/mui-material/src/styles/shouldSkipGeneratingVar.ts
@@ -1,7 +1,7 @@
 export default function shouldSkipGeneratingVar(keys: string[]) {
   return (
     !!keys[0].match(
-      /(cssVarPrefix|colorSchemeSelector|rootSelector|typography|mixins|breakpoints|direction|transitions)/,
+      /(cssVarPrefix|colorSchemeSelector|modularCssLayers|rootSelector|typography|mixins|breakpoints|direction|transitions)/,
     ) ||
     !!keys[0].match(/sxConfig$/) || // ends with sxConfig
     (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/))

--- a/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
+++ b/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
@@ -87,7 +87,7 @@ function getCache(injectFirst, enableCssLayer) {
     if (enableCssLayer) {
       const prevInsert = emotionCache.insert;
       emotionCache.insert = (...args) => {
-        if (!args[1].styles.startsWith('@layer')) {
+        if (!args[1].styles.match(/^@layer\s+[^{]*$/)) {
           // avoid nested @layer
           args[1].styles = `@layer mui {${args[1].styles}}`;
         }

--- a/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
+++ b/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
@@ -103,7 +103,7 @@ export default function StyledEngineProvider(props) {
   const { injectFirst, enableCssLayer, children } = props;
   const cache = React.useMemo(() => {
     const cacheKey = `${injectFirst}-${enableCssLayer}`;
-    if (cacheMap.has(cacheKey)) {
+    if (typeof document === 'object' && cacheMap.has(cacheKey)) {
       return cacheMap.get(cacheKey);
     }
     const fresh = getCache(injectFirst, enableCssLayer);

--- a/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.test.js
+++ b/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.test.js
@@ -33,13 +33,22 @@ describe('[Emotion] StyledEngineProvider', () => {
     expect(rule).to.equal('@layer mui{html{color:red;}}');
   });
 
-  it('should do nothing if the styles already in a layer', () => {
+  it('should not do anything if the style is layer order', () => {
+    render(
+      <StyledEngineProvider enableCssLayer>
+        <GlobalStyles styles="@layer theme, base, mui, components, utilities;" />
+      </StyledEngineProvider>,
+    );
+    expect(rule).to.equal('@layer theme,base,mui,components,utilities;');
+  });
+
+  it('should wrap @layer rule', () => {
     render(
       <StyledEngineProvider enableCssLayer>
         <GlobalStyles styles={{ '@layer components': { html: { color: 'red' } } }} />
       </StyledEngineProvider>,
     );
-    expect(rule).to.equal('@layer components{html{color:red;}}');
+    expect(rule).to.equal('@layer mui{@layer components{html{color:red;}}}');
   });
 
   it('able to config layer order through GlobalStyles', () => {

--- a/packages/mui-system/src/GlobalStyles/GlobalStyles.tsx
+++ b/packages/mui-system/src/GlobalStyles/GlobalStyles.tsx
@@ -1,7 +1,11 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { GlobalStyles as MuiGlobalStyles, Interpolation } from '@mui/styled-engine';
+import {
+  GlobalStyles as MuiGlobalStyles,
+  Interpolation,
+  internal_serializeStyles as serializeStyles,
+} from '@mui/styled-engine';
 import useTheme from '../useTheme';
 import { Theme as SystemTheme } from '../createTheme';
 
@@ -11,17 +15,39 @@ export interface GlobalStylesProps<Theme = SystemTheme> {
   themeId?: string;
 }
 
+function wrapGlobalLayer(styles: any) {
+  const serialized = serializeStyles(styles) as { styles?: string };
+  if (styles !== serialized && serialized.styles) {
+    if (!serialized.styles.match(/^@layer\s+[^{]*$/)) {
+      // If the styles are not already wrapped in a layer, wrap them in a global layer.
+      serialized.styles = `@layer global{${serialized.styles}}`;
+    }
+    return serialized;
+  }
+  return styles;
+}
+
 function GlobalStyles<Theme = SystemTheme>({
   styles,
   themeId,
   defaultTheme = {},
 }: GlobalStylesProps<Theme>) {
   const upperTheme = useTheme(defaultTheme);
+  const resolvedTheme = themeId ? (upperTheme as any)[themeId] || upperTheme : upperTheme;
 
-  const globalStyles =
-    typeof styles === 'function'
-      ? styles(themeId ? (upperTheme as any)[themeId] || upperTheme : upperTheme)
-      : styles;
+  let globalStyles = typeof styles === 'function' ? styles(resolvedTheme) : styles;
+  if (resolvedTheme.modularCssLayers) {
+    if (Array.isArray(globalStyles)) {
+      globalStyles = globalStyles.map((styleArg) => {
+        if (typeof styleArg === 'function') {
+          return wrapGlobalLayer(styleArg(resolvedTheme));
+        }
+        return wrapGlobalLayer(styleArg);
+      });
+    } else {
+      globalStyles = wrapGlobalLayer(globalStyles);
+    }
+  }
 
   return <MuiGlobalStyles styles={globalStyles as any} />;
 }

--- a/packages/mui-system/src/ThemeProvider/ThemeProvider.js
+++ b/packages/mui-system/src/ThemeProvider/ThemeProvider.js
@@ -10,6 +10,7 @@ import { ThemeContext as StyledEngineThemeContext } from '@mui/styled-engine';
 import useThemeWithoutDefault from '../useThemeWithoutDefault';
 import RtlProvider from '../RtlProvider';
 import DefaultPropsProvider from '../DefaultPropsProvider';
+import useLayerOrder from './useLayerOrder';
 
 const EMPTY_THEME = {};
 
@@ -64,6 +65,9 @@ function ThemeProvider(props) {
   const engineTheme = useThemeScoping(themeId, upperTheme, localTheme);
   const privateTheme = useThemeScoping(themeId, upperPrivateTheme, localTheme, true);
   const rtlValue = (themeId ? engineTheme[themeId] : engineTheme).direction === 'rtl';
+
+  const layerOrder = useLayerOrder(engineTheme);
+
   return (
     <MuiThemeProvider theme={privateTheme}>
       <StyledEngineThemeContext.Provider value={engineTheme}>
@@ -71,6 +75,7 @@ function ThemeProvider(props) {
           <DefaultPropsProvider
             value={themeId ? engineTheme[themeId].components : engineTheme.components}
           >
+            {layerOrder}
             {children}
           </DefaultPropsProvider>
         </RtlProvider>

--- a/packages/mui-system/src/ThemeProvider/useLayerOrder.test.tsx
+++ b/packages/mui-system/src/ThemeProvider/useLayerOrder.test.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { ThemeContext } from '@mui/styled-engine';
+import { createRenderer } from '@mui/internal-test-utils';
+import useLayerOrder from './useLayerOrder';
+
+function TestComponent({ theme }: { theme: any }) {
+  const LayerOrder = useLayerOrder(theme);
+  return LayerOrder;
+}
+
+describe('useLayerOrder', () => {
+  const { render } = createRenderer();
+
+  afterEach(() => {
+    // Clean up any injected style tags
+    document.querySelectorAll('style[data-mui-layer-order]').forEach((el) => el.remove());
+  });
+
+  it('attach layer order', () => {
+    const theme = { modularCssLayers: true };
+    render(<TestComponent theme={theme} />);
+    expect(document.head.firstChild).not.to.equal(null);
+    expect(document.head.firstChild?.textContent).to.contain(
+      '@layer mui.global, mui.components, mui.theme, mui.custom, mui.sx;',
+    );
+  });
+
+  it('custom layer order string', () => {
+    const theme = { modularCssLayers: '@layer theme, base, mui, utilities;' };
+    render(<TestComponent theme={theme} />);
+    expect(document.head.firstChild?.textContent).to.contain(
+      '@layer theme, base, mui.global, mui.components, mui.theme, mui.custom, mui.sx, utilities;',
+    );
+  });
+
+  it('does not replace nested layer', () => {
+    const theme = { modularCssLayers: '@layer theme, base, mui.unknown, utilities;' };
+    render(<TestComponent theme={theme} />);
+    expect(document.head.firstChild?.textContent).to.contain(
+      '@layer theme, base, mui.unknown, utilities;',
+    );
+  });
+
+  it('returns null if modularCssLayers is falsy', () => {
+    render(<TestComponent theme={{}} />);
+    expect(document.head.firstChild?.nodeName).not.to.equal('STYLE');
+  });
+
+  it('do nothing if upperTheme exists to avoid duplicate elements', () => {
+    render(
+      <ThemeContext.Provider value={{ modularCssLayers: true }}>
+        <TestComponent theme={{}} />
+      </ThemeContext.Provider>,
+    );
+    expect(document.head.firstChild?.nodeName).not.to.equal('STYLE');
+  });
+});

--- a/packages/mui-system/src/ThemeProvider/useLayerOrder.tsx
+++ b/packages/mui-system/src/ThemeProvider/useLayerOrder.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
+import useId from '@mui/utils/useId';
+import GlobalStyles from '../GlobalStyles';
+import useThemeWithoutDefault from '../useThemeWithoutDefault';
+
+/**
+ * This hook returns a `GlobalStyles` component that sets the CSS layer order (for server-side rendering).
+ * Then on client-side, it injects the CSS layer order into the document head to ensure that the layer order is always present first before other Emotion styles.
+ */
+export default function useLayerOrder(theme: { modularCssLayers?: boolean | string }) {
+  const upperTheme = useThemeWithoutDefault();
+  const id = useId() || '';
+  const { modularCssLayers } = theme;
+
+  let layerOrder = 'mui.global, mui.components, mui.theme, mui.custom, mui.sx';
+
+  if (!modularCssLayers || upperTheme !== null) {
+    // skip this hook if upper theme exists.
+    layerOrder = '';
+  } else if (typeof modularCssLayers === 'string') {
+    layerOrder = modularCssLayers.replace(/mui(?!\.)/g, layerOrder);
+  } else {
+    layerOrder = `@layer ${layerOrder};`;
+  }
+
+  useEnhancedEffect(() => {
+    const head = document.querySelector('head');
+    if (!head) {
+      return;
+    }
+    const firstChild = head.firstChild as HTMLElement | null;
+
+    if (layerOrder) {
+      // Only insert if first child doesn't have data-mui-layer-order attribute
+      if (
+        firstChild &&
+        firstChild.hasAttribute?.('data-mui-layer-order') &&
+        firstChild.getAttribute('data-mui-layer-order') === id
+      ) {
+        return;
+      }
+      const styleElement = document.createElement('style');
+      styleElement.setAttribute('data-mui-layer-order', id);
+      styleElement.textContent = layerOrder;
+
+      head.prepend(styleElement);
+    } else {
+      head.querySelector(`style[data-mui-layer-order="${id}"]`)?.remove();
+    }
+  }, [layerOrder, id]);
+
+  if (!layerOrder) {
+    return null;
+  }
+
+  return <GlobalStyles styles={layerOrder} />;
+}

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.js
@@ -76,7 +76,7 @@ export function unstable_createStyleFunctionSx() {
   }
 
   function styleFunctionSx(props) {
-    const { sx, theme = {} } = props || {};
+    const { sx, theme = {}, nested } = props || {};
 
     if (!sx) {
       return null; // Emotion & styled-components will neglect null
@@ -117,7 +117,7 @@ export function unstable_createStyleFunctionSx() {
               }));
 
               if (objectsHaveSameKeys(breakpointsValues, value)) {
-                css[styleKey] = styleFunctionSx({ sx: value, theme });
+                css[styleKey] = styleFunctionSx({ sx: value, theme, nested: true });
               } else {
                 css = merge(css, breakpointsValues);
               }
@@ -127,6 +127,12 @@ export function unstable_createStyleFunctionSx() {
           }
         }
       });
+
+      if (!nested && theme.modularCssLayers) {
+        return {
+          '@layer sx': sortContainerQueries(theme, removeUnusedBreakpoints(breakpointsKeys, css)),
+        };
+      }
 
       return sortContainerQueries(theme, removeUnusedBreakpoints(breakpointsKeys, css));
     }

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
@@ -477,4 +477,140 @@ describe('styleFunctionSx', () => {
       ).not.to.throw();
     });
   });
+
+  describe('Modular CSS layers', () => {
+    it('should wrapped in @layer', () => {
+      const result = styleFunctionSx({
+        theme: {
+          ...theme,
+          modularCssLayers: true,
+        },
+        sx: {
+          color: 'primary.main',
+          bgcolor: 'secondary.main',
+          outline: 1,
+          outlineColor: 'secondary.main',
+          m: 2,
+          p: 1,
+          fontFamily: 'default',
+          fontWeight: 'light',
+          fontSize: 'fontSize',
+          maxWidth: 'sm',
+        },
+      });
+
+      expect(result).to.deep.equal({
+        '@layer sx': {
+          color: 'rgb(0, 0, 255)',
+          backgroundColor: 'rgb(0, 255, 0)',
+          outline: '1px solid',
+          outlineColor: 'rgb(0, 255, 0)',
+          margin: '20px',
+          padding: '10px',
+          fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+          fontWeight: 300,
+          fontSize: 14,
+          maxWidth: 600,
+        },
+      });
+    });
+
+    it('should work with array type', () => {
+      const result = styleFunctionSx({
+        theme: {
+          ...theme,
+          modularCssLayers: true,
+        },
+        sx: [
+          {
+            bgcolor: 'secondary.main',
+          },
+          {
+            color: 'primary.main',
+          },
+        ],
+      });
+
+      expect(result).to.deep.equal([
+        {
+          '@layer sx': {
+            backgroundColor: 'rgb(0, 255, 0)',
+          },
+        },
+        {
+          '@layer sx': {
+            color: 'rgb(0, 0, 255)',
+          },
+        },
+      ]);
+    });
+
+    it('should work with function type', () => {
+      const result = styleFunctionSx({
+        theme: {
+          ...theme,
+          modularCssLayers: true,
+        },
+        sx: (t) => ({
+          color: t.palette.primary.main,
+          bgcolor: t.palette.secondary.main,
+        }),
+      });
+
+      expect(result).to.deep.equal({
+        '@layer sx': {
+          color: 'rgb(0, 0, 255)',
+          backgroundColor: 'rgb(0, 255, 0)',
+        },
+      });
+    });
+
+    it('should work with nested sx', () => {
+      const result = styleFunctionSx({
+        theme: {
+          ...theme,
+          modularCssLayers: true,
+        },
+        sx: {
+          color: 'primary.main',
+          '&:hover': {
+            bgcolor: 'secondary.main',
+          },
+        },
+      });
+
+      expect(result).to.deep.equal({
+        '@layer sx': {
+          color: 'rgb(0, 0, 255)',
+          '&:hover': {
+            backgroundColor: 'rgb(0, 255, 0)',
+          },
+        },
+      });
+    });
+
+    it('should work with nested sx and function', () => {
+      const result = styleFunctionSx({
+        theme: {
+          ...theme,
+          modularCssLayers: true,
+        },
+        sx: {
+          color: 'primary.main',
+          '&:hover': (t) => ({
+            bgcolor: t.palette.secondary.main,
+          }),
+        },
+      });
+
+      expect(result).to.deep.equal({
+        '@layer sx': {
+          color: 'rgb(0, 0, 255)',
+          '&:hover': {
+            backgroundColor: 'rgb(0, 255, 0)',
+          },
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**Docs**
- [docs/data/material/customization/css-layers/css-layers.md](https://deploy-preview-46283--material-ui.netlify.app/material-ui/customization/css-layers)
- [docs/data/material/integrations/nextjs/nextjs.md](https://deploy-preview-46283--material-ui.netlify.app/integrations/nextjs)

**Next.js Pages**
- demo: https://mui5-nextjs-pages.vercel.app/
- repo: https://github.com/siriwatknp/mui5-nextjs-pages/tree/v6

**Next.js App Router**
- demo: https://mui5-nextjs-pages-git-v6-siriwatknps-projects.vercel.app/
- repo: https://github.com/siriwatknp/mui5-nextjs-app/tree/v6

**Vite**
- demo: https://mui5-vite-git-v6-siriwatknps-projects.vercel.app/
- repo: https://github.com/siriwatknp/mui5-vite/tree/v6
---

This PR cherry pick 2 commits:

- #45596: enable CSS layers for pages router
- #46001: modular CSS Layers

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
