### PR TITLE
[internal] Polish renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>mui/mui-public//renovate/default"],
   "ignoreDeps": [],
+  "schedule": "on sunday before 6:00am",
+  "lockFileMaintenance": {
+    "schedule": "before 6:00am on the first day of the month"
+  },
   "packageRules": [
     {
       "groupName": "Pigment CSS",

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>mui/mui-public//renovate/default"],
-  "ignoreDeps": [],
-  "schedule": "on sunday before 6:00am",
+  // 0-5am on Sunday.
+  "schedule": "* 0-4 * * 7",
   "lockFileMaintenance": {
-    "schedule": "before 6:00am on the first day of the month"
+    // 0-5am on day-of-month 1.
+    "schedule": "* 0-4 1 * *"
   },
   "packageRules": [
     {
@@ -57,7 +58,8 @@
     {
       "groupName": "bundling fixtures",
       "matchPaths": ["test/bundling/fixtures/**/package.json"],
-      "schedule": "every 6 months on the first day of the month"
+      // day-of-month 1 in January and July
+      "schedule": "* * 1 1,7 *"
     },
     {
       "groupName": "examples",


### PR DESCRIPTION
Since #46483 we have the setting shared, but I think we are better of making the schedule specific to each repository

Looking at the history, we haven't been consistent enough to run this update: https://github.com/mui/material-ui/pulls?q=is%3Apr+%22Lock+file+maintenance%22+is%3Aclosed. Which seems to be why we have so many of those: https://github.com/mui/material-ui/security/dependabot.