### PR TITLE
[docs][TextField] Add note about removal of `sizeMedium` class from InputLabel in v7 upgrade guide

### DIFF
--- a/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
+++ b/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
@@ -275,8 +275,6 @@ Depending on your project, you may follow one of the following approaches:
 
 The `size` prop for `InputLabel` now follows the standard naming convention used across other components like `Button` and `TextField`. `'normal'` has been replaced with `'medium'` for consistency.
 
-> **Note:** Because the default size of `InputLabel` was changed from `normal` to `medium`, the class name `MuiInputLabel‑sizeMedium` is no longer added. If you relied on this class for custom styling, apply your own class to the `TextField` or use the `sx` prop to target the label.
-
 If you were using `size="normal"`, update it to `size="medium"`:
 
 ```diff
@@ -293,6 +291,8 @@ Use this codemod to automatically update the `size` value:
 ```bash
 npx @mui/codemod v7.0.0/input-label-size-normal-medium <path/to/folder>
 ```
+
+> **Note:** Because the default size of `InputLabel` was changed from `normal` to `medium`, the class `MuiInputLabel‑sizeMedium` is no longer added. If you relied on this class for custom styling, use a different class.
 
 ### SvgIcon's data-testid removed
 

--- a/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
+++ b/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
@@ -275,6 +275,8 @@ Depending on your project, you may follow one of the following approaches:
 
 The `size` prop for `InputLabel` now follows the standard naming convention used across other components like `Button` and `TextField`. `'normal'` has been replaced with `'medium'` for consistency.
 
+> **Note:** Because the default size of `InputLabel` was changed from `normal` to `medium`, the class name `MuiInputLabel‑sizeMedium` is no longer added. If you relied on this class for custom styling, apply your own class to the `TextField` or use the `sx` prop to target the label.
+
 If you were using `size="normal"`, update it to `size="medium"`:
 
 ```diff

--- a/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
+++ b/docs/data/material/migration/upgrade-to-v7/upgrade-to-v7.md
@@ -292,7 +292,7 @@ Use this codemod to automatically update the `size` value:
 npx @mui/codemod v7.0.0/input-label-size-normal-medium <path/to/folder>
 ```
 
-> **Note:** Because the default size of `InputLabel` was changed from `normal` to `medium`, the class `MuiInputLabel‑sizeMedium` is no longer added. If you relied on this class for custom styling, use a different class.
+**Note:** Because the default size of `InputLabel` was changed from `normal` to `medium`, the class `MuiInputLabel‑sizeMedium` is no longer added. If you relied on this class for custom styling, use a different class.
 
 ### SvgIcon's data-testid removed
 


### PR DESCRIPTION
docs: add note about removal of MuiInputLabel‑sizeMedium class in upgrade guide

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #46684 