### PR TITLE
[material-ui][SpeedDial] Fix  navigation with arrow keys when slotProps.fab is defined

### DIFF
--- a/packages/mui-material/src/SpeedDial/SpeedDial.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.js
@@ -369,6 +369,10 @@ const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
   const children = allItems.map((child, index) => {
     const {
       FabProps: { ref: origButtonRef, ...ChildFabProps } = {},
+      slotProps: {
+        fab: { ref: fabSlotOrigButtonRef, ...fabSlotProps } = {},
+        ...restOfSlotProps
+      } = {},
       tooltipPlacement: tooltipPlacementProp,
     } = child.props;
 
@@ -379,6 +383,13 @@ const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
       FabProps: {
         ...ChildFabProps,
         ref: createHandleSpeedDialActionButtonRef(index, origButtonRef),
+      },
+      slotProps: {
+        fab: {
+          ...fabSlotProps,
+          ref: createHandleSpeedDialActionButtonRef(index, fabSlotOrigButtonRef),
+        },
+        ...restOfSlotProps,
       },
       delay: 30 * (open ? index : allItems.length - index),
       open,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
