### PR TITLE
[code-infra] Disable browserstack on circleci cron jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,13 @@ default-job: &default-job
       description: The base url for running end-to-end test
       type: string
       default: << pipeline.parameters.e2e-base-url >>
+    browserstack-enabled:
+      type: boolean
+      default: false
   environment:
     # expose it globally otherwise we have to thread it from each job to the install command
     BROWSERSTACK_FORCE: << pipeline.parameters.browserstack-force >>
+    BROWSERSTACK_ENABLED: << parameters.browserstack-enabled >>
     REACT_VERSION: << parameters.react-version >>
     TYPESCRIPT_VERSION: << parameters.typescript-version >>
     TEST_GATE: << parameters.test-gate >>
@@ -265,10 +269,6 @@ jobs:
   test_browser:
     <<: *default-job
     resource_class: 'medium+'
-    parameters:
-      browserstack-enabled:
-        type: boolean
-        default: false
     docker:
       - image: mcr.microsoft.com/playwright:v1.55.0-noble
     steps:
@@ -278,8 +278,6 @@ jobs:
       - run:
           name: Tests real browsers
           command: pnpm test:karma
-          environment:
-            BROWSERSTACK_ENABLED: << parameters.browserstack-enabled >>
       - run:
           name: Check coverage generated
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -616,6 +616,8 @@ workflows:
           <<: *default-context
       - test_browser:
           <<: *default-context
+          # only enable on pipeline, the karma.conf.js has logic to disable browserstack on PRs
+          browserstack-force: true
       - test_regressions:
           <<: *default-context
       - test_e2e:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,10 @@ jobs:
   test_browser:
     <<: *default-job
     resource_class: 'medium+'
+    parameters:
+      browserstack-enabled:
+        type: boolean
+        default: false
     docker:
       - image: mcr.microsoft.com/playwright:v1.55.0-noble
     steps:
@@ -274,6 +278,8 @@ jobs:
       - run:
           name: Tests real browsers
           command: pnpm test:karma
+          environment:
+            BROWSERSTACK_ENABLED: << parameters.browserstack-enabled >>
       - run:
           name: Check coverage generated
           command: |
@@ -617,7 +623,7 @@ workflows:
       - test_browser:
           <<: *default-context
           # only enable on pipeline, the karma.conf.js has logic to disable browserstack on PRs
