### PR TITLE
[feat] [ai] Add suggestions to edit with MUI Chat

### DIFF
--- a/docs/.env
+++ b/docs/.env
@@ -1,1 +1,2 @@
 FEEDBACK_URL=https://hgvi836wi8.execute-api.us-east-1.amazonaws.com
+NEXT_PUBLIC_MUI_CHAT_API_BASE_URL=https://chat-backend.mui.com

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -24,7 +24,7 @@ It's meant to be an improved version of the "react-select" and "downshift" packa
 
 The value must be chosen from a predefined set of allowed values.
 
-{{"demo": "ComboBox.js"}}
+{{"demo": "ComboBox.js", "aiSuggestion": "Add an option for Avatar and make the dropdown full width"}}
 
 ### Options structure
 

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -26,6 +26,7 @@ import { useUserLanguage, useTranslate } from '@mui/docs/i18n';
 import stylingSolutionMapping from 'docs/src/modules/utils/stylingSolutionMapping';
 import DemoToolbarRoot from 'docs/src/modules/components/DemoToolbarRoot';
 import { AdCarbonInline } from '@mui/docs/Ad';
+import DemoAiSuggestionHero from 'docs/src/modules/components/DemoAiSuggestionHero';
 
 /**
  * Removes leading spaces (indentation) present in the `.tsx` previews
@@ -502,7 +503,12 @@ export default function Demo(props) {
   return (
     <Root>
       <AnchorLink id={demoName} />
-      <DemoRoot hideToolbar={demoOptions.hideToolbar} bg={demoOptions.bg} id={demoId}>
+      <DemoRoot
+        hideToolbar={demoOptions.hideToolbar}
+        bg={demoOptions.bg}
+        id={demoId}
+        hasAiSuggestion={Boolean(demoOptions.aiSuggestion)}
+      >
         <InitialFocus aria-label={t('initialFocusLabel')} action={initialFocusRef} tabIndex={-1} />
         <DemoSandbox
           key={demoKey}
@@ -591,6 +597,10 @@ export default function Demo(props) {
                         '& .MuiCode-copy': {
                           display: 'none',
                         },
+                        '& pre': {
+                          borderBottomLeftRadius: demoOptions.aiSuggestion ? 0 : 12,
+                          borderBottomRightRadius: demoOptions.aiSuggestion ? 0 : 12,
+                        },
                       }}
                     />
                   ) : (
@@ -614,6 +624,12 @@ export default function Demo(props) {
                         'data-ga-event-label': demo.gaLabel,
                         'data-ga-event-action': 'copy-click',
                       }}
+                      sx={{
+                        '& .scrollContainer': {
+                          borderBottomLeftRadius: demoOptions.aiSuggestion ? 0 : 12,
+                          borderBottomRightRadius: demoOptions.aiSuggestion ? 0 : 12,
+                        },
+                      }}
                     >
                       <DemoEditorError>{debouncedError}</DemoEditorError>
                     </DemoEditor>
@@ -622,6 +638,27 @@ export default function Demo(props) {
               ))}
             </Collapse>
           </Tabs>
+          {/* AI Suggestion Hero UI */}
+          {demoOptions.aiSuggestion ? (
+            <DemoAiSuggestionHero
+              suggestion={demoOptions.aiSuggestion}
+              params={{
+                name: demoName,
+                description: demoOptions.aiSuggestion,
+                files: [
+                  {
+                    path: demo.moduleTS,
+                    content: demo.rawTS,
+                    isEntry: true,
+                  },
+                  ...(demo.relativeModules?.TS ?? []).map((module) => ({
+                    path: module.module,
+                    content: module.raw,
+                  })),
+                ],
+              }}
+            />
+          ) : null}
           {adVisibility ? <AdCarbonInline /> : null}
         </React.Fragment>
       )}

