### PR TITLE
fix(ListItemIcon): replaced hardcoded minWidth with theme.spacing

### DIFF
--- a/packages/mui-material/src/ListItemIcon/ListItemIcon.js
+++ b/packages/mui-material/src/ListItemIcon/ListItemIcon.js
@@ -29,7 +29,7 @@ const ListItemIconRoot = styled('div', {
   },
 })(
   memoTheme(({ theme }) => ({
-    minWidth: 56,
+    minWidth: theme.spacing(4.5),
     color: (theme.vars || theme).palette.action.active,
     flexShrink: 0,
     display: 'inline-flex',


### PR DESCRIPTION
## Summary

This PR replaces the hardcoded `minWidth: 56px` in `ListItemIcon` with `theme.spacing(4.5)` (36px) for consistent spacing with other components like `MenuItem`.

## Fixes
Closes #46596  
Ensures icon spacing is responsive and theme-consistent.

## Testing

- Verified in local docs for both `List` and `Menu`
- Confirmed consistent spacing after the change