-          browserstack-force: true
+          browserstack-enabled: true
       - test_regressions:
           <<: *default-context
       - test_e2e:

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -20,8 +20,8 @@ const browserStack = {
   // However, BrowserStack rarely fails with a true-positive so we use it as a stop gap for release not merge.
   // But always enable it locally since people usually have to explicitly have to expose their BrowserStack access key anyway.
   enabled:
-    process.env.BROWSERSTACK_FORCE === 'true' ||
-    (process.env.CI && process.env.CIRCLE_BRANCH.match(/^(master|next|v.+\.x)$/)),
+    process.env.BROWSERSTACK_FORCE === 'true' &&
+    (process.env.CI ? process.env.CIRCLE_BRANCH.match(/^(master|next|v\d+\.x)$/) : true),
   username: process.env.BROWSERSTACK_USERNAME,
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -3,9 +3,6 @@ const playwright = require('@playwright/test');
 const webpack = require('webpack');
 
 const CI = Boolean(process.env.CI);
-// renovate PRs are based off of  upstream branches.
-// Their CI run will be a branch based run not PR run and therefore won't have a CIRCLE_PR_NUMBER
-const isPR = Boolean(process.env.CIRCLE_PULL_REQUEST);
 
 let build = `material-ui local ${new Date().toISOString()}`;
 
@@ -22,7 +19,9 @@ const browserStack = {
   // Since we have limited resources on BrowserStack we often time out on PRs.
   // However, BrowserStack rarely fails with a true-positive so we use it as a stop gap for release not merge.
   // But always enable it locally since people usually have to explicitly have to expose their BrowserStack access key anyway.
-  enabled: !CI || !isPR || process.env.BROWSERSTACK_FORCE === 'true',
+  enabled:
+    process.env.BROWSERSTACK_FORCE === 'true' ||
+    (process.env.CI && process.env.CIRCLE_BRANCH.match(/^(master|next|v.+\.x)$/)),
   username: process.env.BROWSERSTACK_USERNAME,
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -13,16 +13,6 @@ if (process.env.CIRCLECI) {
       : process.env.CIRCLE_BRANCH;
   build = `${buildPrefix}: ${process.env.CIRCLE_BUILD_URL}`;
 }
-// eslint-disable-next-line no-console
-console.log(
-  !process.CI,
-  process.env.BROWSERSTACK_FORCE,
-  process.env.BROWSERSTACK_FORCE === 'true',
-  process.env.BROWSERSTACK_ENABLED,
-  process.env.BROWSERSTACK_ENABLED === 'true',
-  process.env.CIRCLE_BRANCH,
-  process.env.CIRCLE_BRANCH.match(/^(master|next|v\d+\.x)$/),
-);
 
 const browserStack = {
   // |commits in PRs| >> |Merged commits|.
@@ -30,7 +20,7 @@ const browserStack = {
   // However, BrowserStack rarely fails with a true-positive so we use it as a stop gap for release not merge.
   // But always enable it locally since people usually have to explicitly have to expose their BrowserStack access key anyway.
   enabled:
-    !process.CI ||
+    !process.env.CI ||
     process.env.BROWSERSTACK_FORCE === 'true' ||
     (process.env.BROWSERSTACK_ENABLED === 'true' &&
       process.env.CIRCLE_BRANCH.match(/^(master|next|v\d+\.x)$/)),

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -13,6 +13,16 @@ if (process.env.CIRCLECI) {
       : process.env.CIRCLE_BRANCH;
   build = `${buildPrefix}: ${process.env.CIRCLE_BUILD_URL}`;
 }
+// eslint-disable-next-line no-console
+console.log(
+  !process.CI,
+  process.env.BROWSERSTACK_FORCE,
+  process.env.BROWSERSTACK_FORCE === 'true',
+  process.env.BROWSERSTACK_ENABLED,
+  process.env.BROWSERSTACK_ENABLED === 'true',
+  process.env.CIRCLE_BRANCH,
+  process.env.CIRCLE_BRANCH.match(/^(master|next|v\d+\.x)$/),
+);
 
 const browserStack = {
   // |commits in PRs| >> |Merged commits|.

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -20,8 +20,10 @@ const browserStack = {
   // However, BrowserStack rarely fails with a true-positive so we use it as a stop gap for release not merge.
   // But always enable it locally since people usually have to explicitly have to expose their BrowserStack access key anyway.
   enabled:
-    process.env.BROWSERSTACK_FORCE === 'true' &&
-    (process.env.CI ? process.env.CIRCLE_BRANCH.match(/^(master|next|v\d+\.x)$/) : true),
+    !process.CI ||
+    process.env.BROWSERSTACK_FORCE === 'true' ||
+    (process.env.BROWSERSTACK_ENABLED === 'true' &&
+      process.env.CIRCLE_BRANCH.match(/^(master|next|v\d+\.x)$/)),
   username: process.env.BROWSERSTACK_USERNAME,
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,


### PR DESCRIPTION
Untangling all the flakeyness in circleci. This PR disables browserstack for anyting except for the main pipeline on production branches. We don't need it on the daily react 18/next jobs.

From circleci

* **react-18-cron**

    <img width="1185" height="403" alt="Screenshot 2025-09-10 at 15 46 47" src="https://github.com/user-attachments/assets/39398f66-792d-4fc5-ba8f-c82a1ac4af1b" />

    This got mostly fixed on my last effort a month ogo
    Flakeynes caused by too many concurrent browserstack sessions. this PR disables browserstack for react 18 cron job

* **react-next-cron**

    <img width="1178" height="415" alt="Screenshot 2025-09-10 at 15 47 12" src="https://github.com/user-attachments/assets/6bab9dad-fc6c-4a52-a4dd-06e30c0a0b9a" />
    
    This got mostly fixed on my last effort a month ogo
    Flakeynes caused by too many concurrent browserstack sessions. this PR disables browserstack for react next cron job

* **typescript-next**

    <img width="1184" height="401" alt="Screenshot 2025-09-10 at 15 47 40" src="https://github.com/user-attachments/assets/fd959f4c-c2ce-4a56-a9f9-009eaed765a7" />

    This is being run daily for the v6 branch for some reason. To be disabled in follow-up:

    <img width="1242" height="160" alt="Screenshot 2025-09-10 at 15 58 36" src="https://github.com/user-attachments/assets/c81f29d5-eea4-44ea-b440-d03d837d046a" />

* **typescript-next-cron**
    
    <img width="1189" height="411" alt="Screenshot 2025-09-10 at 15 48 07" src="https://github.com/user-attachments/assets/d2ea9004-ea7f-4ba4-87a1-4f3e1ce4da9b" />
    
    Caused by:
    
    ```
    tsconfig.json(3,3): error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
    ```
    
    Will fix in follow-up