### PR TITLE
fix(input): prevent invalid props from leaking into DOM

### DIFF
--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -35,7 +35,7 @@ const useUtilityClasses = (ownerState) => {
 };
 
 const InputRoot = styled(InputBaseRoot, {
-  shouldForwardProp: (prop) => rootShouldForwardProp(prop) || prop === 'classes',
+  shouldForwardProp: (prop) => rootShouldForwardProp(prop) || (prop === 'classes' || prop === 'ownerState'),
   name: 'MuiInput',
   slot: 'Root',
   overridesResolver: (props, styles) => {

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -196,7 +196,10 @@ Input.propTypes /* remove-proptypes */ = {
    * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
    * The prop defaults to the value (`'primary'`) inherited from the parent FormControl component.
    */
-  color: PropTypes.oneOfType([PropTypes.oneOf(['primary', 'secondary']), PropTypes.string]),
+  color: PropTypes.oneOfType([
+    PropTypes.oneOf(['error', 'info', 'primary', 'secondary', 'success', 'warning']),
+    PropTypes.string,
+  ]),
   /**
    * The components used for each slot inside.
    *

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -34,6 +34,7 @@ const useUtilityClasses = (ownerState) => {
   };
 };
 
+
 const InputRoot = styled(InputBaseRoot, {
   shouldForwardProp: (prop) => rootShouldForwardProp(prop) || (prop === 'classes' || prop === 'ownerState'),
   name: 'MuiInput',
@@ -226,6 +227,7 @@ Input.propTypes /* remove-proptypes */ = {
    *
    * @default {}
    */
+
   componentsProps: PropTypes.shape({
     input: PropTypes.object,
     root: PropTypes.object,

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -26,11 +26,9 @@ const useUtilityClasses = (ownerState) => {
     input: ['input'],
   };
 
-  const composedClasses = composeClasses(slots, getInputUtilityClass, classes);
-
   return {
-    ...classes, // forward classes to the InputBase
-    ...composedClasses,
+    ...classes,
+    ...composeClasses(slots, getInputUtilityClass, classes),
   };
 };
 
@@ -46,88 +44,84 @@ const InputRoot = styled(InputBaseRoot, {
       !ownerState.disableUnderline && styles.underline,
     ];
   },
-})(
-  memoTheme(({ theme }) => {
-    const light = theme.palette.mode === 'light';
-    let bottomLineColor = light ? 'rgba(0, 0, 0, 0.42)' : 'rgba(255, 255, 255, 0.7)';
-    if (theme.vars) {
-      bottomLineColor = `rgba(${theme.vars.palette.common.onBackgroundChannel} / ${theme.vars.opacity.inputUnderline})`;
-    }
-    return {
-      position: 'relative',
-      variants: [
-        {
-          props: ({ ownerState }) => ownerState.formControl,
-          style: {
-            'label + &': {
-              marginTop: 16,
-            },
+})(({ theme }) => {
+  const bottomLineColor = theme.vars
+    ? `rgba(${theme.vars.palette.common.onBackgroundChannel} / ${theme.vars.opacity.inputUnderline})`
+    : theme.palette.mode === 'light'
+      ? 'rgba(0, 0, 0, 0.42)'
+      : 'rgba(255, 255, 255, 0.7)';
+
+  return {
+    position: 'relative',
+    variants: [
+      {
+        props: { formControl: true },
+        style: {
+          'label + &': {
+            marginTop: 16,
           },
         },
-        {
-          props: ({ ownerState }) => !ownerState.disableUnderline,
+      },
+      {
+        props: { disableUnderline: false },
+        style: {
+          '&::after': {
+            left: 0,
+            bottom: 0,
+            content: '""',
+            position: 'absolute',
+            right: 0,
+            transform: 'scaleX(0)',
+            transition: theme.transitions.create('transform', {
+              duration: theme.transitions.duration.shorter,
+              easing: theme.transitions.easing.easeOut,
+            }),
+            pointerEvents: 'none',
+          },
+          [`&.${inputClasses.focused}:after`]: {
+            transform: 'scaleX(1) translateX(0)',
+          },
+          [`&.${inputClasses.error}`]: {
+            '&::before, &::after': {
+              borderBottomColor: (theme.vars || theme).palette.error.main,
+            },
+          },
+          '&::before': {
+            borderBottom: `1px solid ${bottomLineColor}`,
+            left: 0,
+            bottom: 0,
+            content: '"\\00a0"',
+            position: 'absolute',
+            right: 0,
+            transition: theme.transitions.create('border-bottom-color', {
+              duration: theme.transitions.duration.shorter,
+            }),
+            pointerEvents: 'none',
+          },
+          [`&:hover:not(.${inputClasses.disabled}, .${inputClasses.error}):before`]: {
+            borderBottom: `2px solid ${(theme.vars || theme).palette.text.primary}`,
+            '@media (hover: none)': {
+              borderBottom: `1px solid ${bottomLineColor}`,
+            },
+          },
+          [`&.${inputClasses.disabled}:before`]: {
+            borderBottomStyle: 'dotted',
+          },
+        },
+      },
+      ...Object.entries(theme.palette)
+        .filter(createSimplePaletteValueFilter())
+        .map(([color]) => ({
+          props: { color, disableUnderline: false },
           style: {
             '&::after': {
-              left: 0,
-              bottom: 0,
-              content: '""',
-              position: 'absolute',
-              right: 0,
-              transform: 'scaleX(0)',
-              transition: theme.transitions.create('transform', {
-                duration: theme.transitions.duration.shorter,
-                easing: theme.transitions.easing.easeOut,
-              }),
-              pointerEvents: 'none', // Transparent to the hover style.
-            },
-            [`&.${inputClasses.focused}:after`]: {
-              // translateX(0) is a workaround for Safari transform scale bug
-              // See https://github.com/mui/material-ui/issues/31766
-              transform: 'scaleX(1) translateX(0)',
-            },
-            [`&.${inputClasses.error}`]: {
-              '&::before, &::after': {
-                borderBottomColor: (theme.vars || theme).palette.error.main,
-              },
-            },
-            '&::before': {
-              borderBottom: `1px solid ${bottomLineColor}`,
-              left: 0,
-              bottom: 0,
-              content: '"\\00a0"',
-              position: 'absolute',
-              right: 0,
-              transition: theme.transitions.create('border-bottom-color', {
-                duration: theme.transitions.duration.shorter,
-              }),
-              pointerEvents: 'none', // Transparent to the hover style.
-            },
-            [`&:hover:not(.${inputClasses.disabled}, .${inputClasses.error}):before`]: {
-              borderBottom: `2px solid ${(theme.vars || theme).palette.text.primary}`,
-              // Reset on touch devices, it doesn't add specificity
-              '@media (hover: none)': {
-                borderBottom: `1px solid ${bottomLineColor}`,
-              },
-            },
-            [`&.${inputClasses.disabled}:before`]: {
-              borderBottomStyle: 'dotted',
+              borderBottom: `2px solid ${(theme.vars || theme).palette[color].main}`,
             },
           },
-        },
-        ...Object.entries(theme.palette)
-          .filter(createSimplePaletteValueFilter())
-          .map(([color]) => ({
-            props: { color, disableUnderline: false },
-            style: {
-              '&::after': {
-                borderBottom: `2px solid ${(theme.vars || theme).palette[color].main}`,
-              },
-            },
-          })),
-      ],
-    };
-  }),
-);
+        })),
+    ],
+  };
+});
 
 const InputInput = styled(InputBaseInput, {
   name: 'MuiInput',
@@ -151,7 +145,6 @@ const Input = React.forwardRef(function Input(inProps, ref) {
   } = props;
 
   const classes = useUtilityClasses(props);
-
   const ownerState = { disableUnderline };
   const inputComponentsProps = { root: { ownerState } };
 
@@ -226,7 +219,6 @@ Input.propTypes /* remove-proptypes */ = {
    *
    * @default {}
    */
-
   componentsProps: PropTypes.shape({
     input: PropTypes.object,
     root: PropTypes.object,

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -36,12 +36,13 @@ const useUtilityClasses = (ownerState) => {
 
 
 const InputRoot = styled(InputBaseRoot, {
-  shouldForwardProp: (prop) => rootShouldForwardProp(prop) || (prop === 'classes' || prop === 'ownerState'),
+  shouldForwardProp: (prop) => 
+    rootShouldForwardProp(prop) && 
+    !['classes', 'ownerState', 'disableUnderline'].includes(prop),
   name: 'MuiInput',
   slot: 'Root',
   overridesResolver: (props, styles) => {
     const { ownerState } = props;
-
     return [
       ...inputBaseRootOverridesResolver(props, styles),
       !ownerState.disableUnderline && styles.underline,

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -196,10 +196,7 @@ Input.propTypes /* remove-proptypes */ = {
    * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
    * The prop defaults to the value (`'primary'`) inherited from the parent FormControl component.
    */
-  color: PropTypes.oneOfType([
-    PropTypes.oneOf(['error', 'info', 'primary', 'secondary', 'success', 'warning']),
-    PropTypes.string,
-  ]),
+  color: PropTypes.oneOfType([PropTypes.oneOf(['primary', 'secondary']), PropTypes.string]),
   /**
    * The components used for each slot inside.
    *

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -196,10 +196,7 @@ Input.propTypes /* remove-proptypes */ = {
    * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
    * The prop defaults to the value (`'primary'`) inherited from the parent FormControl component.
    */
-  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['primary', 'secondary']),
-    PropTypes.string,
-  ]),
+  color: PropTypes.oneOfType([PropTypes.oneOf(['primary', 'secondary']), PropTypes.string]),
   /**
    * The components used for each slot inside.
    *

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -34,11 +34,9 @@ const useUtilityClasses = (ownerState) => {
   };
 };
 
-
 const InputRoot = styled(InputBaseRoot, {
-  shouldForwardProp: (prop) => 
-    rootShouldForwardProp(prop) && 
-    !['classes', 'ownerState', 'disableUnderline'].includes(prop),
+  shouldForwardProp: (prop) =>
+    rootShouldForwardProp(prop) && !['classes', 'ownerState', 'disableUnderline'].includes(prop),
   name: 'MuiInput',
   slot: 'Root',
   overridesResolver: (props, styles) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,5 +58,5 @@
     // Otherwise we get react-native typings which conflict with dom.lib.
     "types": ["node", "react", "mocha"]
   },
-  "exclude": ["**/.*/", "**/build", "**/node_modules", "docs/export"]
+  "exclude": ["**/.*/", "**/build", "**/node_modules", "docs/export", "packages/mui-icons-material/templateSvgIcon.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,5 +58,5 @@
     // Otherwise we get react-native typings which conflict with dom.lib.
     "types": ["node", "react", "mocha"]
   },
-  "exclude": ["**/.*/", "**/build", "**/node_modules", "docs/export", "packages/mui-icons-material/templateSvgIcon.js"]
+  "exclude": ["**/.*/", "**/build", "**/node_modules", "docs/export"]
 }


### PR DESCRIPTION
## 📝 Description:
This PR : Prevents invalid `classes` and `ownerState` props from leaking into the DOM when using styled(InputBaseRoot).

## 🐛 Fix for [ #46591](https://github.com/mui/material-ui/issues/46591)

### ✅ Changes:
- Updated `shouldForwardProp` logic in `Input.js` to allow valid internal props only.

### 🧪 Tested:
- Warning no longer appears in console when using `<TextField variant="standard" />`
