### PR TITLE
[docs] Add MCP server installation details for Claude Code

### DIFF
--- a/docs/data/material/getting-started/mcp/mcp.md
+++ b/docs/data/material/getting-started/mcp/mcp.md
@@ -21,7 +21,7 @@ MCP solves these problems by:
 
 ## Installation and setup
 
-The sections below detail how to set up the Material UI MCP in popular IDEs.
+The sections below detail how to set up the Material UI MCP in popular agentic coding environments.
 
 ### VS Code, Cursor, Windsurf
 
@@ -82,6 +82,26 @@ Search for `agent: add context server` in the Command Palette and add the follow
   }
 }
 ```
+
+### Claude Code
+
+Claude Code is Anthropic's agentic coding tool that runs in your terminal.
+
+You can add the Material UI MCP server to Claude Code via the command line:
+
+```bash
+claude mcp add mui-mcp -- npx -y @mui/mcp@latest
+```
+
+By default, this installs the MCP server to local-scope of the project you are working on.
+
+If you want the MCP server to always be available to all projects on your machine, you would install it to user-scope:
+
+```bash
+claude mcp add mui-mcp -s user -- npx -y @mui/mcp@latest
+```
+
+To better understand MCP server scope hierarchy and precedence in Claude Code, see their [official documentation](https://docs.anthropic.com/en/docs/claude-code/mcp#understanding-mcp-server-scopes).
 
 ## Common issues
 


### PR DESCRIPTION
Resolves #46471

This pull request adds MCP server installation details for Claude Code to the documentation to provide clearer setup instructions for users integrating Claude Code with the MCP server.