### PR TITLE
[code-infra] Remove `@mui/internal-babel-plugin-resolve-imports` override config

### DIFF
--- a/babel.config.mjs
+++ b/babel.config.mjs
@@ -83,10 +83,6 @@ export default function getBabelConfig(api) {
         exclude: /\.test\.(m?js|ts|tsx)$/,
         plugins: ['@babel/plugin-transform-react-constant-elements'],
       },
-      {
-        test: /(\.test\.[^.]+$|\.test\/)/,
-        plugins: [['@mui/internal-babel-plugin-resolve-imports', false]],
-      },
     ],
     env: {
       coverage: {


### PR DESCRIPTION
Test scripts are failing in Windows OS. Suggested solution is based on discussion in Slack.