### PR TITLE
[infra] Remove useless test step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,14 +240,6 @@ jobs:
             pnpm --filter @mui/joy typescript:module-augmentation
             pnpm --filter @mui/system typescript:module-augmentation
       - run:
-          name: Diff declaration files
-          command: |
-            git add -f packages/mui-material/build || echo '/material declarations do not exist'
-            git add -f packages/mui-lab/build || echo '/lab declarations do not exist'
-            git add -f packages/mui-utils/build || echo '/utils declarations do not exist'
-            pnpm -r build:stable && pnpm -r build:types
-            git --no-pager diff
-      - run:
           name: Any defect declaration files?
           command: node scripts/testBuiltTypes.mjs
       - save_cache:


### PR DESCRIPTION
I'm sure at some point this was testing something useful, but currently, this is testing exactly nothing. Those build folders are always empty at the start of this step and they are gitignored. The whole step is a no-op and has been for a long time.
This will save roughly 1m40s from the runtime