### PR TITLE
[code-infra] Update ci.yml triggers

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -6,14 +6,14 @@ name: CI Check
 on:
   push:
     branches-ignore:
-      # Renovate branches are always Pull Requests.
-      # We don't need to run CI twice (push+pull_request)
-      - 'renovate/**'
-      - 'dependabot/**'
+      # should sync with ci.yml as a workaround to bypass github checks
+      - master
+      - next
+      - v*.x
   pull_request:
     paths:
+      # should sync with ci.yml as a workaround to bypass github checks
       - 'docs/**'
-      - 'examples/**'
 
 permissions: {}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,15 @@ name: CI
 
 on:
   push:
-    branches-ignore:
-      # Renovate branches are always Pull Requests.
-      # We don't need to run CI twice (push+pull_request)
-      - 'renovate/**'
-      - 'dependabot/**'
+    branches:
+      # should sync with ci-check.yml as a workaround to bypass github checks
+      - master
+      - next
+      - v*.x
   pull_request:
     paths-ignore:
       # should sync with ci-check.yml as a workaround to bypass github checks
-      - 'examples/**'
+      - 'docs/**'
 
 permissions: {}
 


### PR DESCRIPTION
Following up after https://github.com/mui/mui-public/pull/632

I believe we could optimize here:

* positive checks for `push` instead of negative, only on release branches, would we need any other?
* sync `paths` and `paths-ignore` and `branches` and `branches-ignore` between ci.yml and ci-check.yml. If I understand the linked documentation correctly, the goal is for the `test-dev` job in those workflow files to be fully mutually exclusive. (@oliviertassinari would love a review on this to confirm)
* remove examples from the ignored paths as we are using those as templates in pkg.pr.new