### PR TITLE
[infra] Remove `@mui/envinfo` dependency on `fs-extra`

### DIFF
--- a/packages/mui-envinfo/package.json
+++ b/packages/mui-envinfo/package.json
@@ -25,8 +25,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.20",
-    "chai": "^4.5.0",
-    "fs-extra": "^11.3.1"
+    "chai": "^4.5.0"
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1331,9 +1331,6 @@ importers:
       chai:
         specifier: ^4.5.0
         version: 4.5.0
-      fs-extra:
-        specifier: ^11.3.1
-        version: 11.3.1
     publishDirectory: build
 
   packages/mui-envinfo/test:


### PR DESCRIPTION
Part of https://github.com/mui/mui-public/issues/481.

Remove `@mui/envinfo` dependency on `fs-extra`.

Tested with `npx https://pkg.pr.new/mui/material-ui/@mui/envinfo@08a7479`