### PR TITLE
[docs] Generate `templates` entries about documented generics

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -163,6 +163,9 @@ export default class MyDocument extends Document {
               '.plan-premium': {
                 backgroundImage: 'url(/static/x/premium.svg)',
               },
+              '.info-block': {
+                cursor: 'help',
+              },
             }}
           />
         </Head>

--- a/docs/translations/api-docs/autocomplete/autocomplete.json
+++ b/docs/translations/api-docs/autocomplete/autocomplete.json
@@ -1,211 +1,68 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "autoComplete": {
-      "description": "If <code>true</code>, the portion of the selected suggestion that the user hasn&#39;t typed, known as the completion string, appears inline after the input cursor in the textbox. The inline completion string is visually highlighted and has a selected state."
-    },
-    "autoHighlight": {
-      "description": "If <code>true</code>, the first option is automatically highlighted."
-    },
-    "autoSelect": {
-      "description": "If <code>true</code>, the selected option becomes the value of the input when the Autocomplete loses focus unless the user chooses a different option or changes the character string in the input.<br>When using the <code>freeSolo</code> mode, the typed value will be the input value if the Autocomplete loses focus without highlighting an option."
-    },
-    "blurOnSelect": {
-      "description": "<p>Control if the input should be blurred when an option is selected:</p>\n<ul>\n<li><code>false</code> the input is not blurred.</li>\n<li><code>true</code> the input is always blurred.</li>\n<li><code>touch</code> the input is blurred after a touch event.</li>\n<li><code>mouse</code> the input is blurred after a mouse event.</li>\n</ul>\n"
-    },
-    "ChipProps": {
-      "description": "Props applied to the <a href=\"https://mui.com/material-ui/api/chip/\"><code>Chip</code></a> element."
-    },
-    "classes": { "description": "Override or extend the styles applied to the component." },
-    "clearIcon": { "description": "The icon to display in place of the default clear icon." },
-    "clearOnBlur": {
-      "description": "If <code>true</code>, the input&#39;s text is cleared on blur if no value is selected.<br>Set it to <code>true</code> if you want to help the user enter a new value. Set it to <code>false</code> if you want to help the user resume their search."
-    },
-    "clearOnEscape": {
-      "description": "If <code>true</code>, clear all values when the user presses escape and the popup is closed."
-    },
-    "clearText": {
-      "description": "Override the default text for the <em>clear</em> icon button.<br>For localization purposes, you can use the provided <a href=\"https://mui.com/material-ui/guides/localization/\">translations</a>."
-    },
-    "closeText": {
-      "description": "Override the default text for the <em>close popup</em> icon button.<br>For localization purposes, you can use the provided <a href=\"https://mui.com/material-ui/guides/localization/\">translations</a>."
-    },
-    "componentsProps": { "description": "The props used for each slot inside." },
-    "defaultValue": {
-      "description": "The default value. Use when the component is not controlled."
-    },
-    "disableClearable": { "description": "If <code>true</code>, the input can&#39;t be cleared." },
-    "disableCloseOnSelect": {
-      "description": "If <code>true</code>, the popup won&#39;t close when a value is selected."
-    },
-    "disabled": { "description": "If <code>true</code>, the component is disabled." },
-    "disabledItemsFocusable": {
-      "description": "If <code>true</code>, will allow focus on disabled items."
-    },
-    "disableListWrap": {
-      "description": "If <code>true</code>, the list box in the popup will not wrap focus."
-    },
-    "disablePortal": {
-      "description": "If <code>true</code>, the <code>Popper</code> content will be under the DOM hierarchy of the parent component."
-    },
-    "filterOptions": {
-      "description": "A function that determines the filtered options to be rendered on search.",
-      "typeDescriptions": {
-        "options": "The options to render.",
-        "state": "The state of the component."
-      }
-    },
-    "filterSelectedOptions": {
-      "description": "If <code>true</code>, hide the selected options from the list box."
-    },
-    "forcePopupIcon": { "description": "Force the visibility display of the popup icon." },
-    "freeSolo": {
-      "description": "If <code>true</code>, the Autocomplete is free solo, meaning that the user input is not bound to provided options."
-    },
-    "fullWidth": {
-      "description": "If <code>true</code>, the input will take up the full width of its container."
-    },
-    "getLimitTagsText": {
-      "description": "The label to display when the tags are truncated (<code>limitTags</code>).",
-      "typeDescriptions": { "more": "The number of truncated tags." }
-    },
-    "getOptionDisabled": {
-      "description": "Used to determine the disabled state for a given option.",
-      "typeDescriptions": { "option": "The option to test." }
-    },
-    "getOptionKey": {
-      "description": "Used to determine the key for a given option. This can be useful when the labels of options are not unique (since labels are used as keys by default).",
-      "typeDescriptions": { "option": "The option to get the key for." }
-    },
-    "getOptionLabel": {
-      "description": "Used to determine the string value for a given option. It&#39;s used to fill the input (and the list box options if <code>renderOption</code> is not provided).<br>If used in free solo mode, it must accept both the type of the options and a string."
-    },
-    "groupBy": {
-      "description": "If provided, the options will be grouped under the returned string. The groupBy value is also used as the text for group headings when <code>renderGroup</code> is not provided.",
-      "typeDescriptions": { "option": "The Autocomplete option." }
-    },
-    "handleHomeEndKeys": {
-      "description": "If <code>true</code>, the component handles the &quot;Home&quot; and &quot;End&quot; keys when the popup is open. It should move focus to the first option and last option, respectively."
-    },
-    "id": {
-      "description": "This prop is used to help implement the accessibility logic. If you don&#39;t provide an id it will fall back to a randomly generated one."
-    },
-    "includeInputInList": {
-      "description": "If <code>true</code>, the highlight can move to the input."
-    },
-    "inputValue": { "description": "The input value." },
-    "isOptionEqualToValue": {
-      "description": "Used to determine if the option represents the given value. Uses strict equality by default. ⚠️ Both arguments need to be handled, an option can only match with one value.",
-      "typeDescriptions": { "option": "The option to test.", "value": "The value to test against." }
-    },
-    "limitTags": {
-      "description": "The maximum number of tags that will be visible when not focused. Set <code>-1</code> to disable the limit."
-    },
-    "ListboxComponent": { "description": "The component used to render the listbox." },
-    "ListboxProps": { "description": "Props applied to the Listbox element." },
-    "loading": {
-      "description": "If <code>true</code>, the component is in a loading state. This shows the <code>loadingText</code> in place of suggestions (only if there are no suggestions to show, for example <code>options</code> are empty)."
-    },
-    "loadingText": {
-      "description": "Text to display when in a loading state.<br>For localization purposes, you can use the provided <a href=\"https://mui.com/material-ui/guides/localization/\">translations</a>."
-    },
-    "multiple": {
-      "description": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections."
-    },
-    "noOptionsText": {
-      "description": "Text to display when there are no options.<br>For localization purposes, you can use the provided <a href=\"https://mui.com/material-ui/guides/localization/\">translations</a>."
-    },
-    "onChange": {
-      "description": "Callback fired when the value changes.",
-      "typeDescriptions": {
-        "event": "The event source of the callback.",
-        "value": "The new value of the component.",
-        "reason": "One of &quot;createOption&quot;, &quot;selectOption&quot;, &quot;removeOption&quot;, &quot;blur&quot; or &quot;clear&quot;."
-      }
-    },
-    "onClose": {
-      "description": "Callback fired when the popup requests to be closed. Use in controlled mode (see open).",
-      "typeDescriptions": {
-        "event": "The event source of the callback.",
-        "reason": "Can be: <code>&quot;toggleInput&quot;</code>, <code>&quot;escape&quot;</code>, <code>&quot;selectOption&quot;</code>, <code>&quot;removeOption&quot;</code>, <code>&quot;blur&quot;</code>."
-      }
-    },
-    "onHighlightChange": {
-      "description": "Callback fired when the highlight option changes.",
-      "typeDescriptions": {
-        "event": "The event source of the callback.",
-        "option": "The highlighted option.",
-        "reason": "Can be: <code>&quot;keyboard&quot;</code>, <code>&quot;mouse&quot;</code>, <code>&quot;touch&quot;</code>."
-      }
-    },
-    "onInputChange": {
-      "description": "Callback fired when the input value changes.",
-      "typeDescriptions": {
-        "event": "The event source of the callback.",
-        "value": "The new value of the text input.",
-        "reason": "Can be: <code>&quot;input&quot;</code> (user input), <code>&quot;reset&quot;</code> (programmatic change), <code>&quot;clear&quot;</code>, <code>&quot;blur&quot;</code>, <code>&quot;selectOption&quot;</code>, <code>&quot;removeOption&quot;</code>"
-      }
-    },
-    "onOpen": {
-      "description": "Callback fired when the popup requests to be opened. Use in controlled mode (see open).",
-      "typeDescriptions": { "event": "The event source of the callback." }
-    },
-    "open": { "description": "If <code>true</code>, the component is shown." },
-    "openOnFocus": { "description": "If <code>true</code>, the popup will open on input focus." },
-    "openText": {
-      "description": "Override the default text for the <em>open popup</em> icon button.<br>For localization purposes, you can use the provided <a href=\"https://mui.com/material-ui/guides/localization/\">translations</a>."
-    },
-    "options": { "description": "A list of options that will be shown in the Autocomplete." },
-    "PaperComponent": { "description": "The component used to render the body of the popup." },
-    "PopperComponent": { "description": "The component used to position the popup." },
-    "popupIcon": { "description": "The icon to display in place of the default popup icon." },
-    "readOnly": {
-      "description": "If <code>true</code>, the component becomes readonly. It is also supported for multiple tags where the tag cannot be deleted."
-    },
-    "renderGroup": {
-      "description": "Render the group.",
-      "typeDescriptions": { "params": "The group to render." }
-    },
-    "renderInput": {
-      "description": "Render the input.<br><strong>Note:</strong> The <code>renderInput</code> prop must return a <code>TextField</code> component or a compatible custom component that correctly forwards <code>InputProps.ref</code> and spreads <code>inputProps</code>. This ensures proper integration with the Autocomplete&#39;s internal logic (e.g., focus management and keyboard navigation).<br>Avoid using components like <code>DatePicker</code> or <code>Select</code> directly, as they may not forward the required props, leading to runtime errors or unexpected behavior."
-    },
-    "renderOption": {
-      "description": "Render the option, use <code>getOptionLabel</code> by default.",
-      "typeDescriptions": {
-        "props": "The props to apply on the li element.",
-        "option": "The option to render.",
-        "state": "The state of each option.",
-        "ownerState": "The state of the Autocomplete component."
-      }
-    },
-    "renderTags": {
-      "description": "Render the selected value when doing multiple selections.",
-      "typeDescriptions": {
-        "value": "The <code>value</code> provided to the component.",
-        "getTagProps": "A tag props getter.",
-        "ownerState": "The state of the Autocomplete component."
-      }
-    },
-    "renderValue": {
-      "description": "Renders the selected value(s) as rich content in the input for both single and multiple selections.",
-      "typeDescriptions": {
-        "value": "The <code>value</code> provided to the component.",
-        "getItemProps": "The value item props.",
-        "ownerState": "The state of the Autocomplete component."
-      }
-    },
-    "selectOnFocus": {
-      "description": "If <code>true</code>, the input&#39;s text is selected on focus. It helps the user clear the selected value."
-    },
-    "size": { "description": "The size of the component." },
-    "slotProps": { "description": "The props used for each slot inside." },
-    "slots": { "description": "The components used for each slot inside." },
-    "sx": {
-      "description": "The system prop that allows defining system overrides as well as additional CSS styles."
-    },
-    "value": {
-      "description": "The value of the autocomplete.<br>The value must have reference equality with the option in order to be selected. You can customize the equality behavior with the <code>isOptionEqualToValue</code> prop."
-    }
+    "autoComplete": "If <code>true</code>, the portion of the selected suggestion that has not been typed by the user, known as the completion string, appears inline after the input cursor in the textbox. The inline completion string is visually highlighted and has a selected state.",
+    "autoHighlight": "If <code>true</code>, the first option is automatically highlighted.",
+    "autoSelect": "If <code>true</code>, the selected option becomes the value of the input when the Autocomplete loses focus unless the user chooses a different option or changes the character string in the input.",
+    "blurOnSelect": "Control if the input should be blurred when an option is selected:<br>- <code>false</code> the input is not blurred. - <code>true</code> the input is always blurred. - <code>touch</code> the input is blurred after a touch event. - <code>mouse</code> the input is blurred after a mouse event.",
+    "ChipProps": "Props applied to the <a href=\"/material-ui/api/chip/\"><code>Chip</code></a> element.",
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "clearIcon": "The icon to display in place of the default clear icon.",
+    "clearOnBlur": "If <code>true</code>, the input&#39;s text is cleared on blur if no value is selected.<br>Set to <code>true</code> if you want to help the user enter a new value. Set to <code>false</code> if you want to help the user resume their search.",
+    "clearOnEscape": "If <code>true</code>, clear all values when the user presses escape and the popup is closed.",
+    "clearText": "Override the default text for the <em>clear</em> icon button.<br>For localization purposes, you can use the provided <a href=\"/material-ui/guides/localization/\">translations</a>.",
+    "closeText": "Override the default text for the <em>close popup</em> icon button.<br>For localization purposes, you can use the provided <a href=\"/material-ui/guides/localization/\">translations</a>.",
+    "componentsProps": "The props used for each slot inside.",
+    "defaultValue": "The default value. Use when the component is not controlled.",
+    "disableClearable": "If <code>true</code>, the input can&#39;t be cleared.",
+    "disableCloseOnSelect": "If <code>true</code>, the popup won&#39;t close when a value is selected.",
+    "disabled": "If <code>true</code>, the component is disabled.",
+    "disabledItemsFocusable": "If <code>true</code>, will allow focus on disabled items.",
+    "disableListWrap": "If <code>true</code>, the list box in the popup will not wrap focus.",
+    "disablePortal": "If <code>true</code>, the <code>Popper</code> content will be under the DOM hierarchy of the parent component.",
+    "filterOptions": "A function that determines the filtered options to be rendered on search.<br><br><strong>Signature:</strong><br><code>function(options: Array&lt;T&gt;, state: object) =&gt; Array&lt;T&gt;</code><br><em>options:</em> The options to render.<br><em>state:</em> The state of the component.",
+    "filterSelectedOptions": "If <code>true</code>, hide the selected options from the list box.",
+    "forcePopupIcon": "Force the visibility display of the popup icon.",
+    "freeSolo": "If <code>true</code>, the Autocomplete is free solo, meaning that the user input is not bound to provided options.",
+    "fullWidth": "If <code>true</code>, the input will take up the full width of its container.",
+    "getLimitTagsText": "The label to display when the tags are truncated (<code>limitTags</code>).<br><br><strong>Signature:</strong><br><code>function(more: number) =&gt; ReactNode</code><br><em>more:</em> The number of truncated tags.",
+    "getOptionDisabled": "Used to determine the disabled state for a given option.<br><br><strong>Signature:</strong><br><code>function(option: T) =&gt; boolean</code><br><em>templates:</em> <span class=\"info-block\" title=\"The option shape. Will be the same shape as an item of the options.\"><code>T</code></span>.<br><em>option:</em> The option to test.",
+    "getOptionLabel": "Used to determine the string value for a given option. It&#39;s used to fill the input (and the list box options if <code>renderOption</code> is not provided).<br>If used in free solo mode, it must accept both the type of the options and a string.<br><br><strong>Signature:</strong><br><code>function(option: T) =&gt; string</code><br>",
+    "groupBy": "If provided, the options will be grouped under the returned string. The groupBy value is also used as the text for group headings when <code>renderGroup</code> is not provided.<br><br><strong>Signature:</strong><br><code>function(options: T) =&gt; string</code><br><em>options:</em> The options to group.",
+    "handleHomeEndKeys": "If <code>true</code>, the component handles the &quot;Home&quot; and &quot;End&quot; keys when the popup is open. It should move focus to the first option and last option, respectively.",
+    "id": "This prop is used to help implement the accessibility logic. If you don&#39;t provide an id it will fall back to a randomly generated one.",
+    "includeInputInList": "If <code>true</code>, the highlight can move to the input.",
+    "inputValue": "The input value.",
+    "isOptionEqualToValue": "Used to determine if the option represents the given value. Uses strict equality by default. ⚠️ Both arguments need to be handled, an option can only match with one value.<br><br><strong>Signature:</strong><br><code>function(option: T, value: T) =&gt; boolean</code><br><em>option:</em> The option to test.<br><em>value:</em> The value to test against.",
+    "limitTags": "The maximum number of tags that will be visible when not focused. Set <code>-1</code> to disable the limit.",
+    "ListboxComponent": "The component used to render the listbox.",
+    "ListboxProps": "Props applied to the Listbox element.",
+    "loading": "If <code>true</code>, the component is in a loading state. This shows the <code>loadingText</code> in place of suggestions (only if there are no suggestions to show, e.g. <code>options</code> are empty).",
+    "loadingText": "Text to display when in a loading state.<br>For localization purposes, you can use the provided <a href=\"/material-ui/guides/localization/\">translations</a>.",
+    "multiple": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections.",
+    "noOptionsText": "Text to display when there are no options.<br>For localization purposes, you can use the provided <a href=\"/material-ui/guides/localization/\">translations</a>.",
+    "onChange": "Callback fired when the value changes.<br><br><strong>Signature:</strong><br><code>function(event: React.SyntheticEvent, value: T | Array&lt;T&gt;, reason: string, details?: string) =&gt; void</code><br><em>event:</em> The event source of the callback.<br><em>value:</em> The new value of the component.<br><em>reason:</em> One of &quot;createOption&quot;, &quot;selectOption&quot;, &quot;removeOption&quot;, &quot;blur&quot; or &quot;clear&quot;.",
+    "onClose": "Callback fired when the popup requests to be closed. Use in controlled mode (see open).<br><br><strong>Signature:</strong><br><code>function(event: React.SyntheticEvent, reason: string) =&gt; void</code><br><em>event:</em> The event source of the callback.<br><em>reason:</em> Can be: <code>&quot;toggleInput&quot;</code>, <code>&quot;escape&quot;</code>, <code>&quot;selectOption&quot;</code>, <code>&quot;removeOption&quot;</code>, <code>&quot;blur&quot;</code>.",
+    "onHighlightChange": "Callback fired when the highlight option changes.<br><br><strong>Signature:</strong><br><code>function(event: React.SyntheticEvent, option: T, reason: string) =&gt; void</code><br><em>event:</em> The event source of the callback.<br><em>option:</em> The highlighted option.<br><em>reason:</em> Can be: <code>&quot;keyboard&quot;</code>, <code>&quot;auto&quot;</code>, <code>&quot;mouse&quot;</code>.",
+    "onInputChange": "Callback fired when the input value changes.<br><br><strong>Signature:</strong><br><code>function(event: React.SyntheticEvent, value: string, reason: string) =&gt; void</code><br><em>event:</em> The event source of the callback.<br><em>value:</em> The new value of the text input.<br><em>reason:</em> Can be: <code>&quot;input&quot;</code> (user input), <code>&quot;reset&quot;</code> (programmatic change), <code>&quot;clear&quot;</code>.",
+    "onOpen": "Callback fired when the popup requests to be opened. Use in controlled mode (see open).<br><br><strong>Signature:</strong><br><code>function(event: React.SyntheticEvent) =&gt; void</code><br><em>event:</em> The event source of the callback.",
+    "open": "If <code>true</code>, the component is shown.",
+    "openOnFocus": "If <code>true</code>, the popup will open on input focus.",
+    "openText": "Override the default text for the <em>open popup</em> icon button.<br>For localization purposes, you can use the provided <a href=\"/material-ui/guides/localization/\">translations</a>.",
+    "options": "Array of options.",
+    "PaperComponent": "The component used to render the body of the popup.",
+    "PopperComponent": "The component used to position the popup.",
+    "popupIcon": "The icon to display in place of the default popup icon.",
+    "readOnly": "If <code>true</code>, the component becomes readonly. It is also supported for multiple tags where the tag cannot be deleted.",
+    "renderGroup": "Render the group.<br><br><strong>Signature:</strong><br><code>function(params: AutocompleteRenderGroupParams) =&gt; ReactNode</code><br><em>params:</em> The group to render.",
+    "renderInput": "Render the input.<br><br><strong>Signature:</strong><br><code>function(params: object) =&gt; ReactNode</code><br>",
+    "renderOption": "Render the option, use <code>getOptionLabel</code> by default.<br><br><strong>Signature:</strong><br><code>function(props: object, option: T, state: object) =&gt; ReactNode</code><br><em>props:</em> The props to apply on the li element.<br><em>option:</em> The option to render.<br><em>state:</em> The state of the component.",
+    "renderTags": "Render the selected value.<br><br><strong>Signature:</strong><br><code>function(value: Array&lt;T&gt;, getTagProps: function, ownerState: object) =&gt; ReactNode</code><br><em>value:</em> The <code>value</code> provided to the component.<br><em>getTagProps:</em> A tag props getter.<br><em>ownerState:</em> The state of the Autocomplete component.",
+    "selectOnFocus": "If <code>true</code>, the input&#39;s text is selected on focus. It helps the user clear the selected value.",
+    "size": "The size of the component.",
+    "slotProps": "The props used for each slot inside.",
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/getting-started/the-sx-prop/\">`sx` page</a> for more details.",
+    "value": "The value of the autocomplete.<br>The value must have reference equality with the option in order to be selected. You can customize the equality behavior with the <code>isOptionEqualToValue</code> prop."
   },
   "classDescriptions": {
     "clearIndicator": {

--- a/packages/api-docs-builder/utils/generatePropDescription.ts
+++ b/packages/api-docs-builder/utils/generatePropDescription.ts
@@ -180,8 +180,11 @@ export default function generatePropDescription(
       signature += `*templates:* `;
       signature += parsedTemplates
         .map(
-          // stripping "`" as it's not going to be parsed into `code` blocks inside of a title
-          (template) => `<span title="${template.description.replace(/`/g, '')}"><code>${template.key}</code></span>`,
+          (template) =>
+            // stripping "`" as it's not going to be parsed into `code` blocks inside of a title
+            `<span title="${template.description.replace(/`/g, '')}"><code>${
+              template.key
+            }</code></span>`,
         )
         .join(', ');
       signature += '.<br>';

--- a/packages/api-docs-builder/utils/generatePropDescription.ts
+++ b/packages/api-docs-builder/utils/generatePropDescription.ts
@@ -182,7 +182,7 @@ export default function generatePropDescription(
         .map(
           (template) =>
             // stripping "`" as it's not going to be parsed into `code` blocks inside of a title
