### PR TITLE
[infra] Remove package.json `module` field

### DIFF
--- a/docs/data/material/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/data/material/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -70,7 +70,7 @@ If you're on **Next.js 13.5 or newer**, you're in good hands. These versions inc
 
 ## Using parcel
 
-Parcel, by default, doesn't resolve package.json "exports". This makes it always resolve to the commonjs version of our library. To make it optimally make use of our ESM version, make sure to [enable the `packageExports` option](https://parceljs.org/features/dependency-resolution/#enabling-package-exports).
+Parcel, by default, doesn't resolve package.json `"exports"`. This makes it always resolve to the commonjs version of our library. To make it optimally make use of our ESM version, make sure to [enable the `packageExports` option](https://parceljs.org/features/dependency-resolution/#enabling-package-exports).
 
 ```json
 // ./package.json

--- a/docs/data/material/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/data/material/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -67,3 +67,16 @@ To prevent VS Code from automatically importing from `@mui/material`, you can u
 ## Using Next.js 13.5 or later?
 
 If you're on **Next.js 13.5 or newer**, you're in good hands. These versions include automatic import optimization via the `optimizePackageImports` option. This removes the need for manual configuration or Babel plugins to optimize imports.
+
+## Using parcel
+
+Parcel, by default, doesn't resolve package.json "exports". This makes it always resolve to the commonjs version of our library. To make it optimally make use of our ESM version, make sure to [enable the `packageExports` option](https://parceljs.org/features/dependency-resolution/#enabling-package-exports).
+
+```json
+// ./package.json
+{
+  "@parcel/resolver-default": {
+    "packageExports": true
+  }
+}
+```

--- a/scripts/copyFilesUtils.mjs
+++ b/scripts/copyFilesUtils.mjs
@@ -138,8 +138,7 @@ function createExportFor(exportName, conditions) {
   };
 }
 
-// TODO: remove useEsmExports paramater once X is on the ESM-exports package layout (default to true)
-export async function createPackageFile(useEsmExports = false) {
+export async function createPackageFile() {
   const packageData = await fse.readFile(path.resolve(packagePath, './package.json'), 'utf8');
   const { nyc, scripts, devDependencies, workspaces, ...packageDataOther } =
     JSON.parse(packageData);

--- a/scripts/copyFilesUtils.mjs
+++ b/scripts/copyFilesUtils.mjs
@@ -170,32 +170,12 @@ export async function createPackageFile(useEsmExports = false) {
     }
   }
 
-  const newPackageData = useEsmExports
-    ? {
-        ...packageDataOther,
-        private: false,
-        ...(packageDataOther.main
-          ? {
-              main: './index.js',
-              module: './esm/index.js',
-            }
-          : {}),
-        exports: packageExports,
-      }
-    : {
-        ...packageDataOther,
-        private: false,
-        ...(packageDataOther.main
-          ? {
-              main: fse.existsSync(path.resolve(buildPath, './node/index.js'))
-                ? './node/index.js'
-                : './index.js',
-              module: fse.existsSync(path.resolve(buildPath, './esm/index.js'))
-                ? './esm/index.js'
-                : './index.js',
-            }
-          : {}),
-      };
+  const newPackageData = {
+    ...packageDataOther,
+    private: false,
+    ...(packageDataOther.main ? { main: './index.js' } : {}),
+    exports: packageExports,
+  };
 
   const typeDefinitionsFilePath = path.resolve(buildPath, './index.d.ts');
   if (await fse.pathExists(typeDefinitionsFilePath)) {


### PR DESCRIPTION
Fix codesandbox and parcel without `packageExports` enabled. The issue is caused by top-level imprts having a cjs and esm variant through main/module fields but the subpath exports only having a cjs  export through file system resolution. We can simply remove the module field to have both resolve to the cjs variant. this only applies on runtimes where the exports field is not supported (codesandbox, parcel, webpack@<=4,...).

[docs](https://deploy-preview-46620--material-ui.netlify.app/material-ui/guides/minimizing-bundle-size/#using-parcel)