### PR TITLE
[code-infra] Disable cache on renovate PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22.18.0'
-          cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
+          cache: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && 'pnpm' || '' }}
       - run: pnpm install
       - run: pnpm build:ci
         env:


### PR DESCRIPTION
Recently got pinged by github that we're exceeding their free cache storage. We could try to disable cache for PRs that likely will bust the cache for each commit.