### PR TITLE
[infra] Fix JSON files not being imported in TS demos

### DIFF
--- a/packages/markdown/loader.mjs
+++ b/packages/markdown/loader.mjs
@@ -5,6 +5,8 @@ import extractImports from './extractImports.mjs';
 
 const notEnglishMarkdownRegExp = /-([a-z]{2})\.md$/;
 
+const variantDependentExtensions = new Set(['js', 'jsx', 'ts', 'tsx']);
+
 /**
  * @param {string} string
  */
@@ -26,6 +28,17 @@ function moduleIDToJSIdentifier(moduleID) {
     .map((part) => (part.length === 0 ? '$' : part))
     .map(upperCaseFirst)
     .join('');
+}
+
+/**
+ * @param {string} moduleID
+ * @returns {string}
+ */
+function getExtension(moduleID) {
+  // If the moduleID does not end with an extension, or ends with an unsupported extension (e.g. ".styling") we need to resolve it
+  // Fastest way to get a file extension, see: https://stackoverflow.com/a/12900504/
+
+  return moduleID.slice((Math.max(0, moduleID.lastIndexOf('.')) || Infinity) + 1);
 }
 
 let componentPackageMapping = null;
@@ -157,9 +170,7 @@ export default async function demoLoader() {
       const demoMap = relativeModules.get(demoName);
       // If the moduleID does not end with an extension, or ends with an unsupported extension (e.g. ".styling") we need to resolve it
       // Fastest way to get a file extension, see: https://stackoverflow.com/a/12900504/
-      const importType = importModuleID.slice(
-        (Math.max(0, importModuleID.lastIndexOf('.')) || Infinity) + 1,
-      );
+      const importType = getExtension(importModuleID);
       const supportedTypes = ['js', 'jsx', 'ts', 'tsx', 'css', 'json'];
       if (!importType || !supportedTypes.includes(importType)) {
         // If the demo is a JS demo, we can assume that the relative import is either
@@ -470,8 +481,11 @@ export default async function demoLoader() {
                 relativeModuleID,
               );
 
-              // the file has already been processed
-              if (addedModulesRelativeToModulePath.has(relativeModuleFilePath)) {
+              if (
+                variantDependentExtensions.has(getExtension(relativeModuleFilePath)) &&
+                addedModulesRelativeToModulePath.has(relativeModuleFilePath)
+              ) {
+                // If the file is a variant dependent file, and it has already been processed, then skip it
                 continue;
               }
 


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/19749. 

Fix JSON files not being imported in TS demos. 

I'm not very experienced with docs-infra, so feel free to suggest improvements. 

It seemed that once a file is processed it won't be processed again. Since JS processing happens before TS processing, modules that independent from the variant won't show up in the TS demo because they will have been processed by the JS demo already. To solve this, I marked `.js`, `.jsx`, `.ts` and `.tsx` as variant-dependent extensions so that all other extensions will be processed twice. 

Before:

https://github.com/user-attachments/assets/0a743932-ff58-44cc-8b56-a9a60aa47e2c


After:

https://github.com/user-attachments/assets/d0f734c6-dd8a-4696-8e3a-2ce8b106d6ba