-            `<span title="${template.description.replace(/`/g, '')}"><code>${
+            `<span class="info-block" title="${template.description.replace(/`/g, '')}"><code>${
               template.key
             }</code></span>`,
         )

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -922,6 +922,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * Used to determine the disabled state for a given option.
    *
    * @param {Value} option The option to test.
+   * @template Value The option shape. Will be the same shape as an item of the options.
    * @returns {boolean}
    */
   getOptionDisabled: PropTypes.func,

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -956,6 +956,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * Used to determine the disabled state for a given option.
    *
    * @param {Value} option The option to test.
+   * @template Value The option shape. Will be the same shape as an item of the options.
    * @returns {boolean}
    */
   getOptionDisabled: PropTypes.func,


### PR DESCRIPTION
Retry https://github.com/mui/material-ui/pull/36097.

> The idea is born from a [concern in docs-feedback](https://mui-org.slack.com/archives/C041SDSF32L/p1675721516737699).

> Process and provide information for `@template <Generic>`, having descriptions, like the following example:
> ```ts
> /**
>  * Callback fired when the value changes.
>  * @template TValue The value type. Will be either the same type as `value` or `null`. Can be in `[start, end]` format in case of range value.
>  * @template TError The validation error type. Will be either `string` or a `null`. Can be in `[start, end]` format in case of range value.
>  * @param {TValue} value The new value.
>  * @param {FieldChangeHandlerContext<TError>} context The context containing the validation result of the current value.
>  */
> onChange?: FieldChangeHandler<TValue, TError>;
> ```
> [Source](https://github.com/mui/mui-x/blob/next/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts#L40)

> A [mui-x api doc](https://deploy-preview-7851--material-ui-x.netlify.app/x/api/date-pickers/date-picker/#:~:text=FieldChangeHandlerContext) example.

> MUI Material [Autocomplete API](https://deploy-preview-36097--material-ui.netlify.app/material-ui/api/autocomplete/#:~:text=of%20truncated%20tags.-,getOptionDisabled,-func) example.