### PR TITLE
removeSystemProps Codemod bugfix

### DIFF
--- a/packages/mui-codemod/src/v6.0.0/system-props/removeSystemProps.js
+++ b/packages/mui-codemod/src/v6.0.0/system-props/removeSystemProps.js
@@ -150,8 +150,8 @@ export default function removeSystemProps(file, api, options) {
         key !== 'color' ||
         (val.value?.includes('.') && val.value !== 'inherit') ||
         val.value === 'divider' ||
-        val.value.startsWith('#') ||
-        val.value.match(/\(.*\)/),
+        val.value?.startsWith('#') ||
+        val.value?.match(/\(.*\)/),
     },
     Link: {
       matcher: (key) => key !== 'color',


### PR DESCRIPTION
This PR fixes the bug in Typography matcher defined in customReplacement by adding optional chaining in case val.value is undefined

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
