### PR TITLE
[l10] Enable `labelDisplayedRows` translation for Romanian

### DIFF
--- a/packages/mui-material/src/locale/index.ts
+++ b/packages/mui-material/src/locale/index.ts
@@ -3242,8 +3242,8 @@ export const roRO: Localization = {
           return 'Mergi la pagina precedentă';
         },
         labelRowsPerPage: 'Rânduri pe pagină:',
-        // labelDisplayedRows: ({ from, to, count }) =>
-        //   `${from}–${to} din ${count !== -1 ? count : `more than ${to}`}`,
+        labelDisplayedRows: ({ from, to, count }) =>
+          `${from}–${to} din ${count !== -1 ? count : `mai mult de ${to}`}`,
       },
     },
     MuiRating: {


### PR DESCRIPTION
Correct "more than" labelDisplayedRows translation for Romanian.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
