### PR TITLE
[docs][careers] Update React Engineer X job posting with enhanced application process and how to apply instructions

### DIFF
--- a/docs/pages/careers/react-engineer-x.md
+++ b/docs/pages/careers/react-engineer-x.md
@@ -121,12 +121,87 @@ We're looking for someone with strong front-end skills. More important than spec
 
 We offer competitive compensation commensurate with your experience level and location and are prepared to pay top market rates for someone who can clearly exceed the role's expectations. You can find the other perks and benefits on the [careers](https://mui.com/careers/#perks-and-benefits) page.
 
+## Application process
+
+### What we're looking for in your application
+
+A strong application includes:
+
+- **Resume/CV** highlighting your relevant experience with React, TypeScript, and front-end development
+- **GitHub profile or portfolio** showcasing your code quality and contributions (particularly open-source work if available)
+- **Cover letter** addressing:
+  - Your experience with front-end infrastructure (design systems, complex React components, or similar work)
+  - A specific example of a complex problem you've solved and your approach
+  - Why you're interested in working on MUI X and open-source software
+- **Sample projects** (optional but encouraged):
+  - Links to production applications you've built
+  - Contributions to open-source projects
+  - Personal projects demonstrating advanced React patterns
+
+### Interview process timeline
+
+Our hiring process typically takes 3-4 weeks and includes:
+
+1. **Application review** (1 week)
+   - Our team reviews all applications
+   - We'll reach out if we'd like to move forward
+
+2. **Initial screening call** (30 minutes)
+   - Video call with our hiring team
+   - Discussion about your background, experience, and interest in the role
+   - Overview of MUI, the team, and what we're building
+
+3. **Technical assessment** (1 week to complete)
+   - Take-home coding assignment related to React components and UI development
+   - You'll have flexibility to complete this on your own schedule
+   - Expected time commitment: 3-4 hours
+   - Focus on code quality, architecture decisions, and problem-solving approach
+
+4. **Technical interview** (60-90 minutes)
+   - Deep dive into your technical assessment solution
+   - Discussion of architectural decisions and trade-offs
+   - Pair programming session on a real-world problem
+   - Questions about React, TypeScript, and front-end best practices
+
+5. **Team fit conversation** (45-60 minutes)
+   - Meet with team members you'd be working with
+   - Discussion about remote collaboration, communication style, and working async
+   - Your questions about day-to-day work, culture, and team dynamics
+
+6. **Final conversation** (30-45 minutes)
+   - Chat with leadership team
+   - Alignment on role expectations, compensation, and logistics
+   - Your final questions
+
+7. **Offer and decision** (within 1 week of final interview)
+
+**Total timeline: 3-4 weeks from application to offer**
+
+We know your time is valuable and will keep you informed at every step. If you need to adjust the timeline due to your current commitments, please let us know—we're happy to accommodate reasonable requests.
+
 ## How to apply
+
+Ready to join us? Here's how to apply:
+
+### Submit your application
 
 [Apply now for this position 📮](https://jobs.ashbyhq.com/MUI/77584e4c-9379-45f3-a294-6e50bf250383/application?utm_source=ZNRrPGBkqO)
 
-Don't meet every requirement?
-Apply anyway!
-Research shows that certain folks are less likely to apply for a role than others [unless they meet 100%](https://hbr.org/2014/08/why-women-dont-apply-for-jobs-unless-theyre-100-qualified) of the outlined qualifications.
-If this role excites you, we want to hear from you.
-We'd love for you to share the unique skills, passion, and experience you could bring to MUI.
+**Application checklist:**
+
+- ✅ Resume/CV
+- ✅ GitHub profile or portfolio link
+- ✅ Cover letter addressing your front-end infrastructure experience
+- ✅ (Optional) Links to relevant projects or contributions
+
+### Don't meet every requirement?
+
+Apply anyway! Research shows that certain folks are less likely to apply for a role than others [unless they meet 100%](https://hbr.org/2014/08/why-women-dont-apply-for-jobs-unless-theyre-100-qualified) of the outlined qualifications.
+
+If this role excites you, we want to hear from you. We'd love for you to share the unique skills, passion, and experience you could bring to MUI.
+
+### Questions about the role?
+
+If you have questions before applying, feel free to reach out to us through the application portal or check our [careers FAQ](https://mui.com/careers/).
+
+We review applications on a rolling basis, so we encourage you to apply early. We're excited to meet you!

--- a/docs/pages/careers/react-engineer-x.md
+++ b/docs/pages/careers/react-engineer-x.md
@@ -132,7 +132,7 @@ A strong application includes:
 - **Cover letter** addressing:
   - Your experience with front-end infrastructure (design systems, complex React components, or similar work)
   - A specific example of a complex problem you've solved and your approach
-  - Why you're interested in working on MUI X and open-source software
+  - Why you're interested in working on MUI\u00a0X and open-source software
 - **Sample projects** (optional but encouraged):
   - Links to production applications you've built
   - Contributions to open-source projects


### PR DESCRIPTION
## What I Changed

The React Engineer X job posting was missing info about what happens after you apply. The "How to apply" section was pretty bare-bones too.

## What I Did

I updated `docs/pages/careers/react-engineer-x.md` to give candidates a clearer picture of our hiring process.

Added:
- Full breakdown of interview stages (screening → take-home → technical interview → team chat → final round)
- Timeline expectations (3-4 weeks total)
- What we're actually looking for in applications (resume, GitHub, cover letter specifics)
- Application checklist so people know what to include
- Made it clear we want diverse applicants, even if they don't tick every box

## How I Tested

- Checked the page locally at http://localhost:3000/careers/react-engineer-x - looks good
- Ran prettier and eslint, everything passed
- Just markdown changes so no tests needed

## Why This Matters

Candidates shouldn't have to guess what our process looks like or what we need from them. Being upfront about timelines and requirements helps everyone - they know what to expect, and we get better applications.

Plus it shows we actually care about making hiring transparent, which fits with how we do everything else at MUI.

---

No related issue - just noticed this while looking at our careers page.

I have attached images of my changes:

<img width="1919" height="1126" alt="Screenshot From 2025-11-14 12-37-12" src="https://github.com/user-attachments/assets/7c76b775-6e12-44bb-9fd7-8837b4494768" />
<img width="1919" height="1126" alt="Screenshot From 2025-11-14 12-37-48" src="https://github.com/user-attachments/assets/bf387bdb-ed83-4205-abcd-648cc0823c25" />
<img width="1919" height="1126" alt="Screenshot From 2025-11-14 12-38-49" src="https://github.com/user-attachments/assets/0355fdc7-aa3d-4914-9676-82c8e707478c" />
