### PR TITLE
[core] Fix the deprecated examples version to v7

### DIFF
--- a/packages/mui-codemod/package.json
+++ b/packages/mui-codemod/package.json
@@ -32,6 +32,7 @@
     "@babel/runtime": "^7.28.6",
     "@babel/traverse": "^7.29.0",
     "@mui/material-v5": "npm:@mui/material@5.18.0",
+    "@mui/material-v7": "npm:@mui/material@7.3.9",
     "jscodeshift": "^17.1.2",
     "jscodeshift-add-imports": "^1.0.11",
     "postcss": "^8.5.8",

--- a/packages/mui-codemod/src/deprecations/accordion-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/accordion-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import Accordion from '@mui/material/Accordion';
-import { Accordion as MyAccordion } from '@mui/material';
+import Accordion from '@mui/material-v7/Accordion';
+import { Accordion as MyAccordion } from '@mui/material-v7';
 
 <Accordion TransitionComponent={CustomTransition} TransitionProps={{ unmountOnExit: true }} />;
 <MyAccordion TransitionComponent={CustomTransition} TransitionProps={transitionVars} />;

--- a/packages/mui-codemod/src/deprecations/accordion-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/accordion-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import Accordion from '@mui/material/Accordion';
-import { Accordion as MyAccordion } from '@mui/material';
+import Accordion from '@mui/material-v7/Accordion';
+import { Accordion as MyAccordion } from '@mui/material-v7';
 
 <Accordion slots={{
   transition: CustomTransition

--- a/packages/mui-codemod/src/deprecations/accordion-summary-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/accordion-summary-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { accordionSummaryClasses } from '@mui/material/AccordionSummary';
+import { accordionSummaryClasses } from '@mui/material-v7/AccordionSummary';
 
 fn({
   MuiAccordionSummary: {

--- a/packages/mui-codemod/src/deprecations/accordion-summary-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/accordion-summary-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { accordionSummaryClasses } from '@mui/material/AccordionSummary';
+import { accordionSummaryClasses } from '@mui/material-v7/AccordionSummary';
 
 fn({
   MuiAccordionSummary: {

--- a/packages/mui-codemod/src/deprecations/alert-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/alert-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { alertClasses } from '@mui/material/Alert';
+import { alertClasses } from '@mui/material-v7/Alert';
 
 ('&.MuiAlert-standardSuccess');
 ('&.MuiAlert-standardInfo');

--- a/packages/mui-codemod/src/deprecations/alert-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/alert-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { alertClasses } from '@mui/material/Alert';
+import { alertClasses } from '@mui/material-v7/Alert';
 
 ('&.MuiAlert-standard.MuiAlert-colorSuccess');
 ('&.MuiAlert-standard.MuiAlert-colorInfo');

--- a/packages/mui-codemod/src/deprecations/alert-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/alert-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import Alert from '@mui/material/Alert';
+import Alert from '@mui/material-v7/Alert';
 
 <Alert
   components={{ CloseButton: ComponentsButton }}

--- a/packages/mui-codemod/src/deprecations/alert-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/alert-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import Alert from '@mui/material/Alert';
+import Alert from '@mui/material-v7/Alert';
 
 <Alert
   slots={{

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/actual.js
@@ -1,7 +1,7 @@
-import Autocomplete from '@mui/material/Autocomplete';
-import {Autocomplete as MyAutocomplete} from '@mui/material';
-import Chip from '@mui/material/Chip';
-import useAutocomplete from '@mui/material/useAutocomplete';
+import Autocomplete from '@mui/material-v7/Autocomplete';
+import {Autocomplete as MyAutocomplete} from '@mui/material-v7';
+import Chip from '@mui/material-v7/Chip';
+import useAutocomplete from '@mui/material-v7/useAutocomplete';
 
 <Autocomplete
   ChipProps={{ height: 10 }}

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/test-cases/expected.js
@@ -1,7 +1,7 @@
-import Autocomplete from '@mui/material/Autocomplete';
-import {Autocomplete as MyAutocomplete} from '@mui/material';
-import Chip from '@mui/material/Chip';
-import useAutocomplete from '@mui/material/useAutocomplete';
+import Autocomplete from '@mui/material-v7/Autocomplete';
+import {Autocomplete as MyAutocomplete} from '@mui/material-v7';
+import Chip from '@mui/material-v7/Chip';
+import useAutocomplete from '@mui/material-v7/useAutocomplete';
 
 <Autocomplete
   slots={{

--- a/packages/mui-codemod/src/deprecations/avatar-group-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/avatar-group-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import AvatarGroup from '@mui/material/AvatarGroup';
-import { AvatarGroup as MyAvatarGroup } from '@mui/material';
+import AvatarGroup from '@mui/material-v7/AvatarGroup';
+import { AvatarGroup as MyAvatarGroup } from '@mui/material-v7';
 
 <AvatarGroup
   componentsProps={{

--- a/packages/mui-codemod/src/deprecations/avatar-group-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/avatar-group-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import AvatarGroup from '@mui/material/AvatarGroup';
-import { AvatarGroup as MyAvatarGroup } from '@mui/material';
+import AvatarGroup from '@mui/material-v7/AvatarGroup';
+import { AvatarGroup as MyAvatarGroup } from '@mui/material-v7';
 
 <AvatarGroup
   slotProps={{

--- a/packages/mui-codemod/src/deprecations/avatar-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/avatar-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import Avatar from '@mui/material/Avatar';
-import { Avatar as MyAvatar } from '@mui/material';
+import Avatar from '@mui/material-v7/Avatar';
+import { Avatar as MyAvatar } from '@mui/material-v7';
 
 <Avatar
   imgProps={{

--- a/packages/mui-codemod/src/deprecations/avatar-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/avatar-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import Avatar from '@mui/material/Avatar';
-import { Avatar as MyAvatar } from '@mui/material';
+import Avatar from '@mui/material-v7/Avatar';
+import { Avatar as MyAvatar } from '@mui/material-v7';
 
 <Avatar
   slotProps={{

--- a/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import Backdrop from '@mui/material/Backdrop';
-import { Backdrop as MyBackdrop } from '@mui/material';
+import Backdrop from '@mui/material-v7/Backdrop';
+import { Backdrop as MyBackdrop } from '@mui/material-v7';
 
 <Backdrop TransitionComponent={CustomTransition} />;
 <MyBackdrop TransitionComponent={CustomTransition} />;

--- a/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import Backdrop from '@mui/material/Backdrop';
-import { Backdrop as MyBackdrop } from '@mui/material';
+import Backdrop from '@mui/material-v7/Backdrop';
+import { Backdrop as MyBackdrop } from '@mui/material-v7';
 
 <Backdrop slots={{
   transition: CustomTransition

--- a/packages/mui-codemod/src/deprecations/badge-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/badge-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { Badge } from '@mui/material';
+import { Badge } from '@mui/material-v7';
 
 <Badge components={{ root: ComponentsRoot }} componentsProps={{ root: componentsRootProps }} />;
 

--- a/packages/mui-codemod/src/deprecations/badge-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/badge-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { Badge } from '@mui/material';
+import { Badge } from '@mui/material-v7';
 
 <Badge slots={{
   root: ComponentsRoot

--- a/packages/mui-codemod/src/deprecations/button-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/button-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { buttonClasses } from '@mui/material/Button';
+import { buttonClasses } from '@mui/material-v7/Button';
 
 ('&.MuiButton-textInherit');
 ('&.MuiButton-textPrimary');

--- a/packages/mui-codemod/src/deprecations/button-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/button-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { buttonClasses } from '@mui/material/Button';
+import { buttonClasses } from '@mui/material-v7/Button';
 
 ("&.MuiButton-text.MuiButton-colorInherit");
 ("&.MuiButton-text.MuiButton-colorPrimary");

--- a/packages/mui-codemod/src/deprecations/button-group-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/button-group-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { buttonGroupClasses } from '@mui/material/ButtonGroup';
+import { buttonGroupClasses } from '@mui/material-v7/ButtonGroup';
 
 ('& .MuiButtonGroup-groupedHorizontal');
 ('& .MuiButtonGroup-groupedVertical');

--- a/packages/mui-codemod/src/deprecations/button-group-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/button-group-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { buttonGroupClasses } from '@mui/material/ButtonGroup';
+import { buttonGroupClasses } from '@mui/material-v7/ButtonGroup';
 
 ("&.MuiButtonGroup-horizontal > .MuiButtonGroup-grouped");
 ("&.MuiButtonGroup-vertical > .MuiButtonGroup-grouped");

--- a/packages/mui-codemod/src/deprecations/card-header-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/card-header-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import CardHeader from '@mui/material/CardHeader';
-import { CardHeader as MyCardHeader } from '@mui/material';
+import CardHeader from '@mui/material-v7/CardHeader';
+import { CardHeader as MyCardHeader } from '@mui/material-v7';
 
 <CardHeader
   titleTypographyProps={{ variant: 'h6' }}

--- a/packages/mui-codemod/src/deprecations/card-header-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/card-header-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import CardHeader from '@mui/material/CardHeader';
-import { CardHeader as MyCardHeader } from '@mui/material';
+import CardHeader from '@mui/material-v7/CardHeader';
+import { CardHeader as MyCardHeader } from '@mui/material-v7';
 
 <CardHeader
   slotProps={{

--- a/packages/mui-codemod/src/deprecations/chip-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/chip-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { chipClasses } from '@mui/material/Chip';
+import { chipClasses } from '@mui/material-v7/Chip';
 
 ('&.MuiChip-clickableColorPrimary');
 ('&.MuiChip-clickableColorSecondary');

--- a/packages/mui-codemod/src/deprecations/chip-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/chip-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { chipClasses } from '@mui/material/Chip';
+import { chipClasses } from '@mui/material-v7/Chip';
 
 ("&.MuiChip-clickable.MuiChip-colorPrimary");
 ("&.MuiChip-clickable.MuiChip-colorSecondary");

--- a/packages/mui-codemod/src/deprecations/circular-progress-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/circular-progress-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { circularProgressClasses } from '@mui/material/CircularProgress';
+import { circularProgressClasses } from '@mui/material-v7/CircularProgress';
 
 ('& .MuiCircularProgress-circleDeterminate');
 ('& .MuiCircularProgress-circleIndeterminate');

--- a/packages/mui-codemod/src/deprecations/circular-progress-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/circular-progress-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { circularProgressClasses } from '@mui/material/CircularProgress';
+import { circularProgressClasses } from '@mui/material-v7/CircularProgress';
 
 ("&.MuiCircularProgress-determinate > .MuiCircularProgress-circle");
 ("&.MuiCircularProgress-indeterminate > .MuiCircularProgress-circle");

--- a/packages/mui-codemod/src/deprecations/dialog-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/dialog-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { dialogClasses } from '@mui/material/Dialog';
+import { dialogClasses } from '@mui/material-v7/Dialog';
 
 ('& .MuiDialog-paperScrollBody');
 ('& .MuiDialog-paperScrollPaper');

--- a/packages/mui-codemod/src/deprecations/dialog-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/dialog-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { dialogClasses } from '@mui/material/Dialog';
+import { dialogClasses } from '@mui/material-v7/Dialog';
 
 ("& .MuiDialog-scrollBody > .MuiDialog-paper");
 ("& .MuiDialog-scrollPaper > .MuiDialog-paper");

--- a/packages/mui-codemod/src/deprecations/dialog-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/dialog-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import Dialog from '@mui/material/Dialog';
-import { Dialog as MyDialog } from '@mui/material';
+import Dialog from '@mui/material-v7/Dialog';
+import { Dialog as MyDialog } from '@mui/material-v7';
 
 <Dialog
   TransitionComponent={CustomTransition}

--- a/packages/mui-codemod/src/deprecations/dialog-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/dialog-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import Dialog from '@mui/material/Dialog';
-import { Dialog as MyDialog } from '@mui/material';
+import Dialog from '@mui/material-v7/Dialog';
+import { Dialog as MyDialog } from '@mui/material-v7';
 
 <Dialog
   slots={{

--- a/packages/mui-codemod/src/deprecations/divider-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/divider-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import Divider from '@mui/material/Divider';
-import { Divider as MyDivider } from '@mui/material';
+import Divider from '@mui/material-v7/Divider';
+import { Divider as MyDivider } from '@mui/material-v7';
 
 <Divider light className="test" />;
 <MyDivider light className="test" />;

--- a/packages/mui-codemod/src/deprecations/divider-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/divider-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import Divider from '@mui/material/Divider';
-import { Divider as MyDivider } from '@mui/material';
+import Divider from '@mui/material-v7/Divider';
+import { Divider as MyDivider } from '@mui/material-v7';
 
 <Divider className="test" sx={{
   opacity: "0.6"

--- a/packages/mui-codemod/src/deprecations/drawer-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/drawer-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { drawerClasses } from '@mui/material/Drawer';
+import { drawerClasses } from '@mui/material-v7/Drawer';
 
 ("& .MuiDrawer-paperAnchorBottom");
 ("& .MuiDrawer-paperAnchorLeft");

--- a/packages/mui-codemod/src/deprecations/drawer-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/drawer-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { drawerClasses } from '@mui/material/Drawer';
+import { drawerClasses } from '@mui/material-v7/Drawer';
 
 ("&.MuiDrawer-anchorBottom > .MuiDrawer-paper");
 ("&.MuiDrawer-anchorLeft > .MuiDrawer-paper");

--- a/packages/mui-codemod/src/deprecations/drawer-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/drawer-props/test-cases/actual.js
@@ -1,6 +1,6 @@
-import Drawer from '@mui/material/Drawer';
-import SwipeableDrawer from '@mui/material/SwipeableDrawer';
-import { Drawer as MyDrawer, SwipeableDrawer as MySwipeableDrawer } from '@mui/material';
+import Drawer from '@mui/material-v7/Drawer';
+import SwipeableDrawer from '@mui/material-v7/SwipeableDrawer';
+import { Drawer as MyDrawer, SwipeableDrawer as MySwipeableDrawer } from '@mui/material-v7';
 
 <Drawer BackdropComponent={Backdrop} BackdropProps={{ transitionDuration: 300 }} />;
 <SwipeableDrawer BackdropComponent={Backdrop} BackdropProps={{ transitionDuration: 300 }} />;

--- a/packages/mui-codemod/src/deprecations/drawer-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/drawer-props/test-cases/expected.js
@@ -1,6 +1,6 @@
-import Drawer from '@mui/material/Drawer';
-import SwipeableDrawer from '@mui/material/SwipeableDrawer';
-import { Drawer as MyDrawer, SwipeableDrawer as MySwipeableDrawer } from '@mui/material';
+import Drawer from '@mui/material-v7/Drawer';
+import SwipeableDrawer from '@mui/material-v7/SwipeableDrawer';
+import { Drawer as MyDrawer, SwipeableDrawer as MySwipeableDrawer } from '@mui/material-v7';
 
 <Drawer slots={{
   backdrop: Backdrop

--- a/packages/mui-codemod/src/deprecations/filled-input-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/filled-input-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import FilledInput from '@mui/material/FilledInput';
+import FilledInput from '@mui/material-v7/FilledInput';
 
 <FilledInput
   components={{ Input: ComponentsInput }}

--- a/packages/mui-codemod/src/deprecations/filled-input-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/filled-input-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import FilledInput from '@mui/material/FilledInput';
+import FilledInput from '@mui/material-v7/FilledInput';
 
 <FilledInput
   slots={{

--- a/packages/mui-codemod/src/deprecations/form-control-label-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/form-control-label-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControlLabel from '@mui/material-v7/FormControlLabel';
 
 <FormControlLabel componentsProps={{ typography: componentsTypographyProps }} />;
 <FormControlLabel

--- a/packages/mui-codemod/src/deprecations/form-control-label-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/form-control-label-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControlLabel from '@mui/material-v7/FormControlLabel';
 
 <FormControlLabel slotProps={{ typography: componentsTypographyProps }} />;
 <FormControlLabel

--- a/packages/mui-codemod/src/deprecations/image-list-item-bar-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/image-list-item-bar-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { imageListItemBarClasses } from '@mui/material/ImageListItemBar';
+import { imageListItemBarClasses } from '@mui/material-v7/ImageListItemBar';
 
 ('& .MuiImageListItemBar-titleWrapBelow');
 ('& .MuiImageListItemBar-titleWrapActionPosLeft');

--- a/packages/mui-codemod/src/deprecations/image-list-item-bar-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/image-list-item-bar-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { imageListItemBarClasses } from '@mui/material/ImageListItemBar';
+import { imageListItemBarClasses } from '@mui/material-v7/ImageListItemBar';
 
 ("&.MuiImageListItemBar-positionBelow > .MuiImageListItemBar-titleWrap");
 ("&.MuiImageListItemBar-actionPositionLeft > .MuiImageListItemBar-titleWrap");

--- a/packages/mui-codemod/src/deprecations/input-base-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/input-base-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { inputBaseClasses } from '@mui/material/InputBase';
+import { inputBaseClasses } from '@mui/material-v7/InputBase';
 
 ('& .MuiInputBase-inputHiddenLabel');
 ('& .MuiInputBase-inputMultiline');

--- a/packages/mui-codemod/src/deprecations/input-base-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/input-base-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { inputBaseClasses } from '@mui/material/InputBase';
+import { inputBaseClasses } from '@mui/material-v7/InputBase';
 
 ("&.MuiInputBase-hiddenLabel > .MuiInputBase-input");
 ("&.MuiInputBase-multiline > .MuiInputBase-input");

--- a/packages/mui-codemod/src/deprecations/input-base-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/input-base-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import InputBase from '@mui/material/InputBase';
+import InputBase from '@mui/material-v7/InputBase';
 
 <InputBase
   components={{ Input: ComponentsInput }}

--- a/packages/mui-codemod/src/deprecations/input-base-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/input-base-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import InputBase from '@mui/material/InputBase';
+import InputBase from '@mui/material-v7/InputBase';
 
 <InputBase
   slots={{

--- a/packages/mui-codemod/src/deprecations/input-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/input-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import Input from '@mui/material/Input';
+import Input from '@mui/material-v7/Input';
 
 <Input
   components={{ Input: ComponentsInput }}

--- a/packages/mui-codemod/src/deprecations/input-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/input-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import Input from '@mui/material/Input';
+import Input from '@mui/material-v7/Input';
 
 <Input
   slots={{

--- a/packages/mui-codemod/src/deprecations/linear-progress-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/linear-progress-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { linearProgressClasses } from '@mui/material/LinearProgress';
+import { linearProgressClasses } from '@mui/material-v7/LinearProgress';
 
 ('& .MuiLinearProgress-bar1Buffer');
 ('& .MuiLinearProgress-bar1Determinate');

--- a/packages/mui-codemod/src/deprecations/linear-progress-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/linear-progress-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { linearProgressClasses } from '@mui/material/LinearProgress';
+import { linearProgressClasses } from '@mui/material-v7/LinearProgress';
 
 ('&.MuiLinearProgress-buffer > .MuiLinearProgress-bar1');
 ('&.MuiLinearProgress-determinate > .MuiLinearProgress-bar1');

--- a/packages/mui-codemod/src/deprecations/list-item-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/list-item-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import ListItem from '@mui/material/ListItem';
+import ListItem from '@mui/material-v7/ListItem';
 
 <ListItem
   components={{ Root: ComponentsRoot }}

--- a/packages/mui-codemod/src/deprecations/list-item-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/list-item-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import ListItem from '@mui/material/ListItem';
+import ListItem from '@mui/material-v7/ListItem';
 
 <ListItem
   slots={{

--- a/packages/mui-codemod/src/deprecations/list-item-text-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/list-item-text-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import ListItemText from '@mui/material/ListItemText';
+import ListItemText from '@mui/material-v7/ListItemText';
 
 <ListItemText secondaryTypographyProps={secondaryTypographyProps} />;
 <ListItemText primaryTypographyProps={primaryTypographyProps} />;

--- a/packages/mui-codemod/src/deprecations/list-item-text-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/list-item-text-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import ListItemText from '@mui/material/ListItemText';
+import ListItemText from '@mui/material-v7/ListItemText';
 
 <ListItemText slotProps={{
   secondary: secondaryTypographyProps

--- a/packages/mui-codemod/src/deprecations/menu-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/menu-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import Menu from '@mui/material/Menu';
-import { Menu as MyMenu } from '@mui/material';
+import Menu from '@mui/material-v7/Menu';
+import { Menu as MyMenu } from '@mui/material-v7';
 
 <Menu
   TransitionComponent={CustomTransition}

--- a/packages/mui-codemod/src/deprecations/menu-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/menu-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import Menu from '@mui/material/Menu';
-import { Menu as MyMenu } from '@mui/material';
+import Menu from '@mui/material-v7/Menu';
+import { Menu as MyMenu } from '@mui/material-v7';
 
 <Menu
   slotProps={{

--- a/packages/mui-codemod/src/deprecations/mobile-stepper-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/mobile-stepper-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import MobileStepper from '@mui/material/MobileStepper';
-import { MobileStepper as MyMobileStepper } from '@mui/material';
+import MobileStepper from '@mui/material-v7/MobileStepper';
+import { MobileStepper as MyMobileStepper } from '@mui/material-v7';
 
 <MobileStepper variant="progress" LinearProgressProps={{ variant: 'determinate' }} />;
 <MyMobileStepper

--- a/packages/mui-codemod/src/deprecations/mobile-stepper-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/mobile-stepper-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import MobileStepper from '@mui/material/MobileStepper';
-import { MobileStepper as MyMobileStepper } from '@mui/material';
+import MobileStepper from '@mui/material-v7/MobileStepper';
+import { MobileStepper as MyMobileStepper } from '@mui/material-v7';
 
 <MobileStepper variant="progress" slotProps={{
   progress: { variant: 'determinate' }

--- a/packages/mui-codemod/src/deprecations/modal-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/modal-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import Modal from '@mui/material/Modal';
+import Modal from '@mui/material-v7/Modal';
 
 <Modal
   components={{ Root: ComponentsRoot }}

--- a/packages/mui-codemod/src/deprecations/modal-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/modal-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import Modal from '@mui/material/Modal';
+import Modal from '@mui/material-v7/Modal';
 
 <Modal
   slots={{

--- a/packages/mui-codemod/src/deprecations/outlined-input-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/outlined-input-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import OutlinedInput from '@mui/material/OutlinedInput';
+import OutlinedInput from '@mui/material-v7/OutlinedInput';
 
 <OutlinedInput
   components={{ Input: ComponentsInput }}

--- a/packages/mui-codemod/src/deprecations/outlined-input-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/outlined-input-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import OutlinedInput from '@mui/material/OutlinedInput';
+import OutlinedInput from '@mui/material-v7/OutlinedInput';
 
 <OutlinedInput
   slots={{

--- a/packages/mui-codemod/src/deprecations/pagination-item-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/pagination-item-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { paginationItemClasses } from '@mui/material/PaginationItem';
+import { paginationItemClasses } from '@mui/material-v7/PaginationItem';
 
 fn({
   MuiPaginationItem: {

--- a/packages/mui-codemod/src/deprecations/pagination-item-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/pagination-item-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { paginationItemClasses } from '@mui/material/PaginationItem';
+import { paginationItemClasses } from '@mui/material-v7/PaginationItem';
 
 fn({
   MuiPaginationItem: {

--- a/packages/mui-codemod/src/deprecations/pagination-item-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/pagination-item-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import PaginationItem from '@mui/material/PaginationItem';
+import PaginationItem from '@mui/material-v7/PaginationItem';
 
 <PaginationItem components={{ first: first, last: last, next: next, previous: previous }} />;
 <PaginationItem

--- a/packages/mui-codemod/src/deprecations/pagination-item-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/pagination-item-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import PaginationItem from '@mui/material/PaginationItem';
+import PaginationItem from '@mui/material-v7/PaginationItem';
 
 <PaginationItem slots={{
   first: first,

--- a/packages/mui-codemod/src/deprecations/popover-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/popover-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import Popover from '@mui/material/Popover';
-import { Popover as MyPopover } from '@mui/material';
+import Popover from '@mui/material-v7/Popover';
+import { Popover as MyPopover } from '@mui/material-v7';
 
 <Popover
   BackdropComponent={CustomBackdrop}

--- a/packages/mui-codemod/src/deprecations/popover-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/popover-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import Popover from '@mui/material/Popover';
-import { Popover as MyPopover } from '@mui/material';
+import Popover from '@mui/material-v7/Popover';
+import { Popover as MyPopover } from '@mui/material-v7';
 
 <Popover
   slots={{

--- a/packages/mui-codemod/src/deprecations/popper-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/popper-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import Popper from '@mui/material/Popper';
+import Popper from '@mui/material-v7/Popper';
 
 <Popper
   components={{ Root: ComponentsRoot }}

--- a/packages/mui-codemod/src/deprecations/popper-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/popper-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import Popper from '@mui/material/Popper';
+import Popper from '@mui/material-v7/Popper';
 
 <Popper
   slots={{

--- a/packages/mui-codemod/src/deprecations/rating-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/rating-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import Rating from '@mui/material/Rating';
-import { Rating as MyRating } from '@mui/material';
+import Rating from '@mui/material-v7/Rating';
+import { Rating as MyRating } from '@mui/material-v7';
 
 <Rating IconContainerComponent={CustomIconContainer} />;
 <MyRating IconContainerComponent={CustomIconContainer} />;

--- a/packages/mui-codemod/src/deprecations/rating-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/rating-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import Rating from '@mui/material/Rating';
-import { Rating as MyRating } from '@mui/material';
+import Rating from '@mui/material-v7/Rating';
+import { Rating as MyRating } from '@mui/material-v7';
 
 <Rating slotProps={{
   icon: {

--- a/packages/mui-codemod/src/deprecations/select-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/select-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { selectClasses } from '@mui/material/Select';
+import { selectClasses } from '@mui/material-v7/Select';
 
 ('& .MuiSelect-iconFilled');
 ('& .MuiSelect-iconOutlined');

--- a/packages/mui-codemod/src/deprecations/select-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/select-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { selectClasses } from '@mui/material/Select';
+import { selectClasses } from '@mui/material-v7/Select';
 
 ("& .MuiSelect-filled ~ .MuiSelect-icon");
 ("& .MuiSelect-outlined ~ .MuiSelect-icon");

--- a/packages/mui-codemod/src/deprecations/slider-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/slider-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { sliderClasses } from '@mui/material/Slider';
+import { sliderClasses } from '@mui/material-v7/Slider';
 
 ('& .MuiSlider-thumbSizeSmall');
 ('& .MuiSlider-thumbSizeMedium');

--- a/packages/mui-codemod/src/deprecations/slider-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/slider-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { sliderClasses } from '@mui/material/Slider';
+import { sliderClasses } from '@mui/material-v7/Slider';
 
 ("&.MuiSlider-sizeSmall > .MuiSlider-thumb");
 ("&.MuiSlider-sizeMedium > .MuiSlider-thumb");

--- a/packages/mui-codemod/src/deprecations/slider-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/slider-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import Slider from '@mui/material/Slider';
+import Slider from '@mui/material-v7/Slider';
 
 <Slider
   components={{ Track: ComponentsTrack }}

--- a/packages/mui-codemod/src/deprecations/slider-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/slider-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import Slider from '@mui/material/Slider';
+import Slider from '@mui/material-v7/Slider';
 
 <Slider
   slots={{

--- a/packages/mui-codemod/src/deprecations/snackbar-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/snackbar-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import Snackbar from '@mui/material/Snackbar';
-import { Snackbar as MySnackbar } from '@mui/material';
+import Snackbar from '@mui/material-v7/Snackbar';
+import { Snackbar as MySnackbar } from '@mui/material-v7';
 
 <Snackbar
   ClickAwayListenerProps={CustomListenerProps}

--- a/packages/mui-codemod/src/deprecations/snackbar-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/snackbar-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import Snackbar from '@mui/material/Snackbar';
-import { Snackbar as MySnackbar } from '@mui/material';
+import Snackbar from '@mui/material-v7/Snackbar';
+import { Snackbar as MySnackbar } from '@mui/material-v7';
 
 <Snackbar
   slots={{

--- a/packages/mui-codemod/src/deprecations/speed-dial-action-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/speed-dial-action-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import SpeedDialAction from '@mui/material/SpeedDialAction';
-import { SpeedDialAction as MySpeedDialAction } from '@mui/material';
+import SpeedDialAction from '@mui/material-v7/SpeedDialAction';
+import { SpeedDialAction as MySpeedDialAction } from '@mui/material-v7';
 
 <SpeedDialAction tooltipTitle="test" />;
 <SpeedDialAction tooltipOpen={true} />;

--- a/packages/mui-codemod/src/deprecations/speed-dial-action-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/speed-dial-action-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import SpeedDialAction from '@mui/material/SpeedDialAction';
-import { SpeedDialAction as MySpeedDialAction } from '@mui/material';
+import SpeedDialAction from '@mui/material-v7/SpeedDialAction';
+import { SpeedDialAction as MySpeedDialAction } from '@mui/material-v7';
 
 <SpeedDialAction slotProps={{
   tooltip: {

--- a/packages/mui-codemod/src/deprecations/speed-dial-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/speed-dial-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import SpeedDial from '@mui/material/SpeedDial';
-import { SpeedDial as MySpeedDial } from '@mui/material';
+import SpeedDial from '@mui/material-v7/SpeedDial';
+import { SpeedDial as MySpeedDial } from '@mui/material-v7';
 
 <SpeedDial TransitionComponent={CustomTransition} TransitionProps={CustomTransitionProps} />;
 <MySpeedDial TransitionComponent={CustomTransition} TransitionProps={CustomTransitionProps} />;

--- a/packages/mui-codemod/src/deprecations/speed-dial-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/speed-dial-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import SpeedDial from '@mui/material/SpeedDial';
-import { SpeedDial as MySpeedDial } from '@mui/material';
+import SpeedDial from '@mui/material-v7/SpeedDial';
+import { SpeedDial as MySpeedDial } from '@mui/material-v7';
 
 <SpeedDial slots={{
   transition: CustomTransition

--- a/packages/mui-codemod/src/deprecations/step-connector-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/step-connector-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { stepConnectorClasses } from '@mui/material/StepConnector';
+import { stepConnectorClasses } from '@mui/material-v7/StepConnector';
 
 ('& .MuiStepConnector-lineHorizontal');
 ('& .MuiStepConnector-lineVertical');

--- a/packages/mui-codemod/src/deprecations/step-connector-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/step-connector-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { stepConnectorClasses } from '@mui/material/StepConnector';
+import { stepConnectorClasses } from '@mui/material-v7/StepConnector';
 
 ("&.MuiStepConnector-horizontal > .MuiStepConnector-line");
 ("&.MuiStepConnector-vertical > .MuiStepConnector-line");

--- a/packages/mui-codemod/src/deprecations/step-content-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/step-content-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import StepContent from '@mui/material/StepContent';
-import { StepContent as MyStepContent } from '@mui/material';
+import StepContent from '@mui/material-v7/StepContent';
+import { StepContent as MyStepContent } from '@mui/material-v7';
 
 <StepContent TransitionComponent={CustomTransition} TransitionProps={{ unmountOnExit: true }} />;
 <MyStepContent TransitionComponent={CustomTransition} TransitionProps={transitionVars} />;

--- a/packages/mui-codemod/src/deprecations/step-content-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/step-content-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import StepContent from '@mui/material/StepContent';
-import { StepContent as MyStepContent } from '@mui/material';
+import StepContent from '@mui/material-v7/StepContent';
+import { StepContent as MyStepContent } from '@mui/material-v7';
 
 <StepContent slots={{
   transition: CustomTransition

--- a/packages/mui-codemod/src/deprecations/step-label-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/step-label-props/test-cases/actual.js
@@ -1,4 +1,4 @@
-import StepLabel from '@mui/material/StepLabel';
+import StepLabel from '@mui/material-v7/StepLabel';
 
 <StepLabel componentsProps={{ label: componentsLabelProps }} />;
 <StepLabel

--- a/packages/mui-codemod/src/deprecations/step-label-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/step-label-props/test-cases/expected.js
@@ -1,4 +1,4 @@
-import StepLabel from '@mui/material/StepLabel';
+import StepLabel from '@mui/material-v7/StepLabel';
 
 <StepLabel slotProps={{ label: componentsLabelProps }} />;
 <StepLabel

--- a/packages/mui-codemod/src/deprecations/tab-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/tab-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { tabClasses } from '@mui/material/Tab';
+import { tabClasses } from '@mui/material-v7/Tab';
 
 ('& .MuiTab-iconWrapper');
 `& .${tabClasses.iconWrapper}`;

--- a/packages/mui-codemod/src/deprecations/tab-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/tab-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { tabClasses } from '@mui/material/Tab';
+import { tabClasses } from '@mui/material-v7/Tab';
 
 ("& .MuiTab-icon");
 `& .${tabClasses.icon}`;

--- a/packages/mui-codemod/src/deprecations/table-pagination-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/table-pagination-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import TablePagination from '@mui/material/TablePagination';
-import { TablePagination as MyTablePagination } from '@mui/material';
+import TablePagination from '@mui/material-v7/TablePagination';
+import { TablePagination as MyTablePagination } from '@mui/material-v7';
 
 <TablePagination ActionsComponent="div" SelectProps={{ native: true }} />;
 <TablePagination

--- a/packages/mui-codemod/src/deprecations/table-pagination-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/table-pagination-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import TablePagination from '@mui/material/TablePagination';
-import { TablePagination as MyTablePagination } from '@mui/material';
+import TablePagination from '@mui/material-v7/TablePagination';
+import { TablePagination as MyTablePagination } from '@mui/material-v7';
 
 <TablePagination slots={{
   actions: "div"

--- a/packages/mui-codemod/src/deprecations/table-sort-label-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/table-sort-label-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { tableSortLabelClasses } from '@mui/material/TableSortLabel';
+import { tableSortLabelClasses } from '@mui/material-v7/TableSortLabel';
 
 ('& .MuiTableSortLabel-iconDirectionDesc');
 ('& .MuiTableSortLabel-iconDirectionAsc');

--- a/packages/mui-codemod/src/deprecations/table-sort-label-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/table-sort-label-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { tableSortLabelClasses } from '@mui/material/TableSortLabel';
+import { tableSortLabelClasses } from '@mui/material-v7/TableSortLabel';
 
 ("&.MuiTableSortLabel-directionDesc > .MuiTableSortLabel-icon");
 ("&.MuiTableSortLabel-directionAsc > .MuiTableSortLabel-icon");

--- a/packages/mui-codemod/src/deprecations/tabs-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/tabs-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { tabsClasses } from '@mui/material/Tabs';
+import { tabsClasses } from '@mui/material-v7/Tabs';
 
 ('&.MuiTabs-flexContainer');
 ('&.MuiTabs-flexContainerVertical');

--- a/packages/mui-codemod/src/deprecations/tabs-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/tabs-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { tabsClasses } from '@mui/material/Tabs';
+import { tabsClasses } from '@mui/material-v7/Tabs';
 
 ("&.MuiTabs-list");
 ("&.MuiTabs-list.MuiTabs-vertical");

--- a/packages/mui-codemod/src/deprecations/tabs-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/tabs-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import Tabs from '@mui/material/Tabs';
-import { Tabs as MyTabs } from '@mui/material';
+import Tabs from '@mui/material-v7/Tabs';
+import { Tabs as MyTabs } from '@mui/material-v7';
 
 <Tabs
   ScrollButtonComponent={CustomScrollButton}

--- a/packages/mui-codemod/src/deprecations/tabs-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/tabs-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import Tabs from '@mui/material/Tabs';
-import { Tabs as MyTabs } from '@mui/material';
+import Tabs from '@mui/material-v7/Tabs';
+import { Tabs as MyTabs } from '@mui/material-v7';
 
 <Tabs
   slots={{

--- a/packages/mui-codemod/src/deprecations/text-field-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/text-field-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import TextField from '@mui/material/TextField';
-import { TextField as MyTextField } from '@mui/material';
+import TextField from '@mui/material-v7/TextField';
+import { TextField as MyTextField } from '@mui/material-v7';
 
 <TextField
   InputProps={CustomInputProps}

--- a/packages/mui-codemod/src/deprecations/text-field-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/text-field-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import TextField from '@mui/material/TextField';
-import { TextField as MyTextField } from '@mui/material';
+import TextField from '@mui/material-v7/TextField';
+import { TextField as MyTextField } from '@mui/material-v7';
 
 <TextField
   slotProps={{

--- a/packages/mui-codemod/src/deprecations/toggle-button-group-classes/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/toggle-button-group-classes/test-cases/actual.js
@@ -1,4 +1,4 @@
-import { toggleButtonGroupClasses } from '@mui/material/ToggleButtonGroup';
+import { toggleButtonGroupClasses } from '@mui/material-v7/ToggleButtonGroup';
 
 ('& .MuiToggleButtonGroup-groupedHorizontal');
 ('& .MuiToggleButtonGroup-groupedVertical');

--- a/packages/mui-codemod/src/deprecations/toggle-button-group-classes/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/toggle-button-group-classes/test-cases/expected.js
@@ -1,4 +1,4 @@
-import { toggleButtonGroupClasses } from '@mui/material/ToggleButtonGroup';
+import { toggleButtonGroupClasses } from '@mui/material-v7/ToggleButtonGroup';
 
 ("&.MuiToggleButtonGroup-horizontal > .MuiToggleButtonGroup-grouped");
 ("&.MuiToggleButtonGroup-vertical > .MuiToggleButtonGroup-grouped");

--- a/packages/mui-codemod/src/deprecations/tooltip-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/tooltip-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import Tooltip from '@mui/material/Tooltip';
-import { Tooltip as MyTooltip } from '@mui/material';
+import Tooltip from '@mui/material-v7/Tooltip';
+import { Tooltip as MyTooltip } from '@mui/material-v7';
 
 <Tooltip
   components={{

--- a/packages/mui-codemod/src/deprecations/tooltip-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/tooltip-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import Tooltip from '@mui/material/Tooltip';
-import { Tooltip as MyTooltip } from '@mui/material';
+import Tooltip from '@mui/material-v7/Tooltip';
+import { Tooltip as MyTooltip } from '@mui/material-v7';
 
 <Tooltip
   slots={{

--- a/packages/mui-codemod/src/deprecations/typography-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/typography-props/test-cases/actual.js
@@ -1,5 +1,5 @@
-import Typography from '@mui/material/Typography';
-import { Typography as MyTypography } from '@mui/material';
+import Typography from '@mui/material-v7/Typography';
+import { Typography as MyTypography } from '@mui/material-v7';
 
 <Typography />;
 <MyTypography />;

--- a/packages/mui-codemod/src/deprecations/typography-props/test-cases/expected.js
+++ b/packages/mui-codemod/src/deprecations/typography-props/test-cases/expected.js
@@ -1,5 +1,5 @@
-import Typography from '@mui/material/Typography';
-import { Typography as MyTypography } from '@mui/material';
+import Typography from '@mui/material-v7/Typography';
+import { Typography as MyTypography } from '@mui/material-v7';
 
 <Typography />;
 <MyTypography />;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,6 +825,9 @@ importers:
       '@mui/material-v5':
         specifier: npm:@mui/material@5.18.0
         version: '@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)'
+      '@mui/material-v7':
+        specifier: npm:@mui/material@7.3.9
+        version: '@mui/material@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)'
       jscodeshift:
         specifier: ^17.1.2
         version: 17.1.2(@babel/preset-env@7.29.0(@babel/core@7.29.0))
@@ -3638,6 +3641,9 @@ packages:
   '@mui/core-downloads-tracker@5.18.0':
     resolution: {integrity: sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==}
 
+  '@mui/core-downloads-tracker@7.3.9':
+    resolution: {integrity: sha512-MOkOCTfbMJwLshlBCKJ59V2F/uaLYfmKnN76kksj6jlGUVdI25A9Hzs08m+zjBRdLv+sK7Rqdsefe8X7h/6PCw==}
+
   '@mui/internal-babel-plugin-display-name@1.0.4-canary.14':
     resolution: {integrity: sha512-dTkq8nLCnjA/LW+rm2RPqMwttwFzgG0LZ3gQqFLbnwGW2ty3s9QzVfvGN04qCGm8vvTG6NNMlxhQySE7/SrPjg==}
     peerDependencies:
@@ -3761,6 +3767,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/material@7.3.9':
+    resolution: {integrity: sha512-I8yO3t4T0y7bvDiR1qhIN6iBWZOTBfVOnmLlM7K6h3dx5YX2a7rnkuXzc2UkZaqhxY9NgTnEbdPlokR1RxCNRQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@mui/material-pigment-css': ^7.3.9
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@mui/material-pigment-css':
+        optional: true
+      '@types/react':
+        optional: true
+
   '@mui/private-theming@5.17.1':
     resolution: {integrity: sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==}
     engines: {node: '>=12.0.0'}
@@ -3773,6 +3799,16 @@ packages:
 
   '@mui/private-theming@6.4.8':
     resolution: {integrity: sha512-sWwQoNSn6elsPTAtSqCf+w5aaGoh7AASURNmpy+QTTD/zwJ0Jgwt0ZaaP6mXq2IcgHxYnYloM/+vJgHPMkRKTQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/private-theming@7.3.9':
+    resolution: {integrity: sha512-ErIyRQvsiQEq7Yvcvfw9UDHngaqjMy9P3JDPnRAaKG5qhpl2C4tX/W1S4zJvpu+feihmZJStjIyvnv6KDbIrlw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3796,6 +3832,19 @@ packages:
 
   '@mui/styled-engine@6.4.0':
     resolution: {integrity: sha512-ek/ZrDujrger12P6o4luQIfRd2IziH7jQod2WMbLqGE03Iy0zUwYmckRTVhRQTLPNccpD8KXGcALJF+uaUQlbg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/styled-engine@7.3.9':
+    resolution: {integrity: sha512-JqujWt5bX4okjUPGpVof/7pvgClqh7HvIbsIBIOOlCh2u3wG/Bwp4+E1bc1dXSwkrkp9WUAoNdI5HEC+5HKvMw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.4.1
@@ -3845,8 +3894,32 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/system@7.3.9':
+    resolution: {integrity: sha512-aL1q9am8XpRrSabv9qWf5RHhJICJql34wnrc1nz0MuOglPRYF/liN+c8VqZdTvUn9qg+ZjRVbKf4sJVFfIDtmg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+
   '@mui/types@7.2.24':
     resolution: {integrity: sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/types@7.4.12':
+    resolution: {integrity: sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
@@ -3883,6 +3956,16 @@ packages:
 
   '@mui/utils@7.3.6':
     resolution: {integrity: sha512-jn+Ba02O6PiFs7nKva8R2aJJ9kJC+3kQ2R0BbKNY3KQQ36Qng98GnPRFTlbwYTdMD6hLEBKaMLUktyg/rTfd2w==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/utils@7.3.9':
+    resolution: {integrity: sha512-U6SdZaGbfb65fqTsH3V5oJdFj9uYwyLE2WVuNvmbggTSDBb8QHrFsqY8BN3taK9t3yJ8/BPHD/kNvLNyjwM7Yw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -14952,6 +15035,8 @@ snapshots:
 
   '@mui/core-downloads-tracker@5.18.0': {}
 
+  '@mui/core-downloads-tracker@7.3.9': {}
+
   '@mui/internal-babel-plugin-display-name@1.0.4-canary.14(@babel/core@7.29.0)(@babel/preset-react@7.28.5(@babel/core@7.29.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -15194,6 +15279,27 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       '@types/react': 19.2.14
 
+  '@mui/material@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@mui/core-downloads-tracker': 7.3.9
+      '@mui/system': 7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
+      '@mui/types': 7.4.12(@types/react@19.2.14)
+      '@mui/utils': 7.3.9(@types/react@19.2.14)(react@19.2.4)
+      '@popperjs/core': 2.11.8
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.14)
+      clsx: 2.1.1
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 19.2.4
+      react-transition-group: 4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
+      '@types/react': 19.2.14
+
   '@mui/private-theming@5.17.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -15212,6 +15318,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@mui/private-theming@7.3.9(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@mui/utils': 7.3.9(@types/react@19.2.14)(react@19.2.4)
+      prop-types: 15.8.1
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@mui/styled-engine@5.18.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -15225,6 +15340,19 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
 
   '@mui/styled-engine@6.4.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/sheet': 1.4.0
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.4
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
+
+  '@mui/styled-engine@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@emotion/cache': 11.14.0
@@ -15275,7 +15403,29 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       '@types/react': 19.2.14
 
+  '@mui/system@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@mui/private-theming': 7.3.9(@types/react@19.2.14)(react@19.2.4)
+      '@mui/styled-engine': 7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+      '@mui/types': 7.4.12(@types/react@19.2.14)
+      '@mui/utils': 7.3.9(@types/react@19.2.14)(react@19.2.4)
+      clsx: 2.1.1
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.4
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
+      '@types/react': 19.2.14
+
   '@mui/types@7.2.24(@types/react@19.2.14)':
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@mui/types@7.4.12(@types/react@19.2.14)':
+    dependencies:
+      '@babel/runtime': 7.28.6
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -15313,6 +15463,18 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.6
       '@mui/types': 7.4.9(@types/react@19.2.14)
+      '@types/prop-types': 15.7.15
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-is: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@mui/utils@7.3.9(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@mui/types': 7.4.12(@types/react@19.2.14)
       '@types/prop-types': 15.7.15
       clsx: 2.1.1
       prop-types: 15.8.1


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixing the version in the codemod deprecated files imports, otherwise in v9 those deprecated props won't exist anymore.
