### PR TITLE
[docs-infra] Handle white spaces and generate either TS or JS demo for llms files

### DIFF
--- a/packages-internal/scripts/generate-llms-txt/src/processComponent.ts
+++ b/packages-internal/scripts/generate-llms-txt/src/processComponent.ts
@@ -13,7 +13,7 @@ interface DemoReplaceOptions {
  */
 export function removeComponentSyntax(markdownContent: string): string {
   // Regular expression to match {{"component": "ComponentName"}} pattern
-  const componentRegex = /\{\{"component":\s*"[^"]+"\}\}/g;
+  const componentRegex = /\{\{\s*"component":\s*"[^"]+"\s*\}\}/g;
   return markdownContent.replace(componentRegex, '');
 }
 
@@ -39,10 +39,10 @@ export function replaceDemoWithSnippet(
   markdownPath: string,
   options: DemoReplaceOptions = {},
 ): string {
-  const { basePath = '', includeTypeScript = true } = options;
+  const { basePath = '' } = options;
 
   // Regular expression to match {{"demo": "filename.js"}} pattern
-  const demoRegex = /\{\{"demo":\s*"([^"]+)"(?:,\s*[^}]+)?\}\}/g;
+  const demoRegex = /\{\{\s*"demo":\s*"([^"]+)"(?:,\s*[^}]+)?\s*\}\}/g;
 
   return markdownContent.replace(demoRegex, (match, filename) => {
     try {
@@ -54,28 +54,26 @@ export function replaceDemoWithSnippet(
 
       let codeSnippet = '';
 
-      // Try to read JavaScript file
-      const jsPath = basePath
-        ? path.join(basePath, `${baseFilename}.js`)
-        : path.join(markdownDir, `${baseFilename}.js`);
+      // Try to read TypeScript file before JavaScript file
+      const tsPath = basePath
+        ? path.join(basePath, `${baseFilename}.tsx`)
+        : path.join(markdownDir, `${baseFilename}.tsx`);
 
-      if (fs.existsSync(jsPath)) {
-        const jsContent = fs.readFileSync(jsPath, 'utf-8');
-        codeSnippet += `\`\`\`jsx\n${jsContent}\n\`\`\``;
-      }
+      if (fs.existsSync(tsPath)) {
+        const tsContent = fs.readFileSync(tsPath, 'utf-8');
+        if (codeSnippet) {
+          codeSnippet += '\n\n';
+        }
+        codeSnippet += `\`\`\`tsx\n${tsContent}\n\`\`\``;
+      } else {
+        // Try to read JavaScript file
+        const jsPath = basePath
+          ? path.join(basePath, `${baseFilename}.js`)
+          : path.join(markdownDir, `${baseFilename}.js`);
 
-      // Try to read TypeScript file if includeTypeScript is true
-      if (includeTypeScript) {
-        const tsPath = basePath
-          ? path.join(basePath, `${baseFilename}.tsx`)
-          : path.join(markdownDir, `${baseFilename}.tsx`);
-
-        if (fs.existsSync(tsPath)) {
-          const tsContent = fs.readFileSync(tsPath, 'utf-8');
-          if (codeSnippet) {
-            codeSnippet += '\n\n';
-          }
-          codeSnippet += `\`\`\`tsx\n${tsContent}\n\`\`\``;
+        if (fs.existsSync(jsPath)) {
+          const jsContent = fs.readFileSync(jsPath, 'utf-8');
+          codeSnippet += `\`\`\`jsx\n${jsContent}\n\`\`\``;
         }
       }
 

--- a/packages-internal/scripts/generate-llms-txt/test/processComponent.test.ts
+++ b/packages-internal/scripts/generate-llms-txt/test/processComponent.test.ts
@@ -45,27 +45,22 @@ export default function BasicButton() {
       expect(result).to.not.include('{{"demo": "BasicButton.js"}}');
     });
 
-    it('should include both JS and TS files when includeTypeScript is true', () => {
-      const markdown = `{{"demo": "Component.js"}}`;
+    it('should handle white spaces in demo syntax', () => {
+      const markdown = `{{ "demo": "Component.js"  }}`;
 
       const jsContent = `// JavaScript version`;
-      const tsContent = `// TypeScript version`;
 
       fs.writeFileSync(path.join(tempDir, 'Component.js'), jsContent);
-      fs.writeFileSync(path.join(tempDir, 'Component.tsx'), tsContent);
 
       const result = replaceDemoWithSnippet(markdown, path.join(tempDir, 'test.md'), {
         basePath: tempDir,
-        includeTypeScript: true,
       });
 
       expect(result).to.include('```jsx');
       expect(result).to.include(jsContent);
-      expect(result).to.include('```tsx');
-      expect(result).to.include(tsContent);
     });
 
-    it('should only include JS file when includeTypeScript is false', () => {
+    it('should include only TS files', () => {
       const markdown = `{{"demo": "Component.js"}}`;
 
       const jsContent = `// JavaScript version`;
@@ -76,13 +71,28 @@ export default function BasicButton() {
 
       const result = replaceDemoWithSnippet(markdown, path.join(tempDir, 'test.md'), {
         basePath: tempDir,
-        includeTypeScript: false,
+      });
+
+      expect(result).to.include('```tsx');
+      expect(result).to.include(tsContent);
+      expect(result).to.not.include('```jsx');
+      expect(result).to.not.include(jsContent);
+    });
+
+    it('should only include JS file when TS file does not exist', () => {
+      const markdown = `{{"demo": "Component.js"}}`;
+
+      const jsContent = `// JavaScript version`;
+
+      fs.writeFileSync(path.join(tempDir, 'Component.js'), jsContent);
+
+      const result = replaceDemoWithSnippet(markdown, path.join(tempDir, 'test.md'), {
+        basePath: tempDir,
       });
 
       expect(result).to.include('```jsx');
       expect(result).to.include(jsContent);
       expect(result).to.not.include('```tsx');
-      expect(result).to.not.include(tsContent);
     });
 
     it('should handle multiple demos in the same markdown', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Feedback from https://github.com/mui/mui-x/pull/18595

- To handle `{{ "demo": "…" }}` (with white spaces inside)
- Generate either TS or JS demo (before contains both snippet for each demo "```js" and "```ts")

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
