### PR TITLE
[infra] Remove `fs-extra` from `netlify-plugin-cache-docs`

### DIFF
--- a/packages/netlify-plugin-cache-docs/index.js
+++ b/packages/netlify-plugin-cache-docs/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 const path = require('path');
-const fse = require('fs-extra');
+const fs = require('node:fs');
 
 const CACHE_OUTPUT_FILE = 'cache-output.json';
 
@@ -22,14 +22,14 @@ module.exports = {
     const { constants, utils } = context;
     const { nextjsCacheDir } = generateAbsolutePaths({ constants });
 
-    const cacheDirExists = fse.existsSync(nextjsCacheDir);
+    const cacheDirExists = fs.existsSync(nextjsCacheDir);
     console.log("'%s' exists: %s", nextjsCacheDir, String(cacheDirExists));
 
     const success = await utils.cache.restore(nextjsCacheDir);
 
     console.log("Restored the cached '%s' folder: %s", nextjsCacheDir, String(success));
 
-    const restoredCacheDir = fse.existsSync(nextjsCacheDir);
+    const restoredCacheDir = fs.existsSync(nextjsCacheDir);
     console.log("'%s' exists: %s", nextjsCacheDir, String(restoredCacheDir));
   },
   // On build, cache the `.next/cache` folder
@@ -39,7 +39,7 @@ module.exports = {
     const { constants, utils } = context;
     const { nextjsCacheDir } = generateAbsolutePaths({ constants });
 
-    const cacheExists = fse.existsSync(nextjsCacheDir);
+    const cacheExists = fs.existsSync(nextjsCacheDir);
 
     if (cacheExists) {
       console.log("'%s' exists: %s", nextjsCacheDir, String(cacheExists));
@@ -59,8 +59,8 @@ module.exports = {
     const cacheManifestPath = path.join(PUBLISH_DIR, cacheManifestFileName);
     console.log('Saving cache file manifest for debugging...');
     const files = await utils.cache.list();
-    await fse.mkdirp(PUBLISH_DIR);
-    await fse.writeJSON(cacheManifestPath, files, { spaces: 2 });
+    await fs.promises.mkdir(PUBLISH_DIR, { recursive: true });
+    await fs.promises.writeFile(cacheManifestPath, JSON.stringify(files, null, 2));
     console.log(`Cache file count: ${files.length}`);
     console.log(`Cache manifest saved to ${cacheManifestPath}`);
     console.log(`Please download the build files to inspect ${cacheManifestFileName}.`);


### PR DESCRIPTION
Part of https://github.com/mui/mui-public/issues/481.

Should allow removing `fs-extra` from MUI X's repo, which failed due to this dependency ([revert PR](https://github.com/mui/mui-x/pull/19176)).

The actual fix would be to move `fs-extra` to the dependencies of the monorepo, but if we can get rid of better it would be better. 

[The run was successful](https://app.netlify.com/projects/material-ui/deploys/689cab40a2599300080e1acc)