### PR TITLE
[docs] Update popper.md Click-Away Listener URL

### DIFF
--- a/docs/data/material/components/popper/popper.md
+++ b/docs/data/material/components/popper/popper.md
@@ -19,7 +19,7 @@ Some important features of the Popper component:
 - The scroll isn't blocked like with the [Popover](/material-ui/react-popover/) component.
   The placement of the popper updates with the available area in the viewport.
 - Clicking away does not hide the Popper component.
-  If you need this behavior, you can use the [MUI Base Click-Away Listener](https://v6.mui.com/base-ui/react-click-away-listener/) - see the example in the [menu documentation section](/material-ui/react-menu/#composition-with-menu-list).
+  If you need this behavior, you can use the [MUI Click-Away Listener](https://mui.com/material-ui/react-click-away-listener/) - see the example in the [menu documentation section](/material-ui/react-menu/#composition-with-menu-list).
 - The `anchorEl` is passed as the reference object to create a new `Popper.js` instance.
 
 {{"component": "@mui/docs/ComponentLinkHeader", "design": false}}


### PR DESCRIPTION
The URL on the Popper component documentation leading to the MUI Click-Away listener seems to be outdated: it opens a page that states that the @mui/base is deprecated. It seems that there's a newer and updated page for the Click-Away Listener. This commit changes the URL to lead to that newer page

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
