### PR TITLE
[code-infra] Accomodate build requirements from mui-x

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -21,7 +21,15 @@ const bundleTypes = {
 };
 
 async function run(argv) {
-  const { bundle, largeFiles, outDir: outDirBase, verbose, cjsDir } = argv;
+  const {
+    bundle,
+    largeFiles,
+    outDir: outDirBase,
+    verbose,
+    cjsDir,
+    babelIgnore,
+    babelFlag: babelFlags,
+  } = argv;
 
   if (!validBundles.includes(bundle)) {
     throw new TypeError(
@@ -32,11 +40,16 @@ async function run(argv) {
   const packageJsonPath = path.resolve('./package.json');
   const packageJson = JSON.parse(await fs.readFile(packageJsonPath, { encoding: 'utf8' }));
 
-  const babelRuntimeVersion = packageJson.dependencies?.['@babel/runtime'];
+  let babelRuntimeVersion = packageJson.dependencies['@babel/runtime'];
   if (!babelRuntimeVersion) {
     throw new Error(
       'package.json needs to have a dependency on `@babel/runtime` when building with `@babel/plugin-transform-runtime`.',
     );
+  } else if (babelRuntimeVersion === 'catalog:') {
+    // resolve the version from the given package
+    const { stdout: listedBabelRuntime } = await exec('pnpm list "@babel/runtime" --json');
+    const jsonListedDependencies = JSON.parse(listedBabelRuntime);
+    babelRuntimeVersion = jsonListedDependencies[0].dependencies['@babel/runtime'].version;
   }
 
   const babelConfigPath = path.resolve(getWorkspaceRoot(), 'babel.config.js');
@@ -46,11 +59,13 @@ async function run(argv) {
     '**/*.test.js',
     '**/*.test.ts',
     '**/*.test.tsx',
+    '**/*.spec.js',
     '**/*.spec.ts',
     '**/*.spec.tsx',
     '**/*.d.ts',
     '**/*.test/*.*',
     '**/test-cases/*.*',
+    ...babelIgnore,
   ];
 
   const outFileExtension = '.js';
@@ -68,7 +83,7 @@ async function run(argv) {
     MUI_BUILD_VERBOSE: verbose,
     MUI_BABEL_RUNTIME_VERSION: babelRuntimeVersion,
     MUI_OUT_FILE_EXTENSION: outFileExtension,
-    ...(await getVersionEnvVariables(packageJson)),
+    ...getVersionEnvVariables(packageJson),
   };
 
   const babelArgs = [
@@ -82,6 +97,7 @@ async function run(argv) {
     '--ignore',
     // Need to put these patterns in quotes otherwise they might be evaluated by the used terminal.
     `"${ignore.join('","')}"`,
+    ...babelFlags,
   ];
 
   if (outFileExtension !== '.js') {
@@ -153,7 +169,14 @@ yargs(process.argv.slice(2))
           description: 'The directory to copy the cjs files to.',
         })
         .option('out-dir', { default: './build', type: 'string' })
-        .option('verbose', { type: 'boolean' });
+        .option('babel-ignore', { type: 'string', array: true, default: [] })
+        .option('verbose', { type: 'boolean' })
+        .option('babel-flag', {
+          type: 'string',
+          array: true,
+          default: [],
+          description: 'Additional flags to pass to babel cli.',
+        });
     },
     handler: run,
   })

--- a/scripts/copyFiles.mjs
+++ b/scripts/copyFiles.mjs
@@ -34,16 +34,28 @@ async function run() {
   const extraFiles = process.argv.slice(2);
   try {
     const packageData = await createPackageFile(true);
+    const defaultFiles = ['README.md'];
 
-    let changlogPath;
-    if (await fileExists(path.join(packagePath, './CHANGELOG.md'))) {
-      changlogPath = './CHANGELOG.md';
-    } else {
-      changlogPath = '../../CHANGELOG.md';
-    }
+    const packageOrRootFiles = [
+      ['LICENSE', '../../LICENSE'],
+      ['CHANGELOG.md', '../../CHANGELOG.md'],
+    ];
 
     await Promise.all(
-      ['./README.md', changlogPath, '../../LICENSE', ...extraFiles].map(async (file) => {
+      packageOrRootFiles.map(async (files) => {
+        for (const file of files) {
+          const sourcePath = path.join(packagePath, file);
+          // eslint-disable-next-line no-await-in-loop
+          if (await fileExists(sourcePath)) {
+            defaultFiles.push(file);
+            break;
+          }
+        }
+      }),
+    );
+
+    await Promise.all(
+      [...defaultFiles, ...extraFiles].map(async (file) => {
         const [sourcePath, targetPath] = file.split(':');
         await includeFileInBuild(sourcePath, targetPath);
       }),


### PR DESCRIPTION
* Allow passing of extra flags to the babel-cli (temporarily)
* Check existence of package files (like license, changelogs etc) before
copying them.

This change will allow us to reuse the build and copyFiles script on `mui-x`.

Followup on mui-x - https://github.com/mui/mui-x/pull/18832

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
