### PR TITLE
[useScrollTrigger] refactor: improve scroll event handling with requestAnimationFrame throttling

### DIFF
--- a/packages/mui-material/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/mui-material/src/useScrollTrigger/useScrollTrigger.test.js
@@ -96,8 +96,8 @@ describe('useScrollTrigger', () => {
       customContainer: PropTypes.bool,
     };
 
-    function dispatchScroll(offset, element = window) {
-      act(() => {
+    async function dispatchScroll(offset, element = window) {
+      await act(async () => {
         element.pageYOffset = offset;
         element.dispatchEvent(new window.Event('scroll', {}));
       });

--- a/packages/mui-material/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/mui-material/src/useScrollTrigger/useScrollTrigger.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
@@ -72,7 +73,7 @@ describe('useScrollTrigger', () => {
   describeSkipIf(!window.navigator.userAgent.includes('jsdom'))('scroll', () => {
     const triggerRef = React.createRef();
     const containerRef = React.createRef(); // Get the scroll container's parent
-    const getContainer = () => containerRef.current.children[0]; // Get the scroll container
+    const getContainer = () => containerRef.current?.children[0]; // Get the scroll container
     const getTriggerValue = () => triggerRef.current.textContent; // Retrieve the trigger value
 
     function Test(props) {
@@ -108,23 +109,25 @@ describe('useScrollTrigger', () => {
       expect(container.textContent).to.include('Custom container');
     });
 
-    it('should not trigger from window scroll events with ref', () => {
+    it('should not trigger from window scroll events with ref', async () => {
       render(<Test customContainer />);
-      [101, 200, 300, -10, 100, 101, 99, 200, 199, 0, 1, -1, 150].forEach((offset, i) => {
-        dispatchScroll(offset);
+      for (const [i, offset] of [
+        101, 200, 300, -10, 100, 101, 99, 200, 199, 0, 1, -1, 150,
+      ].entries()) {
+        await dispatchScroll(offset);
         expect(getTriggerValue()).to.equal('false', `Index: ${i} Offset: ${offset}`);
-      });
+      }
     });
 
-    it('should trigger above default threshold with ref', () => {
+    it('should trigger above default threshold with ref', async () => {
       render(<Test customContainer />);
-      dispatchScroll(300, getContainer());
+      await dispatchScroll(300, getContainer());
       expect(getTriggerValue()).to.equal('true');
     });
 
-    it('should have correct hysteresis triggering threshold with ref', () => {
+    it('should have correct hysteresis triggering threshold with ref', async () => {
       render(<Test customContainer />);
-      [
+      const tests = [
         { offset: 100, result: 'false' },
         { offset: 101, result: 'true' },
         { offset: 100, result: 'false' },
@@ -142,15 +145,16 @@ describe('useScrollTrigger', () => {
         { offset: 3, result: 'false' },
         { offset: 103, result: 'true' },
         { offset: 102, result: 'false' },
-      ].forEach((test, index) => {
-        dispatchScroll(test.offset, getContainer());
+      ];
+      for (const [index, test] of tests.entries()) {
+        await dispatchScroll(test.offset, getContainer());
         expect(getTriggerValue()).to.equal(test.result, `Index: ${index} ${JSON.stringify(test)}`);
-      });
+      }
     });
 
-    it('should have correct hysteresis triggering with default threshold with ref', () => {
+    it('should have correct hysteresis triggering with default threshold with ref', async () => {
       render(<Test customContainer disableHysteresis />);
-      [
+      const tests = [
         { offset: 100, result: 'false' },
         { offset: 101, result: 'true' },
         { offset: 200, result: 'true' },
@@ -167,15 +171,16 @@ describe('useScrollTrigger', () => {
         { offset: -3, result: 'false' },
         { offset: 3, result: 'false' },
         { offset: 103, result: 'true' },
-      ].forEach((test, index) => {
-        dispatchScroll(test.offset, getContainer());
+      ];
+      for (const [index, test] of tests.entries()) {
+        await dispatchScroll(test.offset, getContainer());
         expect(getTriggerValue()).to.equal(test.result, `Index: ${index} ${JSON.stringify(test)}`);
-      });
+      }
     });
 
-    it('should have correct hysteresis triggering with custom threshold with ref', () => {
+    it('should have correct hysteresis triggering with custom threshold with ref', async () => {
       render(<Test customContainer disableHysteresis threshold={50} />);
-      [
+      const tests = [
         { offset: 100, result: 'true' },
         { offset: 101, result: 'true' },
         { offset: 101, result: 'true' },
@@ -190,15 +195,16 @@ describe('useScrollTrigger', () => {
         { offset: -50, result: 'false' },
         { offset: 50, result: 'false' },
         { offset: 51, result: 'true' },
-      ].forEach((test, index) => {
-        dispatchScroll(test.offset, getContainer());
+      ];
+      for (const [index, test] of tests.entries()) {
+        await dispatchScroll(test.offset, getContainer());
         expect(getTriggerValue()).to.equal(test.result, `Index: ${index} ${JSON.stringify(test)}`);
-      });
+      }
     });
 
-    it('should not trigger at exact threshold value with ref', () => {
+    it('should not trigger at exact threshold value with ref', async () => {
       render(<Test customContainer threshold={100} />);
-      [
+      const tests = [
         { offset: 100, result: 'false' },
         { offset: 99, result: 'false' },
         { offset: 100, result: 'false' },
@@ -206,30 +212,32 @@ describe('useScrollTrigger', () => {
         { offset: 100, result: 'false' },
         { offset: 99, result: 'false' },
         { offset: 100, result: 'false' },
-      ].forEach((test, index) => {
-        dispatchScroll(test.offset, getContainer());
+      ];
+      for (const [index, test] of tests.entries()) {
+        await dispatchScroll(test.offset, getContainer());
         expect(getTriggerValue()).to.equal(test.result, `Index: ${index} ${JSON.stringify(test)}`);
-      });
+      }
     });
 
-    it('should not trigger at exact threshold value with hysteresis disabled with ref', () => {
+    it('should not trigger at exact threshold value with hysteresis disabled with ref', async () => {
       render(<Test customContainer disableHysteresis threshold={100} />);
-      [
+      const tests = [
         { offset: 100, result: 'false' },
         { offset: 99, result: 'false' },
         { offset: 100, result: 'false' },
         { offset: 101, result: 'true' },
         { offset: 100, result: 'false' },
         { offset: 99, result: 'false' },
-      ].forEach((test, index) => {
-        dispatchScroll(test.offset, getContainer());
+      ];
+      for (const [index, test] of tests.entries()) {
+        await dispatchScroll(test.offset, getContainer());
         expect(getTriggerValue()).to.equal(test.result, `Index: ${index} ${JSON.stringify(test)}`);
-      });
+      }
     });
 
-    it('should correctly evaluate sequential scroll events with identical scrollY offsets with ref', () => {
+    it('should correctly evaluate sequential scroll events with identical scrollY offsets with ref', async () => {
       render(<Test customContainer threshold={199} />);
-      [
+      const tests = [
         { offset: 200, result: 'true' },
         { offset: 200, result: 'true' },
         { offset: 200, result: 'true' },
@@ -238,15 +246,16 @@ describe('useScrollTrigger', () => {
         { offset: 199, result: 'false' },
         { offset: 200, result: 'true' },
         { offset: 200, result: 'true' },
-      ].forEach((test, index) => {
-        dispatchScroll(test.offset, getContainer());
+      ];
+      for (const [index, test] of tests.entries()) {
+        await dispatchScroll(test.offset, getContainer());
         expect(getTriggerValue()).to.equal(test.result, `Index: ${index} ${JSON.stringify(test)}`);
-      });
+      }
     });
 
-    it('should correctly evaluate sequential scroll events with identical scrollY offsets and hysteresis disabled with ref', () => {
+    it('should correctly evaluate sequential scroll events with identical scrollY offsets and hysteresis disabled with ref', async () => {
       render(<Test customContainer disableHysteresis threshold={199} />);
-      [
+      const tests = [
         { offset: 200, result: 'true' },
         { offset: 200, result: 'true' },
         { offset: 200, result: 'true' },
@@ -255,21 +264,23 @@ describe('useScrollTrigger', () => {
         { offset: 199, result: 'false' },
         { offset: 200, result: 'true' },
         { offset: 200, result: 'true' },
-      ].forEach((test, index) => {
-        dispatchScroll(test.offset, getContainer());
+      ];
+      for (const [index, test] of tests.entries()) {
+        await dispatchScroll(test.offset, getContainer());
         expect(getTriggerValue()).to.equal(test.result, `Index: ${index} ${JSON.stringify(test)}`);
-      });
+      }
     });
 
-    it('should correctly evaluate scroll events on page first load', () => {
-      [
+    it('should correctly evaluate scroll events on page first load', async () => {
+      const tests = [
         { offset: 101, result: 'true' },
         { offset: 100, result: 'false' },
-      ].forEach((test, index) => {
+      ];
+      for (const [index, test] of tests.entries()) {
         window.pageYOffset = test.offset;
         render(<Test threshold={100} />);
         expect(getTriggerValue()).to.equal(test.result, `Index: ${index} ${JSON.stringify(test)}`);
-      });
+      }
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR enhances the `useScrollTrigger` hook by introducing `requestAnimationFrame` throttling to the scroll event listener.

### Improvements and Benefits:

- Introduces a `ticking` flag combined with `requestAnimationFrame` to throttle scroll event handling, reducing the number of state updates and re-renders on rapid scroll events.
- Prevents potential performance bottlenecks caused by frequent and expensive update calls during fast scrolling.
- Cleans up any scheduled animation frame callbacks on unmount to avoid memory leaks.
- The initial trigger evaluation remains immediate on mount and dependency changes, maintaining correct state without unnecessary delay.
- Improves smoothness and responsiveness especially on devices or browsers where scroll events fire frequently.

These changes help optimize performance without changing the hook’s external behavior or API.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
