### PR TITLE
[code-infra] Remove baseUrl

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -4,8 +4,6 @@
     "allowJs": true,
     "isolatedModules": true,
     "moduleResolution": "bundler",
-    /* files are emitted by babel */
-    "baseUrl": "../",
     "noEmit": true,
     "noUnusedLocals": true,
     "resolveJsonModule": true,

--- a/examples/material-ui-nextjs-ts/tsconfig.json
+++ b/examples/material-ui-nextjs-ts/tsconfig.json
@@ -19,7 +19,6 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/examples/material-ui-react-router-ts/tsconfig.json
+++ b/examples/material-ui-react-router-ts/tsconfig.json
@@ -8,7 +8,6 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"]
     },

--- a/examples/material-ui-remix-ts/tsconfig.json
+++ b/examples/material-ui-remix-ts/tsconfig.json
@@ -11,7 +11,6 @@
     "strict": true,
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"]
     },

--- a/packages/api-docs-builder/tsconfig.json
+++ b/packages/api-docs-builder/tsconfig.json
@@ -12,7 +12,6 @@
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "strict": true,
-    "baseUrl": "./",
     "paths": {
       "@mui/internal-docs-utils": ["../../packages-internal/docs-utils/src"]
     }

--- a/scripts/buidApiDocs/tsconfig.json
+++ b/scripts/buidApiDocs/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "./",
-
     "module": "node16",
     "target": "es2022",
     "moduleResolution": "node16",


### PR DESCRIPTION
Deprecated in typescript@next as per https://app.circleci.com/pipelines/github/mui/material-ui/161160/workflows/1d47c1b7-1da5-49a0-b613-a1cb4822948e/jobs/860333