### PR TITLE
[code-infra] Further improve node versioning in renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -89,7 +89,7 @@
     {
       "groupName": "node",
       "matchPackageNames": ["@types/node", "node", "cimg/node", "actions/setup-node"],
-      "allowedVersions": "20"
+      "allowedVersions": "22"
     },
     {
       "groupName": "Playwright",

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     "enabled": true,
     "schedule": "before 6:00am on the first day of the month"
   },
-    "ignorePaths": [ "examples/**"],
+  "ignorePaths": ["examples/**"],
   "packageRules": [
     {
       "groupName": "Infra packages",

--- a/renovate.json
+++ b/renovate.json
@@ -81,19 +81,14 @@
       "matchPackagePatterns": "@typescript-eslint/*"
     },
     {
-      "groupName": "@types/node",
-      "matchPackageNames": ["@types/node"],
-      "allowedVersions": "< 21.0.0"
-    },
-    {
       "groupName": "bundling fixtures",
       "matchPaths": ["test/bundling/fixtures/**/package.json"],
       "schedule": "every 6 months on the first day of the month"
     },
     {
       "groupName": "node",
-      "matchPackageNames": ["node", "cimg/node", "actions/setup-node"],
-      "enabled": false
+      "matchPackageNames": ["@types/node", "node", "cimg/node", "actions/setup-node"],
+      "allowedVersions": "22"
     },
     {
       "groupName": "examples",

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
     "enabled": true,
     "schedule": "before 6:00am on the first day of the month"
   },
+    "ignorePaths": [ "examples/**"],
   "packageRules": [
     {
       "groupName": "Infra packages",
@@ -89,11 +90,6 @@
       "groupName": "node",
       "matchPackageNames": ["@types/node", "node", "cimg/node", "actions/setup-node"],
       "allowedVersions": "20"
-    },
-    {
-      "groupName": "examples",
-      "matchPaths": ["examples/**/package.json"],
-      "enabled": false
     },
     {
       "groupName": "Playwright",

--- a/renovate.json
+++ b/renovate.json
@@ -88,7 +88,7 @@
     {
       "groupName": "node",
       "matchPackageNames": ["@types/node", "node", "cimg/node", "actions/setup-node"],
-      "allowedVersions": "22"
+      "allowedVersions": "20"
     },
     {
       "groupName": "examples",


### PR DESCRIPTION
Missed in https://github.com/mui/material-ui/pull/46474 that this was disabled. Are there any good reasons to disable this and not just set an allowed version?

Also using `ignorePaths` to disallow updating [`@types/node`](https://github.com/mui/material-ui/blob/79bb2dd47e48b5dc2bb735a5c6b8f77bc44ae815/examples/material-ui-nextjs-ts/package.json#L24) and others in examples folders, which are set to `latest`.

Let's see if this setup works for us