### PR TITLE
[material-ui][Drawer]: add dialog role and aria-modal for temporary variant accessibility

### DIFF
--- a/packages/mui-material/src/Drawer/Drawer.js
+++ b/packages/mui-material/src/Drawer/Drawer.js
@@ -287,6 +287,10 @@ const Drawer = React.forwardRef(function Drawer(inProps, ref) {
     additionalProps: {
       elevation: variant === 'temporary' ? elevation : 0,
       square: true,
+      ...(variant === 'temporary' && {
+        role: 'dialog',
+        'aria-modal': 'true',
+      }),
     },
   });
 


### PR DESCRIPTION
This PR  closes #46673

- Added `role="dialog"` to identify the temporary drawer as a dialog element
- Added `aria-modal="true"` to indicate temporary drawer is a modal