### PR TITLE
[infra] Remove deprecated esmExternals

### DIFF
--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -74,7 +74,6 @@ function withDocsInfra(nextConfig) {
     },
     experimental: {
       scrollRestoration: true,
-      esmExternals: false,
       workerThreads: false,
       cpus: 3,
       ...nextConfig.experimental,


### PR DESCRIPTION
Remove deprecated `esmExternals`. We can finally follow up on https://github.com/mui/material-ui/issues/30671#issuecomment-2130387754 now that https://github.com/mui/material-ui/commit/433a9fc04c25400235ed6b964e0fa2d9184880de is merged.