### PR TITLE
[docs] Fix Material UI and MUI system "Upgrade to v9" docs

### DIFF
--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -7,7 +7,7 @@
 ### Improved accessibility and platform alignment
 
 Material UI v9 continues improving the accessibility and semantics of core components.
-This release includes updates to keyboard navigation, focus management, and DOM structure so components align more closely with web platform and accessibility expectations and modern assistive technology behavior.
+This release includes updates to keyboard navigation, focus management, and DOM structure so components align more closely with web platform, accessibility expectations and modern assistive technology behavior.
 
 ### Quality-of-life improvements
 

--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -7,7 +7,7 @@
 ### Improved accessibility and platform alignment
 
 Material UI v9 continues improving the accessibility and semantics of core components.
-This release includes updates to keyboard navigation, focus management, and DOM structure so components align more closely with platform expectations and modern assistive technology behavior.
+This release includes updates to keyboard navigation, focus management, and DOM structure so components align more closely with web platform and accessibility expectations and modern assistive technology behavior.
 
 ### Quality-of-life improvements
 

--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -2,17 +2,30 @@
 
 <p class="description">This guide explains how to upgrade from Material UI v7 to v9.</p>
 
-## Start using the alpha release
+## Why you should upgrade to Material UI v9
 
-In the `package.json` file, change the package version from `latest` to `next`.
+### Improved accessibility and platform alignment
 
-```diff title="package.json"
--"@mui/material": "latest",
-+"@mui/material": "next",
-```
+Material UI v9 continues improving the accessibility and semantics of core components.
+This release includes updates to keyboard navigation, focus management, and DOM structure so components align more closely with platform expectations and modern assistive technology behavior.
 
-Using `next` ensures your project always uses the latest v9 pre-releases.
-Alternatively, you can pin it to a specific version, for example, `9.0.0-alpha.0`.
+### Quality-of-life improvements
+
+Material UI v9 also includes a number of quality-of-life improvements, including:
+
+- removal of deprecated APIs to reduce the API surface and make the docs easier to navigate
+- improved consistency across `slot` and `slotProps` APIs
+- better defaults and behaviors for modern browser environments
+
+If you're using any of these packages, you should also update them to compatible v9 versions:
+
+- `@mui/icons-material` to `9.0.0`
+- `@mui/system` to `9.0.0`
+- `@mui/lab` to the latest v9 beta release
+- `@mui/material-nextjs` to `9.0.0`
+- `@mui/styled-engine` to `9.0.0`
+- `@mui/styled-engine-sc` to `9.0.0`
+- `@mui/utils` to `9.0.0`
 
 ## Supported browsers and versions
 
@@ -2252,7 +2265,7 @@ The following deprecated props have been removed from the `Typography` component
 
 ### System props
 
