### PR TITLE
[dialog] Fix unwanted `DialogPaper` focus ring

### DIFF
--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -117,6 +117,8 @@ const DialogPaper = styled(Paper, {
     margin: 32,
     position: 'relative',
     overflowY: 'auto',
+    // We disable the focus ring for mouse, touch and keyboard users.
+    outline: 0,
     '@media print': {
       overflowY: 'visible',
       boxShadow: 'none',

--- a/packages/mui-material/src/Dialog/Dialog.test.js
+++ b/packages/mui-material/src/Dialog/Dialog.test.js
@@ -156,6 +156,9 @@ describe('<Dialog />', () => {
     expect(dialog).toHaveFocus();
     expect(dialog.tagName).to.equal('DIV');
     expect(dialog).to.have.attribute('tabindex', '-1');
+    if (!isJsdom()) {
+      expect(dialog).toHaveComputedStyle({ outlineWidth: '0px' });
+    }
   });
 
   it('should focus the Paper element (role="alertdialog") on open', () => {


### PR DESCRIPTION
Preview: https://stackblitz.com/edit/cxdgcqan-xwxuwosp?file=package.json

The issue was that if no dialog content/children took focus (most docs demos set `autoFocus` on some content) the `Paper` itself would retain focus which triggered browser `:focus-visible` styles.

Reported for `v7.x` but also happens with `v9.x`

Fixes https://github.com/mui/material-ui/issues/48531

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