--- a/docs/src/modules/components/DemoAiSuggestionHero.tsx
+++ b/docs/src/modules/components/DemoAiSuggestionHero.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import CircularProgress from '@mui/material/CircularProgress';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import { SxProps, Theme } from '@mui/material/styles';
+
+export interface DemoAiSuggestionHeroProps {
+  suggestion: string;
+  params: Record<string, any>;
+  sx?: SxProps<Theme>;
+  onSuccess?: (url: string) => void;
+}
+
+const baseUrl = process.env.NEXT_PUBLIC_MUI_CHAT_API_BASE_URL;
+
+const DemoAiSuggestionHero: React.FC<DemoAiSuggestionHeroProps> = ({
+  suggestion,
+  params,
+  sx,
+  onSuccess,
+}) => {
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<Error | null>(null);
+
+  const handleClick = async () => {
+    if (!baseUrl) return;
+    const setLoadingTimeout = setTimeout(() => setLoading(true), 200);
+    setError(null);
+    try {
+      const response = await fetch(`${baseUrl}/v1/public/chat/open`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          ...params,
+          type: 'mui-docs',
+        }),
+      });
+      if (!response.ok) {
+        throw new Error('Failed to open in MUI Chat');
+      }
+      const data = await response.json();
+      if (onSuccess) onSuccess(data.nextUrl);
+      window.open(data.nextUrl, '_blank');
+    } catch (err: any) {
+      setError(err as Error);
+    } finally {
+      clearTimeout(setLoadingTimeout);
+      setLoading(false);
+    }
+  };
+
+  if (!baseUrl) return null;
+
+  return (
+    <Box
+      sx={{
+        border: '1px solid',
+        borderColor: 'divider',
+        borderTop: 'none',
+        borderRadius: '0 0 12px 12px',
+        p: 0,
+        backgroundColor: 'background.paper',
+        boxShadow: 0,
+        maxWidth: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'stretch',
+        ...sx,
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', px: 2, pt: 2, pb: 1 }}>
+        <AutoAwesomeIcon fontSize="small" sx={{ color: 'primary.main', mr: 1 }} />
+        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+          Want to customize this?
+        </Typography>
+      </Box>
+      <Box sx={{ px: 2, pb: 2 }}>
+        <Button
+          variant="outlined"
+          sx={{
+            textTransform: 'none',
+            fontWeight: 400,
+            fontSize: '0.98rem',
+            borderRadius: '12px',
+            justifyContent: 'flex-start',
+            px: 2,
+            py: 1,
+            backgroundColor: '#F6FAFD',
+            border: '1px solid #B6E3FF',
+            color: '#1976d2',
+            boxShadow: 'none',
+            transition: 'none',
+            mt: 0,
+            mb: 0,
+            '&:hover': {
+              backgroundColor: '#EDF6FB',
+              border: '1px solid #90caf9',
+              boxShadow: 'none',
+            },
+          }}
+          onClick={handleClick}
+          disabled={loading}
+          startIcon={loading ? <CircularProgress color="inherit" size={16} /> : null}
+        >
+          {suggestion}
+        </Button>
+      </Box>
+      <Snackbar
+        open={!!error}
+        color="error"
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        onClose={() => setError(null)}
+        autoHideDuration={6000}
+      >
+        <Alert onClose={() => setError(null)} severity="error" sx={{ width: '100%' }}>
+          <AlertTitle>Failed to open in MUI Chat</AlertTitle>
+          {error?.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default DemoAiSuggestionHero;

--- a/docs/src/modules/components/DemoEditor.tsx
+++ b/docs/src/modules/components/DemoEditor.tsx
@@ -69,10 +69,11 @@ interface DemoEditorProps extends React.HTMLAttributes<HTMLDivElement> {
   language: string;
   onChange: () => {};
   value: string;
+  sx?: React.CSSProperties;
 }
 
 export default function DemoEditor(props: DemoEditorProps) {
-  const { language, value, onChange, copyButtonProps, children, id, ...other } = props;
+  const { language, value, onChange, copyButtonProps, children, id, sx, ...other } = props;
   const t = useTranslate();
   const contextTheme = useTheme();
   const wrapperRef = React.useRef<HTMLElement>(null);
@@ -105,6 +106,7 @@ export default function DemoEditor(props: DemoEditorProps) {
           }
         }
       }}
+      sx={sx}
       {...other}
     >
       <div className="MuiCode-root" {...handlers}>


### PR DESCRIPTION
- ![Screenshot 2025-06-10 at 3 27 17 PM](https://github.com/user-attachments/assets/fcf28adc-62fe-4919-9aa3-d69c682c072b)
- Add a pre-generated `aiSuggestion` prop to the demo
- Clicking on the suggestion leads to MUI Chat with that demo opened, and the suggestion pre-typed in the chat*
- *Needs to add a feature to get an `initialMessage` from the `/open` API
