### PR TITLE
added enhancement editing experience on autocomplete with multiple

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -186,6 +186,7 @@ export const InputBaseInput = styled('input', {
       // Make the flex item shrink with Firefox
       minWidth: 0,
       width: '100%',
+      flexBasis: 'content',
       '&::-webkit-input-placeholder': placeholder,
       '&::-moz-placeholder': placeholder, // Firefox 19+
       '&::-ms-input-placeholder': placeholder, // Edge

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -186,7 +186,6 @@ export const InputBaseInput = styled('input', {
       // Make the flex item shrink with Firefox
       minWidth: 0,
       width: '100%',
-      flexBasis: 'content',
       '&::-webkit-input-placeholder': placeholder,
       '&::-moz-placeholder': placeholder, // Firefox 19+
       '&::-ms-input-placeholder': placeholder, // Edge
@@ -249,6 +248,12 @@ export const InputBaseInput = styled('input', {
           },
           style: {
             MozAppearance: 'textfield', // Improve type search style.
+          },
+        },
+        {
+          props: ({ ownerState }) => ownerState.startAdornment,
+          style: {
+            flexBasis: 'content',
           },
         },
       ],


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

closes #43197 

**Solution** - flex-basis can wrap the text-field as input component width basis, covers the issue enchancement request

## **Updated version** - 
![Screen Recording 2025-09-08 at 12 08 21 PM](https://github.com/user-attachments/assets/496f321b-a1e1-4b7d-af4c-5de4d0ec9502)




## **Older version** - 
![Screen Recording 2025-09-08 at 12 16 13 PM](https://github.com/user-attachments/assets/b77a09e8-3753-43e9-8294-8e8e9fc364c3)
