### PR TITLE
[infra] Update scripts to delete publishConfig.directory

### DIFF
--- a/packages/mui-codemod/package.json
+++ b/packages/mui-codemod/package.json
@@ -14,7 +14,9 @@
   "scripts": {
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-codemod/**/*.test.?(c|m)[jt]s?(x)'",
     "prebuild": "rimraf build",
-    "build": "node ../../scripts/build.mjs node --out-dir ./build && cpy README.md build && cpy package.json build && cpy codemod.js build",
+    "build:node": "node ../../scripts/build.mjs node --out-dir ./build",
+    "build:copy-files": "node ../../scripts/copyFiles.mjs codemod.js",
+    "build": "pnpm build:node && pnpm build:copy-files",
     "release": "pnpm build && pnpm publish"
   },
   "repository": {

--- a/packages/mui-envinfo/package.json
+++ b/packages/mui-envinfo/package.json
@@ -16,7 +16,9 @@
   "homepage": "https://github.com/mui/material-ui/tree/HEAD/packages/mui-envinfo",
   "files": [],
   "scripts": {
-    "build": "node scripts/build"
+    "build": "pnpm build:node && pnpm build:copy-files",
+    "build:node": "node scripts/build",
+    "build:copy-files": "node ../../scripts/copyFiles.mjs"
   },
   "dependencies": {
     "envinfo": "^7.14.0"

--- a/packages/mui-envinfo/scripts/build.js
+++ b/packages/mui-envinfo/scripts/build.js
@@ -43,6 +43,11 @@ async function main() {
   } finally {
     await fse.remove(untarDestination);
   }
+  const pkgJson = await fse.readJson(path.join(buildDirectory, 'package.json'));
+  delete pkgJson.publishConfig.directory;
+  await fse.writeJson(path.join(buildDirectory, 'package.json'), pkgJson, {
+    spaces: 2,
+  });
 }
 
 main().catch((error) => {

--- a/packages/mui-envinfo/scripts/build.js
+++ b/packages/mui-envinfo/scripts/build.js
@@ -43,11 +43,6 @@ async function main() {
   } finally {
     await fse.remove(untarDestination);
   }
-  const pkgJson = await fse.readJson(path.join(buildDirectory, 'package.json'));
-  delete pkgJson.publishConfig.directory;
-  await fse.writeJson(path.join(buildDirectory, 'package.json'), pkgJson, {
-    spaces: 2,
-  });
 }
 
 main().catch((error) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12191,7 +12191,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qjobs@1.2.0:

--- a/scripts/copyFilesUtils.mjs
+++ b/scripts/copyFilesUtils.mjs
@@ -202,6 +202,10 @@ export async function createPackageFile(useEsmExports = false) {
     newPackageData.types = './index.d.ts';
   }
 
+  if (newPackageData.publishConfig?.directory) {
+    delete newPackageData.publishConfig.directory;
+  }
+
   const targetPath = path.resolve(buildPath, './package.json');
 
   await fse.writeFile(targetPath, JSON.stringify(newPackageData, null, 2), 'utf8');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

It is not required within the `build` directory and also helps with pkg.pr.new publishing so that we are able to use `pnpm pack` instead of `npm pack`.

I don't see any downsides of this but please let me know if there can be any other major repercussions that I might not have though of.

Here's the output in mui-x - https://publint.dev/pkg.pr.new/mui/mui-x/@mui/x-charts-pro@890bc9d

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
