### PR TITLE
[infra] Create update PR on every canary publish for internal packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,12 @@
   },
   "packageRules": [
     {
+      "groupName": "Infra packages",
+      "matchPackagePatterns": "@mui/internal-*",
+      "followTag": "canary",
+      "schedule": null
+    },
+    {
       "matchDepTypes": ["peerDependencies"],
       "rangeStrategy": "widen"
     },


### PR DESCRIPTION
* Track the canary release of internal packages.
* Canary releases are now published on every push to master of mui-public.
* Merge the renovate branch at your discretion

We can decide to follow this up with auto merging, but we'll probably have to tweak branch rules for that.


open questions:
* what about the notifications noise this will create?
* auto merge once per day?