### PR TITLE
[core] Fix unpinned version regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-      - run: npm install -g npm@latest
       - run: pnpm install:codesandbox
       - run: pnpm build:codesandbox
       - run: pnpm pkg-pr-new-release


### PR DESCRIPTION
This should fix https://securityscorecards.dev/viewer/?uri=github.com%2Fmui%2Fmaterial-ui, back to 10/10.

<img width="557" alt="SCR-20250628-nuyi" src="https://github.com/user-attachments/assets/c224df2c-2569-4bf7-adaa-646fd4a4adc3" />

Preview: https://deploy-preview-46438--material-ui.netlify.app/material-ui/react-alert/#introduction. I have tested the pkg.pr.new output with the code demos, it seems to work just fine. So https://github.com/mui/material-ui/pull/42984#discussion_r1691950071, considering that the rest of our codebase doesn't has this, I don't buy it.

---

A quick win, while I had a quick look at https://mui.zendesk.com/agent/tickets/28723.

As a side note, the way pkg-pr-new is configured in the codebase (base ui, joy ui, material ui, mui x) is so different. Can we please make it the same everywhere? no reason to be different. It makes it so hard to propagate fixes like this everywhere.