### PR TITLE
fix: add dark mode Firefox fix for Select

### DIFF
--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -23,23 +23,32 @@ const SelectSelect = styled(StyledSelectSelect, {
   overridesResolver: (props, styles) => {
     const { ownerState } = props;
     return [
-      // Win specificity over the input base
       { [`&.${selectClasses.select}`]: styles.select },
       { [`&.${selectClasses.select}`]: styles[ownerState.variant] },
       { [`&.${selectClasses.error}`]: styles.error },
       { [`&.${selectClasses.multiple}`]: styles.multiple },
     ];
   },
-})({
-  // Win specificity over the input base
+})((theme) => ({
   [`&.${selectClasses.select}`]: {
-    height: 'auto', // Resets for multiple select with chips
-    minHeight: '1.4375em', // Required for select\text-field height consistency
+    height: 'auto',
+    minHeight: '1.4375em',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
+    // Dark mode + Firefox fix
+    '&:-moz-focusring': {
+      color:
+        theme.palette.mode === 'dark'
+          ? theme.palette.text.primary
+          : 'transparent',
+      textShadow:
+        theme.palette.mode === 'dark'
+          ? `0 0 0 ${theme.palette.text.primary}`
+          : '0 0 0 #000',
+    },
   },
-});
+}));
 
 const SelectIcon = styled(StyledSelectIcon, {
   name: 'MuiSelect',


### PR DESCRIPTION
### Summary:

This PR improves accessibility and visual consistency for the `<Select>` component in **Firefox + dark mode**.

Currently, when the component receives focus via keyboard (e.g., Tab), the text becomes **transparent**, making the selected value unreadable in dark mode. This is due to the `:-moz-focusring` style not accounting for dark themes.

### What’s Fixed
:
Added dark mode–specific styling inside the `SelectSelect` styled component to fix this issue:

```js
'&:-moz-focusring': {
  color: theme.palette.mode === 'dark'
    ? theme.palette.text.primary
    : 'transparent',
  textShadow: theme.palette.mode === 'dark'
    ? `0 0 0 ${theme.palette.text.primary}`
    : '0 0 0 #000',
},

> Note: Please add the `test-label-applied` label to pass CI — external contributors cannot apply labels.
