### PR TITLE
[docs] Fix small typo in NumberField page

### DIFF
--- a/docs/data/material/components/number-field/number-field.md
+++ b/docs/data/material/components/number-field/number-field.md
@@ -46,7 +46,7 @@ yarn add @base-ui/react
 ## Outlined field
 
 The outlined field uses the same building-block components as Material UI's outlined `TextField`—`FormControl`, `OutlinedInput`, `InputLabel`, and `FormHelperText`—with end adornments for the increment and decrement buttons.
-See [Text Field—Compononents](/material-ui/react-text-field/#components) for more details.
+See [Text Field—Components](/material-ui/react-text-field/#components) for more details.
 
 {{"demo": "FieldDemo.js"}}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Just a small typo I noticed in the documentation ([here](https://mui.com/material-ui/react-number-field/#outlined-field)) - hope it's fine to open a pull request for this

Thanks for your work! 😊 

ps: not sure about the required label check failing - because there's no related issue?
I didn't want to open one just for this tiny change, let me know if I missed something