### PR TITLE
[TextareaAutosize] Prevent placeholder from affecting height

### DIFF
--- a/packages/mui-material/src/TextareaAutosize/TextareaAutosize.tsx
+++ b/packages/mui-material/src/TextareaAutosize/TextareaAutosize.tsx
@@ -89,7 +89,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
     }
 
     hiddenTextarea.style.width = computedStyle.width;
-    hiddenTextarea.value = textarea.value || props.placeholder || 'x';
+    hiddenTextarea.value = textarea.value || 'x';
     if (hiddenTextarea.value.slice(-1) === '\n') {
       // Certain fonts which overflow the line height will cause the textarea
       // to report a different scrollHeight depending on whether the last line
@@ -126,7 +126,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
     const overflowing = Math.abs(outerHeight - innerHeight) <= 1;
 
     return { outerHeightStyle, overflowing };
-  }, [maxRows, minRows, props.placeholder]);
+  }, [maxRows, minRows]);
 
   const didHeightChange = useEventCallback(() => {
     const textarea = textareaRef.current;
@@ -155,6 +155,9 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
       textarea.style.height = `${outerHeightStyle}px`;
     }
     textarea.style.overflow = textareaStyles.overflowing ? 'hidden' : '';
+    if (!textarea.value) {
+      textarea.style.whiteSpace = 'nowrap';
+    }
   }, [calculateTextareaStyles]);
 
   const frameRef = React.useRef(-1);
@@ -274,10 +277,6 @@ TextareaAutosize.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   onChange: PropTypes.func,
-  /**
-   * @ignore
-   */
-  placeholder: PropTypes.string,
   /**
    * @ignore
    */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixed #46543 

Summary:

TextareaAutosize ignores placeholder text when measuring height for auto-resize and ensures long placeholders do not cause unintended row expansion.


Before:

https://github.com/user-attachments/assets/67c60da3-d717-422a-9bd7-4a88f059aa41

After:

https://github.com/user-attachments/assets/1cb0d739-0f8f-4055-b3b6-26e37be815c1

