### PR TITLE
Fix/tabs not scrolling to correct tab issue

### DIFF
--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./export/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./export/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/mui-material/src/Tabs/Tabs.js
+++ b/packages/mui-material/src/Tabs/Tabs.js
@@ -634,7 +634,8 @@ const Tabs = React.forwardRef(function Tabs(inProps, ref) {
       scroll(nextScrollStart, { animation });
     } else if (tabMeta[end] > tabsMeta[end]) {
       // right side of button is out of view
-      const nextScrollStart = tabsMeta[scrollStart] + (tabMeta[end] - tabsMeta[end]);
+      const nextScrollStart =
+        tabsMeta[scrollStart] + (tabMeta[end] - tabsMeta[end]) + tabMeta[size];
       scroll(nextScrollStart, { animation });
     }
   });


### PR DESCRIPTION
- [ X ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

closes #44211 

Root cause - 
When the scroll happened the calculation for the position was not accounting for the width/height of the tab

The fix includes ltr, since rtl has lot of issues that needs to fixed alongside the current fix

Please do share any feedback 
Thanks!