### PR TITLE
[material-ui][ButtonGroup] Compute per-button position classes via context

### DIFF
--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
@@ -276,5 +276,115 @@ describe('<ButtonGroup />', () => {
       expect(button).not.to.have.class(classes.middleButton);
       expect(button).not.to.have.class(classes.lastButton);
     });
+
+    it('applies first/last to actual Button roots when children are wrapped', () => {
+      function Wrapper({ children }) {
+        return <div data-testid="wrapper">{children}</div>;
+      }
+
+      render(
+        <ButtonGroup>
+          <Wrapper>
+            <Button>A</Button>
+          </Wrapper>
+          <Wrapper>
+            <Button>B</Button>
+          </Wrapper>
+        </ButtonGroup>,
+      );
+
+      const [a, b] = screen.getAllByRole('button');
+      expect(a).to.have.class(classes.firstButton);
+      expect(a).not.to.have.class(classes.middleButton);
+      expect(a).not.to.have.class(classes.lastButton);
+
+      expect(b).to.have.class(classes.lastButton);
+      expect(b).not.to.have.class(classes.middleButton);
+      expect(b).not.to.have.class(classes.firstButton);
+    });
+
+    it('removes position classes when a wrapped sibling becomes hidden (only case)', () => {
+      function Wrapper({ show = true, children }) {
+        return show ? children : null;
+      }
+
+      const { rerender } = render(
+        <ButtonGroup>
+          <Wrapper show>
+            <Button>A</Button>
+          </Wrapper>
+          <Wrapper show>
+            <Button>B</Button>
+          </Wrapper>
+        </ButtonGroup>,
+      );
+
+      // both visible: first/last
+      const [a, b] = screen.getAllByRole('button');
+      expect(a).to.have.class(classes.firstButton);
+      expect(b).to.have.class(classes.lastButton);
+
+      // hide second
+      rerender(
+        <ButtonGroup>
+          <Wrapper show>
+            <Button>A</Button>
+          </Wrapper>
+          <Wrapper show={false}>
+            <Button>B</Button>
+          </Wrapper>
+        </ButtonGroup>,
+      );
+
+      const only = screen.getByRole('button');
+      expect(only).not.to.have.class(classes.firstButton);
+      expect(only).not.to.have.class(classes.middleButton);
+      expect(only).not.to.have.class(classes.lastButton);
+    });
+
+    it('keeps first/last correct when a middle wrapped child is removed', () => {
+      function Wrapper({ show = true, children }) {
+        return show ? children : null;
+      }
+
+      const { rerender } = render(
+        <ButtonGroup>
+          <Wrapper show>
+            <Button>A</Button>
+          </Wrapper>
+          <Wrapper show>
+            <Button>B</Button>
+          </Wrapper>
+          <Wrapper show>
+            <Button>C</Button>
+          </Wrapper>
+        </ButtonGroup>,
+      );
+
+      // eslint-disable-next-line prefer-const
+      let [a, b, c] = screen.getAllByRole('button');
+      expect(a).to.have.class(classes.firstButton);
+      expect(b).to.have.class(classes.middleButton);
+      expect(c).to.have.class(classes.lastButton);
+
+      // hide middle
+      rerender(
+        <ButtonGroup>
+          <Wrapper show>
+            <Button>A</Button>
+          </Wrapper>
+          <Wrapper show={false}>
+            <Button>B</Button>
+          </Wrapper>
+          <Wrapper show>
+            <Button>C</Button>
+          </Wrapper>
+        </ButtonGroup>,
+      );
+
+      [a, c] = screen.getAllByRole('button');
+      expect(a).to.have.class(classes.firstButton);
+      expect(c).to.have.class(classes.lastButton);
+    });
   });
 });

--- a/packages/mui-material/src/ButtonGroup/ButtonGroupContext.ts
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroupContext.ts
@@ -2,6 +2,9 @@
 import * as React from 'react';
 import type { ButtonGroupProps } from './ButtonGroup';
 
+export type ButtonGroupItemHandle = { id: symbol };
+export type ButtonGroupItemPosition = 'first' | 'middle' | 'last' | 'only';
+
 interface ButtonGroupContextType {
   className?: string;
   color?: ButtonGroupProps['color'];
@@ -12,6 +15,15 @@ interface ButtonGroupContextType {
   fullWidth?: boolean;
   size?: ButtonGroupProps['size'];
   variant?: ButtonGroupProps['variant'];
+
+  // Child button calls this once when it mounts
+  register?: (node: HTMLElement | null) => ButtonGroupItemHandle;
+  // Child Button calls this when it unmounts. The group removes that item from its live set.
+  unregister?: (h: ButtonGroupItemHandle) => void;
+  // Child Button calls this to ask "given all currently mounted group items, where am I?" The group looks at its ordered list and answers.
+  getPosition?: (h: ButtonGroupItemHandle) => ButtonGroupItemPosition;
+  // Simple counter to bump when the context value changes, so that children can re-evaluate their position.
+  version?: number;
 }
 
 /**


### PR DESCRIPTION
Fixes #39488 

## Summary

Restore correct `first`, `middle` and `last` styles in `ButtonGroup` with custom, wrapped, or conditionally rendered `Button`s by using runtime registration via context (no JSX/DOM heuristics, no Emotion `:first/last-child` dependence).

## Changes

* `ButtonGroup`: add `register`, `unregister`, `getPosition` context; stop leaking internal props to DOM.
* `Button`: register actual root, apply position class from context, merge `classes.grouped`.

## Tests

* Position classes: single, multiple, wrapped, and hidden children.
* Button integration: grouped class merge, position class, no unknown-prop warnings.

## Others

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
