### PR TITLE
[material-ui] Skip generating `modularCssLayers` CSS var

### DIFF
--- a/packages/mui-material/src/styles/extendTheme.test.js
+++ b/packages/mui-material/src/styles/extendTheme.test.js
@@ -865,4 +865,11 @@ describe('extendTheme', () => {
       ]);
     });
   });
+
+  it('should not generate vars for modularCssLayers', () => {
+    const theme = extendTheme({
+      modularCssLayers: '@layer mui,utilities;',
+    });
+    expect(theme.vars.modularCssLayers).to.equal(undefined);
+  });
 });

--- a/packages/mui-material/src/styles/shouldSkipGeneratingVar.ts
+++ b/packages/mui-material/src/styles/shouldSkipGeneratingVar.ts
@@ -1,7 +1,7 @@
 export default function shouldSkipGeneratingVar(keys: string[]) {
   return (
     !!keys[0].match(
-      /(cssVarPrefix|colorSchemeSelector|rootSelector|typography|mixins|breakpoints|direction|transitions)/,
+      /(cssVarPrefix|colorSchemeSelector|modularCssLayers|rootSelector|typography|mixins|breakpoints|direction|transitions)/,
     ) ||
     !!keys[0].match(/sxConfig$/) || // ends with sxConfig
     (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/))


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


<img width="355" alt="image" src="https://github.com/user-attachments/assets/b75350df-2982-48c9-ac49-cdd7d180c9f0" />


The `modularCssLayers` can be a string, so it should be skipped from generating var because it cannot be used as a CSS variable else where.

Note: The `modularCssLayers` feature has not been released yet.


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
