### PR TITLE
[TextField] Fix Safari outlined notch expansion in flex layouts

### DIFF
--- a/packages/mui-material/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material/src/OutlinedInput/NotchedOutline.js
@@ -70,7 +70,8 @@ const NotchedOutlineLegend = styled('legend', {
       {
         props: ({ ownerState }) => ownerState.withLabel && ownerState.notched,
         style: {
-          maxWidth: '100%',
+          // Safari: avoid percentage max-width on <legend> inside <fieldset> in flex layouts.
+          maxWidth: 'none',
           transition: theme.transitions.create('max-width', {
             duration: 100,
             easing: theme.transitions.easing.easeOut,

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -1261,9 +1261,9 @@ describe('<Select />', () => {
           </Select>,
         );
 
-        expect(container.querySelector('legend')).toHaveComputedStyle({
-          maxWidth: '100%',
-        });
+        expect(container.querySelector('legend').getBoundingClientRect().width).to.be.greaterThan(
+          1,
+        );
       },
     );
   });

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -6,6 +6,7 @@ import FormControl from '@mui/material/FormControl';
 import { inputBaseClasses } from '@mui/material/InputBase';
 import MenuItem from '@mui/material/MenuItem';
 import { outlinedInputClasses } from '@mui/material/OutlinedInput';
+import Stack from '@mui/material/Stack';
 import TextField, { textFieldClasses as classes } from '@mui/material/TextField';
 import describeConformance from '../../test/describeConformance';
 
@@ -221,6 +222,23 @@ describe('<TextField />', () => {
           );
           expect(container1.querySelector('span')).toHaveComputedStyle(spanStyle);
         });
+      },
+    );
+
+    it.skipIf(isJsdom())(
+      'should expand notch when focused inside a Stack layout',
+      function test() {
+        const { container } = render(
+          <Stack spacing={2} sx={{ width: 300 }}>
+            <TextField label="First name" variant="outlined" />
+          </Stack>,
+        );
+
+        const input = screen.getByRole('textbox', { name: 'First name' });
+        fireEvent.focus(input);
+
+        const legend = container.querySelector('fieldset legend');
+        expect(legend.getBoundingClientRect().width).to.be.greaterThan(1);
       },
     );
   });

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -225,22 +225,19 @@ describe('<TextField />', () => {
       },
     );
 
-    it.skipIf(isJsdom())(
-      'should expand notch when focused inside a Stack layout',
-      function test() {
-        const { container } = render(
-          <Stack spacing={2} sx={{ width: 300 }}>
-            <TextField label="First name" variant="outlined" />
-          </Stack>,
-        );
+    it.skipIf(isJsdom())('should expand notch when focused inside a Stack layout', function test() {
+      const { container } = render(
+        <Stack spacing={2} sx={{ width: 300 }}>
+          <TextField label="First name" variant="outlined" />
+        </Stack>,
+      );
 
-        const input = screen.getByRole('textbox', { name: 'First name' });
-        fireEvent.focus(input);
+      const input = screen.getByRole('textbox', { name: 'First name' });
+      fireEvent.focus(input);
 
-        const legend = container.querySelector('fieldset legend');
-        expect(legend.getBoundingClientRect().width).to.be.greaterThan(1);
-      },
-    );
+      const legend = container.querySelector('fieldset legend');
+      expect(legend.getBoundingClientRect().width).to.be.greaterThan(1);
+    });
   });
 
   describe('prop: InputProps', () => {

--- a/test/e2e/fixtures/TextField/OutlinedTextFieldInStack.tsx
+++ b/test/e2e/fixtures/TextField/OutlinedTextFieldInStack.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+
+export default function OutlinedTextFieldInStack() {
+  return (
+    <Stack spacing={2} sx={{ width: 300 }}>
+      <TextField id="outlined-in-stack" label="First name" variant="outlined" />
+    </Stack>
+  );
+}

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -241,6 +241,19 @@ describe('e2e', () => {
       const errorSelector = page.locator('.MuiInputBase-root.Mui-error');
       await errorSelector.waitFor();
     });
+
+    it('should expand the notched outline when focused inside a Stack layout', async () => {
+      await renderFixture('TextField/OutlinedTextFieldInStack');
+
+      const input = page.getByRole('textbox', { name: 'First name' });
+      await input.click();
+
+      const notchWidth = await page
+        .locator('fieldset legend')
+        .evaluate((element) => element.getBoundingClientRect().width);
+
+      expect(notchWidth).toBeGreaterThan(1);
+    });
   });
 
   describe('<Select />', () => {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This fixes a Safari/WebKit rendering bug where the outlined TextField notch fails to expand correctly in flex layouts (commonly reproduced with Stack), causing the floating label to overlap the top border.

The root cause is WebKit’s handling of percentage max-width on legend inside fieldset in this layout scenario.  To my knowledge, this:

* fixes #44988 
* fixes #46891

I updated OutlinedInput notch expansion style to avoid percentage max-width in the notched state ('100%' maxWidth: '100%' → 'none').  Using this approach keeps behavior consistent across browsers while specifically addressing Safari/WebKit and does not rely on any hardcoded values for width and should not change behavior.  

I added a test that reproduces this flex layout scenario and asserts the notch expands on focus.  I also added an e2e test on this scenario.  These tests (and any tests that failed due to this change) now test on behavior, not on a strictly computed style.  I find this makes for more robust tests, but I am happy to change if this is problematic.