-Use the [system-props codemod](/material-ui/migration/migrating-from-deprecated-apis/#system-props) below to migrate the code as described in the following section:
+Use the [system-props codemod](https://github.com/mui/material-ui/blob/master/packages/mui-codemod/README.md#system-props) below to migrate the code as described in the following section:
 
 ```bash
 npx @mui/codemod@latest v9.0.0/system-props <path/to/folder>

--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -44,11 +44,6 @@ The default bundle targets have changed in v9.
 Since v9 is a new major release, it contains some changes that affect the public API.
 The steps you need to take to migrate from Material UI v7 to v9 are described below.
 
-:::info
-This list is a work in progress.
-Expect updates as new breaking changes are introduced.
-:::
-
 ### Autocomplete
 
 #### Listbox toggle on right click

--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -2,16 +2,16 @@
 
 <p class="description">This guide explains how to upgrade from Material UI v7 to v9.</p>
 
-## Why you should upgrade to Material UI v9
+## Why you should upgrade to Material UI v9
 
 ### Improved accessibility and platform alignment
 
-Material UI v9 continues improving the accessibility and semantics of core components.
+Material UI v9 continues improving the accessibility and semantics of core components.
 This release includes updates to keyboard navigation, focus management, and DOM structure so components align more closely with platform expectations and modern assistive technology behavior.
 
 ### Quality-of-life improvements
 
-Material UI v9 also includes a number of quality-of-life improvements, including:
+Material UI v9 also includes a number of quality-of-life improvements, including:
 
 - removal of deprecated APIs to reduce the API surface and make the docs easier to navigate
 - improved consistency across `slot` and `slotProps` APIs

--- a/docs/data/system/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/system/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -1,35 +1,67 @@
 # Upgrade to v9
 
-<p class="description">This guide explains how to upgrade from MUI System v7 to v9.</p>
+<p class="description">This guide explains how to upgrade from MUI System v7 to v9.</p>
 
-## Start using the alpha release
+## Why you should upgrade to MUI System v9
 
-In the `package.json` file, change the package version from `latest` to `next`.
+### More consistent styling APIs
 
-```diff title="package.json"
--"@mui/system": "latest",
-+"@mui/system": "next",
-```
+MUI System v9 removes deprecated system props in favor of the `sx` prop.
+This reduces the API surface, makes styling behavior more consistent across components, and avoids conflicts with props that should be forwarded to the underlying element.
 
-Using `next` ensures your project always uses the latest v9 pre-releases.
-Alternatively, you can also target and fix it to a specific version, for example, `9.0.0-alpha.0`.
+### Clearer layout primitives
+
+MUI System v9 keeps `Grid` focused on two-dimensional layouts and encourages `Stack` for vertical layouts.
+This makes the layout APIs easier to reason about and aligns them more closely with their intended use cases.
 
 ## Breaking changes
 
 Since v9 is a new major release, it contains some changes that affect the public API.
-The steps you need to take to migrate from MUI System v7 to v9 are described below.
+The steps you need to take to migrate from MUI System v7 to v9 are described below.
 
-:::info
-This list is a work in progress.
-Expect updates as new breaking changes are introduced.
-:::
+### Deprecated system props removed
 
-### Grid
+Use the [system-props codemod](https://github.com/mui/material-ui/blob/master/packages/mui-codemod/README.md#system-props) below to migrate the code as described in the following section:
 
-The Grid component no longer supports system props.
-Use the `sx` prop instead:
+```bash
+npx @mui/codemod@latest v9.0.0/system-props <path/to/folder>
+```
+
+The deprecated system props have been removed from the following components:
+
+- `Box`
+- `Grid`
+- `Stack`
 
 ```diff
+-<Box mt={2} color="primary.main" />
++<Box sx={{ mt: 2, color: 'primary.main' }} />
+
 -<Grid mt={2} mr={1} />
 +<Grid sx={{ mt: 2, mr: 1 }} />
+
+-<Stack mt={2} alignItems="center" />
++<Stack sx={{ mt: 2, alignItems: 'center' }} />
+```
+
+This also fixes an issue where props like `color` could be consumed by the component instead of being forwarded to the element rendered via the `component` prop.
+
+### Grid direction
+
+The `Grid` component no longer supports `direction="column"` or `direction="column-reverse"`.
+`Grid` is designed for two-dimensional layouts organized into columns.
+For vertical layouts, use `Stack` instead.
+
+```diff
+-import Grid from '@mui/system/Grid';
++import Stack from '@mui/system/Stack';
+
+-<Grid container direction="column" spacing={2}>
+-  <Grid>First item</Grid>
+-  <Grid>Second item</Grid>
+-</Grid>
++<Stack spacing={2}>
++  <div>First item</div>
++  <div>Second item</div>
++</Stack>
 ```

--- a/docs/data/system/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/system/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -1,23 +1,23 @@
 # Upgrade to v9
 
-<p class="description">This guide explains how to upgrade from MUI System v7 to v9.</p>
+<p class="description">This guide explains how to upgrade from MUI System v7 to v9.</p>
 
-## Why you should upgrade to MUI System v9
+## Why you should upgrade to MUI System v9
 
 ### More consistent styling APIs
 
-MUI System v9 removes deprecated system props in favor of the `sx` prop.
+MUI System v9 removes deprecated system props in favor of the `sx` prop.
 This reduces the API surface, makes styling behavior more consistent across components, and avoids conflicts with props that should be forwarded to the underlying element.
 
 ### Clearer layout primitives
 
-MUI System v9 keeps `Grid` focused on two-dimensional layouts and encourages `Stack` for vertical layouts.
+MUI System v9 keeps `Grid` focused on two-dimensional layouts and encourages `Stack` for vertical layouts.
 This makes the layout APIs easier to reason about and aligns them more closely with their intended use cases.
 
 ## Breaking changes
 
 Since v9 is a new major release, it contains some changes that affect the public API.
-The steps you need to take to migrate from MUI System v7 to v9 are described below.
+The steps you need to take to migrate from MUI System v7 to v9 are described below.
 
 ### Deprecated system props removed
 


### PR DESCRIPTION
Resolves point 2 in comment https://github.com/mui/material-ui/issues/48224#issuecomment-4209132721.

Material UI:

- Before: https://mui.com/material-ui/migration/upgrade-to-v9/
- After: https://deploy-preview-48245--material-ui.netlify.app/material-ui/migration/upgrade-to-v9/

MUI System
- Before: https://mui.com/system/migration/upgrade-to-v9/
- After: https://deploy-preview-48245--material-ui.netlify.app/system/migration/upgrade-to-v9/