### PR TITLE
[infra] Remove `api-docs-builder` dependency on `fs-extra`

### DIFF
--- a/packages/api-docs-builder/buildApi.ts
+++ b/packages/api-docs-builder/buildApi.ts
@@ -61,7 +61,7 @@ async function removeOutdatedApiDocsTranslations(
 
   await Promise.all(
     Array.from(outdatedComponentDirectories, (outdatedComponentDirectory) =>
-      fs.rm(outdatedComponentDirectory, { recursive: true }),
+      fs.rm(outdatedComponentDirectory, { recursive: true, force: true }),
     ),
   );
 }

--- a/packages/api-docs-builder/package.json
+++ b/packages/api-docs-builder/package.json
@@ -16,7 +16,6 @@
     "ast-types": "^0.14.2",
     "doctrine": "^3.0.0",
     "fast-glob": "^3.3.3",
-    "fs-extra": "^11.3.1",
     "lodash": "^4.17.21",
     "prettier": "^3.6.2",
     "react-docgen": "^5.4.3",

--- a/packages/api-docs-builder/utils/findApiPages.ts
+++ b/packages/api-docs-builder/utils/findApiPages.ts
@@ -1,11 +1,11 @@
 import path from 'path';
-import * as fse from 'fs-extra';
+import * as fs from 'node:fs';
 
 const getAllFiles = (dirPath: string, arrayOfFiles: string[] = []) => {
-  const files = fse.readdirSync(dirPath);
+  const files = fs.readdirSync(dirPath);
 
   files.forEach((file) => {
-    if (fse.statSync(`${dirPath}/${file}`).isDirectory()) {
+    if (fs.statSync(`${dirPath}/${file}`).isDirectory()) {
       arrayOfFiles = getAllFiles(`${dirPath}/${file}`, arrayOfFiles);
     } else {
       arrayOfFiles.push(path.join(__dirname, dirPath, '/', file));

--- a/packages/api-docs-builder/utils/parseTest.ts
+++ b/packages/api-docs-builder/utils/parseTest.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as babel from '@babel/core';
-import { readFile } from 'fs-extra';
+import * as fs from 'node:fs/promises';
 import glob from 'fast-glob';
 
 function getTestFilesNames(filepath: string) {
@@ -16,7 +16,7 @@ function getTestFilesNames(filepath: string) {
 }
 
 async function parseWithConfig(filename: string) {
-  const source = await readFile(filename, { encoding: 'utf8' });
+  const source = await fs.readFile(filename, { encoding: 'utf8' });
   const partialConfig = babel.loadPartialConfig({
     filename,
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1084,9 +1084,6 @@ importers:
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
-      fs-extra:
-        specifier: ^11.3.1
-        version: 11.3.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21


### PR DESCRIPTION
Part of https://github.com/mui/mui-public/issues/481.

Remove `api-docs-builder` dependency on `fs-extra`.