### PR TITLE
[tabs] Disable animation on tab initialization

### DIFF
--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -75,7 +75,7 @@ function withDocsInfra(nextConfig) {
     experimental: {
       scrollRestoration: true,
       workerThreads: false,
-      ...(process.env.CI ? { cpus: 3 } : {}),
+      ...(process.env.CI ? { cpus: 2 } : {}),
       ...nextConfig.experimental,
     },
     eslint: {

--- a/packages/mui-material/src/Tabs/Tabs.js
+++ b/packages/mui-material/src/Tabs/Tabs.js
@@ -747,7 +747,7 @@ const Tabs = React.forwardRef(function Tabs(inProps, ref) {
 
   React.useEffect(() => {
     if (scrollable && scrollButtons === 'auto' && (displayEndScroll || displayStartScroll)) {
-      scrollSelectedIntoView(true);
+      scrollSelectedIntoView(false);
     }
   }, [displayEndScroll, displayStartScroll, scrollable, scrollButtons, scrollSelectedIntoView]);
 


### PR DESCRIPTION
The effect introduced in https://github.com/mui/material-ui/pull/46869 causes a animation when loading and results in very flaky screenshots. This PR just disables the animation in an attempt to stabilize the screenshots. I suppose an animation on load is not intended behavior.

I don't have the bandwidth to dig deep into this, but this component still feels very glitchy. I'd expect the tabs to just initialize in the correct scroll position. Instead there are these flashes of intermediate scroll positions.