### PR TITLE
[docs] Clarify MUI Base != Base UI (1/2)

### DIFF
--- a/docs/data/base/components/autocomplete/autocomplete.md
+++ b/docs/data/base/components/autocomplete/autocomplete.md
@@ -4,6 +4,8 @@ title: React Autocomplete hook
 hooks: useAutocomplete
 githubLabel: 'component: autocomplete'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
+newName: Combobox
+newUrl: https://base-ui.com/react/components/autocomplete
 ---
 
 # Autocomplete

--- a/docs/data/base/components/snackbar/snackbar.md
+++ b/docs/data/base/components/snackbar/snackbar.md
@@ -4,6 +4,8 @@ title: React Snackbar component and hook
 components: Snackbar
 hooks: useSnackbar
 githubLabel: 'component: snackbar'
+newName: Toast
+newUrl: https://base-ui.com/react/components/toast
 ---
 
 # Snackbar

--- a/docs/src/components/productBaseUI/MuiBaseDeprecation.tsx
+++ b/docs/src/components/productBaseUI/MuiBaseDeprecation.tsx
@@ -2,18 +2,15 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import { MarkdownElement } from '@mui/docs/MarkdownElement';
 
-export default function MuiBaseDeprecation(props: {
-  newComponentName?: string;
-  newComponentUrl?: string;
-}) {
-  if (props.newComponentUrl && props.newComponentName) {
+export default function MuiBaseDeprecation(props: { newName?: string; newUrl?: string }) {
+  if (props.newUrl && props.newName) {
     return (
       <MarkdownElement>
         <Box component="aside" className="MuiCallout-root MuiCallout-error">
           <Icon />
           <Box className="MuiCallout-content">
-            @mui/base has been deprecated and has been replaced by Base UI. We strongly recommend
-            using the Base UI <a href={props.newComponentUrl}>{props.newComponentName} component</a>{' '}
+            MUI Base (@mui/base) has been deprecated. Base UI is its successor. We strongly
+            recommend using the new <a href={props.newUrl}>Base UI {props.newName} component</a>{' '}
             instead.
           </Box>
         </Box>
@@ -25,9 +22,8 @@ export default function MuiBaseDeprecation(props: {
       <Box component="aside" className="MuiCallout-root MuiCallout-error">
         <Icon />
         <Box className="MuiCallout-content">
-          @mui/base has been deprecated and has been replaced by{' '}
-          <a href="https://base-ui.com">Base UI</a>. We strongly recommend using the new package
-          instead.
+          MUI Base (@mui/base) has been deprecated. <a href="https://base-ui.com">Base UI</a> is its
+          successor. We strongly recommend using the new package instead.
         </Box>
       </Box>
     </MarkdownElement>

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -78,8 +78,8 @@ export default function MarkdownDocs(props) {
         {isJoy && <JoyModeObserver mode={theme.palette.mode} />}
         {isBase && (
           <MuiBaseDeprecation
-            newComponentUrl={localizedDoc.headers.newUrl}
-            newComponentName={localizedDoc.headers.newName}
+            newUrl={localizedDoc.headers.newUrl}
+            newName={localizedDoc.headers.newName}
           />
         )}
         {localizedDoc.rendered.map((renderedMarkdownOrDemo, index) => (

--- a/docs/src/modules/components/MarkdownDocsV2.js
+++ b/docs/src/modules/components/MarkdownDocsV2.js
@@ -276,8 +276,8 @@ export default function MarkdownDocsV2(props) {
           {isJoy && <JoyModeObserver mode={theme.palette.mode} />}
           {isBase && (
             <MuiBaseDeprecation
-              newComponentUrl={localizedDoc.headers.newUrl}
-              newComponentName={localizedDoc.headers.newName}
+              newUrl={localizedDoc.headers.newUrl}
+              newName={localizedDoc.headers.newName}
             />
           )}
           {commonElements}

--- a/examples/base-ui-cra-ts/README.md
+++ b/examples/base-ui-cra-ts/README.md
@@ -1,6 +1,6 @@
 # MUI Base - Create React App example in TypeScript
 
-[MUI Base](https://mui.com/base-ui/) is a library of unstyled React UI components and hooks.
+[MUI Base](https://v6.mui.com/base-ui/getting-started/) is a library of unstyled React UI components and hooks.
 
 [Create React App](https://create-react-app.dev/) is a framework for quickly creating a new React project without the need to configure complex build tools or development environments.
 

--- a/examples/base-ui-cra-ts/src/App.tsx
+++ b/examples/base-ui-cra-ts/src/App.tsx
@@ -6,7 +6,7 @@ export default function App() {
     <div className="box">
       <h1>Base UI + Create React App scaffold (TypeScript)</h1>
       <div className="item">
-        <a href="https://mui.com/base-ui/">Base UI</a> is a library of unstyled React UI components
+        <a href="https://v6.mui.com/base-ui/getting-started/">MUI Base</a> is a library of unstyled React UI components
         which includes prebuilt components with production-ready functionality, along with low-level
         hooks for transferring that functionality to other components.
       </div>

--- a/examples/base-ui-cra/README.md
+++ b/examples/base-ui-cra/README.md
@@ -1,6 +1,6 @@
 # MUI Base - Create React App example in JavaScript
 
-[MUI Base](https://mui.com/base-ui/) is a library of unstyled React UI components and hooks.
+[MUI Base](https://v6.mui.com/base-ui/getting-started/) is a library of unstyled React UI components and hooks.
 
 [Create React App](https://create-react-app.dev/) is a framework for quickly creating a new React project without the need to configure complex build tools or development environments.
 

--- a/examples/base-ui-cra/src/App.js
+++ b/examples/base-ui-cra/src/App.js
@@ -6,7 +6,7 @@ export default function App() {
     <div className="box">
       <h1>Base UI + Create React App scaffold (JavaScript)</h1>
       <div className="item">
-        <a href="https://mui.com/base-ui/">Base UI</a> is a library of unstyled React UI components
+        <a href="https://v6.mui.com/base-ui/getting-started/">MUI Base</a> is a library of unstyled React UI components
         and hooks.
       </div>
       <div className="item">

--- a/examples/base-ui-vite-tailwind-ts/README.md
+++ b/examples/base-ui-vite-tailwind-ts/README.md
@@ -1,6 +1,6 @@
 # MUI Base - Vite.js example with Tailwind CSS in TypeScript
 
-[MUI Base](https://mui.com/base-ui/) is a library of unstyled React UI components and hooks.
+[MUI Base](https://v6.mui.com/base-ui/getting-started/) is a library of unstyled React UI components and hooks.
 
 [Vite](https://vite.dev/) is a build tool that aims to provide a faster and leaner development experience for modern web projects, consisting of a dev server and a build command
 

--- a/examples/base-ui-vite-tailwind/README.md
+++ b/examples/base-ui-vite-tailwind/README.md
@@ -1,6 +1,6 @@
 # MUI Base - Vite.js example with Tailwind CSS
 
-[MUI Base](https://mui.com/base-ui/) is a library of unstyled React UI components and hooks.
+[MUI Base](https://v6.mui.com/base-ui/getting-started/) is a library of unstyled React UI components and hooks.
 
 [Vite](https://vite.dev/) is a build tool that aims to provide a faster and leaner development experience for modern web projects, consisting of a dev server and a build command
 

--- a/examples/base-ui-vite-tailwind/src/App.jsx
+++ b/examples/base-ui-vite-tailwind/src/App.jsx
@@ -6,8 +6,8 @@ export default function App() {
       <h1 className="text-3xl font-semibold mb-4">MUI Base + Vite.js + Tailwind CSS</h1>
       <ul>
         <li className="card">
-          <a href="https://mui.com/base-ui/" className="link">
-            Base UI
+          <a href="https://v6.mui.com/base-ui/getting-started/" className="link">
+            MUI Base
           </a>{' '}
           is a library of unstyled React UI components and hooks.
         </li>

--- a/packages/mui-base/README.md
+++ b/packages/mui-base/README.md
@@ -1,11 +1,11 @@
 <!-- markdownlint-disable-next-line -->
 <p align="center">
-  <a href="https://mui.com/base-ui/" rel="noopener" target="_blank"><img width="150" height="133" src="https://mui.com/static/logo.svg" alt="Base UI logo"></a>
+  <a href="https://v6.mui.com/base-ui/getting-started/" rel="noopener" target="_blank"><img width="150" height="133" src="https://mui.com/static/logo.svg" alt="MUI Base logo"></a>
 </p>
 
-<h1 align="center">Base UI</h1>
+<h1 align="center">MUI Base</h1>
 
-Base UI is a library of headless ("unstyled") React components and low-level hooks. You gain complete control over your app's CSS and accessibility features.
+MUI Base is a library of headless ("unstyled") React components and low-level hooks. You gain complete control over your app's CSS and accessibility features.
 
 ## Installation
 
@@ -19,7 +19,7 @@ npm install @mui/base
 
 <!-- #host-reference -->
 
-Visit [https://v6.mui.com/base-ui/](https://v6.mui.com/base-ui/) to view the full documentation.
+Visit [https://v6.mui.com/base-ui/getting-started/](https://v6.mui.com/base-ui/getting-started/) to view the full documentation.
 
 ## Questions
 
@@ -28,7 +28,7 @@ Use the "base-ui" tag on Stack Overflow to make it easier for the community to 
 
 ## Examples
 
-Our documentation features [a collection of example projects using Base UI](https://github.com/mui/material-ui/tree/master/examples).
+Our documentation features [a collection of example projects using MUI Base](https://github.com/mui/material-ui/tree/master/examples).
 
 ## Contributing
 

--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/mui/material-ui/issues"
   },
-  "homepage": "https://mui.com/base-ui/",
+  "homepage": "https://v6.mui.com/base-ui/getting-started/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui-org"


### PR DESCRIPTION
In https://www.reddit.com/r/reactjs/comments/1k1gerj/in_2025_whats_the_goto_reactjs_ui_library/, you can find levels of confusion:

<img width="652" height="419" alt="SCR-20250926-cbfh" src="https://github.com/user-attachments/assets/49a3f0f4-c770-4739-bebf-2fac589e285b" />

Now, when I see: https://www.npmjs.com/package/@mui/base

<img width="680" height="517" alt="SCR-20250926-ccls" src="https://github.com/user-attachments/assets/594e0004-1a6d-4e62-b5b0-e36971423ff0" />

or https://mui.com/blog/base-ui-2024-plans/. It feels like we add confusion, we dont have a clear separation between the two; Hence this PR and #46979.

We started the work, e.g. #45060, but it doesn't feel like we ever finished it. I don't know if this PR is enough to call it done, but this feels like we're getting closer.