### PR TITLE
[docs] Fix incorrect Typography override example for responsive styles

### DIFF
--- a/docs/data/material/customization/typography/typography.md
+++ b/docs/data/material/customization/typography/typography.md
@@ -115,17 +115,21 @@ The `theme.typography.*` [variant](#variants) properties map directly to the gen
 You can use [media queries](/material-ui/customization/breakpoints/#api) inside them:
 
 ```js
-const theme = createTheme();
+const baseTheme = createTheme();
 
-theme.typography.h3 = {
-  fontSize: '1.2rem',
-  '@media (min-width:600px)': {
-    fontSize: '1.5rem',
+const theme = createTheme({
+  typography: {
+    h3: {
+      fontSize: '1.2rem',
+      '@media (min-width:600px)': {
+        fontSize: '1.5rem',
+      },
+      [baseTheme.breakpoints.up('md')]: {
+        fontSize: '2.4rem',
+      },
+    },
   },
-  [theme.breakpoints.up('md')]: {
-    fontSize: '2.4rem',
-  },
-};
+});
 ```
 
 {{"demo": "CustomResponsiveFontSizes.js"}}


### PR DESCRIPTION
Updated the Typography `h3` override example to define styles inside `createTheme`, as suggested in [this comment](https://github.com/mui/material-ui/issues/46498#issuecomment-3082743270)

This ensures media queries and CSS variable overrides are properly applied.

Fixes #46498


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
