### PR TITLE
[docs][autocomplete] Fix header sentence case

### DIFF
--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -229,7 +229,7 @@ This demo has limited quotas to make API requests. When your quota exceeds, you 
 
 By default (when `multiple={false}`), the selected option is displayed as plain text inside the input.
 The `renderValue` prop allows you to customize how the selected value is rendered.
-This can be useful for adding custom styles, displaying additional information, or formatting the value differently:
+This can be useful for adding custom styles, displaying additional information, or formatting the value differently.
 
 - The `getItemProps` getter provides props like `data-item-index`, `disabled`, `tabIndex` and others. These props should be spread onto the rendered component for proper accessibility.
 - If using a custom component other than a Material UI Chip, destructure the `onDelete` prop as it's specific to the Material UI Chip.

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -225,11 +225,13 @@ Before you can start using the Google Maps JavaScript API and Places API, you ne
 This demo has limited quotas to make API requests. When your quota exceeds, you will see the response for "Paris".
 :::
 
-## Custom Single Value Rendering
+## Single value rendering
 
-By default, when `multiple={false}`, the selected option is displayed as plain text inside the input. The `renderValue` prop allows you to customize how the selected value is rendered. This can be useful for adding custom styles, displaying additional information, or formatting the value differently.
+By default (when `multiple={false}`), the selected option is displayed as plain text inside the input.
+The `renderValue` prop allows you to customize how the selected value is rendered.
+This can be useful for adding custom styles, displaying additional information, or formatting the value differently:
 
-- The `getItemProps` callback provides props like `data-item-index`, `disabled`, `tabIndex` and others. These props should be spread onto the rendered component for proper accessibility.
+- The `getItemProps` getter provides props like `data-item-index`, `disabled`, `tabIndex` and others. These props should be spread onto the rendered component for proper accessibility.
 - If using a custom component other than a Material UI Chip, destructure the `onDelete` prop as it's specific to the Material UI Chip.
 
 {{"demo": "CustomSingleValueRendering.js"}}
@@ -238,7 +240,7 @@ By default, when `multiple={false}`, the selected option is displayed as plain t
 
 When `multiple={true}`, the user can select multiple values. These selected values, referred to as "items" can be customized using the `renderValue` prop.
 
-- The `getItemProps` callback supplies essential props like `data-item-index`, `disabled`, `tabIndex` and others. Make sure to spread them on each rendered item.
+- The `getItemProps` getter supplies essential props like `data-item-index`, `disabled`, `tabIndex` and others. Make sure to spread them on each rendered item.
 - If using a custom component other than a Material UI Chip, destructure the `onDelete` prop as it's specific to the Material UI Chip.
 
 {{"demo": "Tags.js"}}
@@ -279,7 +281,7 @@ If you're using a custom input component inside the Autocomplete, make sure that
 
 {{"demo": "CustomInputAutocomplete.js"}}
 
-### Globally Customized Options
+### Globally customized options
 
 To globally customize the Autocomplete options for all components in your app,
 you can use the [theme default props](/material-ui/customization/theme-components/#theme-default-props) and set the `renderOption` property in the `defaultProps` key.


### PR DESCRIPTION
I noticed this in #46804. Those docs are not sticking to https://www.notion.so/mui-org/Writing-style-guide-2a957a4168a54d47b14bae026d06a24b.

Preview: https://deploy-preview-46805--material-ui.netlify.app/material-ui/react-autocomplete/.