### PR TITLE
docs(migration): clarify @mui/lab v6 version availability

### DIFF
--- a/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
+++ b/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
@@ -579,3 +579,12 @@ Those deprecations will be removed in the next major version.
 ## Pigment CSS integration (optional)
 
 Once you've finished upgrading your app to v6, you'll be ready to start [migrating to Pigment CSS](/material-ui/migration/migrating-to-pigment-css/) for RSC support and a smaller bundle size.
+
+### @mui/lab version clarification
+
+If you are using components from `@mui/lab`, please note that version **6 does not exist as a stable release**.
+
+However, you can install the latest **beta** version using:
+
+```bash
+npm install @mui/lab@6.0.1-beta.35

--- a/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
+++ b/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
@@ -588,3 +588,4 @@ However, you can install the latest **beta** version using:
 
 ```bash
 npm install @mui/lab@6.0.1-beta.35
+```


### PR DESCRIPTION
This PR updates the migration guide for Material UI v6 to clarify that @mui/lab v6 is not yet available as a stable release.

🔹 Added a note under the "@mui/lab version clarification" section.
🔹 Included command to install the latest beta version.

This helps developers avoid confusion and ensures smoother migration.
