### PR TITLE
[autocomplete] Fix item removal when it receives focus from VoiceOver before using Backspace

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1237,6 +1237,39 @@ describe('<Autocomplete />', () => {
       expect(textbox).toHaveFocus();
     });
 
+    it('should suppress a spurious Backspace on the input immediately after removing a focused chip', async () => {
+      const handleChange = spy();
+      const options = ['one', 'two', 'three'];
+      const { user } = render(
+        <Autocomplete
+          defaultValue={options}
+          options={options}
+          onChange={handleChange}
+          renderInput={(params) => <TextField {...params} autoFocus />}
+          multiple
+        />,
+      );
+      const textbox = screen.getByRole('combobox');
+      const firstSelectedValue = screen.getByRole('button', { name: 'one' });
+
+      await user.keyboard('{ArrowLeft}{ArrowLeft}{ArrowLeft}');
+
+      // Removing the focused chip sets the suppression flag.
+      // Use fireEvent (not user.keyboard) so the setTimeout(0) auto-clear
+      // is not flushed before the next keydown.
+      fireEvent.keyDown(firstSelectedValue, { key: 'Backspace' });
+
+      expect(handleChange.callCount).to.equal(1);
+      expect(textbox).toHaveFocus();
+
+      // Simulate the spurious Backspace VoiceOver synthesises on the input
+      // right after focus returns to it — should be suppressed.
+      fireEvent.keyDown(textbox, { key: 'Backspace' });
+
+      expect(handleChange.callCount).to.equal(1);
+      expect(handleChange.args[0][1]).to.deep.equal(['two', 'three']);
+    });
+
     it('should keep listbox open on pressing left or right keys when inputValue is not empty', () => {
       const handleClose = spy();
       const options = ['one', 'two', 'three'];

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1095,10 +1095,10 @@ describe('<Autocomplete />', () => {
       expect(handleChange.args[0][1]).to.deep.equal([options[0]]);
     });
 
-    it('navigates between different tags', () => {
+    it.only('navigates between different tags', async () => {
       const handleChange = spy();
       const options = ['one', 'two'];
-      render(
+      const { user } = render(
         <Autocomplete
           defaultValue={options}
           options={options}
@@ -1110,22 +1110,22 @@ describe('<Autocomplete />', () => {
       const textbox = screen.getByRole('combobox');
       const [firstSelectedValue, secondSelectedValue] = screen.getAllByRole('button');
 
-      fireEvent.keyDown(textbox, { key: 'ArrowLeft' });
+      await user.keyboard('{ArrowLeft}');
       expect(secondSelectedValue).toHaveFocus();
 
-      fireEvent.keyDown(secondSelectedValue, { key: 'ArrowLeft' });
+      await user.keyboard('{ArrowLeft}');
       expect(firstSelectedValue).toHaveFocus();
 
-      fireEvent.keyDown(firstSelectedValue, { key: 'Backspace' });
+      await user.keyboard('{Backspace}');
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal([options[1]]);
       expect(textbox).toHaveFocus();
     });
 
-    it('deletes a focused tag when pressing the delete key', () => {
+    it.only('deletes a focused tag when pressing the delete key', async () => {
       const handleChange = spy();
       const options = ['one', 'two'];
-      render(
+      const { user } = render(
         <Autocomplete
           defaultValue={options}
           options={options}
@@ -1138,23 +1138,72 @@ describe('<Autocomplete />', () => {
       const [firstSelectedValue, secondSelectedValue] = screen.getAllByRole('button');
 
       // check that no tags get deleted when the tag is not a focused tag
-      fireEvent.keyDown(textbox, { key: 'Delete' });
+      await user.keyboard('{Delete}');
 
       expect(handleChange.callCount).to.equal(0);
       expect(textbox).toHaveFocus();
 
       // expect on focused tag to delete when pressing delete key
-      fireEvent.keyDown(textbox, { key: 'ArrowLeft' });
+      await user.keyboard('{ArrowLeft}');
 
       expect(secondSelectedValue).toHaveFocus();
 
-      fireEvent.keyDown(secondSelectedValue, { key: 'ArrowLeft' });
+      await user.keyboard('{ArrowLeft}');
 
       expect(firstSelectedValue).toHaveFocus();
 
-      fireEvent.keyDown(firstSelectedValue, { key: 'Delete' });
+      await user.keyboard('{Delete}');
+      expect(handleChange.callCount).to.equal(1);
+      expect(textbox).toHaveFocus();
+    });
+
+    it.only('should remove only the focused chip when pressing the delete key', async () => {
+      const handleChange = spy();
+      const options = ['one', 'two', 'three'];
+      const { user } = render(
+        <Autocomplete
+          defaultValue={options}
+          options={options}
+          onChange={handleChange}
+          renderInput={(params) => <TextField {...params} />}
+          multiple
+        />,
+      );
+      const textbox = screen.getByRole('combobox');
+      const firstSelectedValue = screen.getByRole('button', { name: 'one' });
+
+      act(() => {
+        firstSelectedValue.focus();
+      });
+      await user.keyboard('{Delete}');
 
       expect(handleChange.callCount).to.equal(1);
+      expect(handleChange.args[0][1]).to.deep.equal(['two', 'three']);
+      expect(textbox).toHaveFocus();
+    });
+
+    it.only('should remove only the focused chip when pressing the backspace key', async () => {
+      const handleChange = spy();
+      const options = ['one', 'two', 'three'];
+      const { user } = render(
+        <Autocomplete
+          defaultValue={options}
+          options={options}
+          onChange={handleChange}
+          renderInput={(params) => <TextField {...params} />}
+          multiple
+        />,
+      );
+      const textbox = screen.getByRole('combobox');
+      const firstSelectedValue = screen.getByRole('button', { name: 'one' });
+
+      act(() => {
+        firstSelectedValue.focus();
+      });
+      await user.keyboard('{Backspace}');
+
+      expect(handleChange.callCount).to.equal(1);
+      expect(handleChange.args[0][1]).to.deep.equal(['two', 'three']);
       expect(textbox).toHaveFocus();
     });
 

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1154,6 +1154,36 @@ describe('<Autocomplete />', () => {
 
       await user.keyboard('{Delete}');
       expect(handleChange.callCount).to.equal(1);
+      expect(handleChange.args[0][1]).to.deep.equal([options[1]]);
+      expect(textbox).toHaveFocus();
+    });
+
+    it('can delete one tag after another', async () => {
+      const handleChange = spy();
+      const options = ['one', 'two'];
+      const { user } = render(
+        <Autocomplete
+          defaultValue={options}
+          options={options}
+          onChange={handleChange}
+          renderInput={(params) => <TextField {...params} autoFocus />}
+          multiple
+        />,
+      );
+      const textbox = screen.getByRole('combobox');
+
+      await user.keyboard('{ArrowLeft}');
+      await user.keyboard('{Backspace}');
+
+      expect(handleChange.callCount).to.equal(1);
+      expect(handleChange.args[0][1]).to.deep.equal([options[0]]);
+      expect(textbox).toHaveFocus();
+
+      await user.keyboard('{ArrowLeft}');
+      await user.keyboard('{Backspace}');
+
+      expect(handleChange.callCount).to.equal(2);
+      expect(handleChange.args[1][1]).to.deep.equal([]);
       expect(textbox).toHaveFocus();
     });
 

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1157,7 +1157,7 @@ describe('<Autocomplete />', () => {
       expect(textbox).toHaveFocus();
     });
 
-    it.only('should remove only the focused chip when pressing the delete key', async () => {
+    it('should remove only the focused chip when pressing the delete key', async () => {
       const handleChange = spy();
       const options = ['one', 'two', 'three'];
       const { user } = render(
@@ -1182,7 +1182,7 @@ describe('<Autocomplete />', () => {
       expect(textbox).toHaveFocus();
     });
 
-    it.only('should remove only the focused chip when pressing the backspace key', async () => {
+    it('should remove only the focused chip when pressing the backspace key', async () => {
       const handleChange = spy();
       const options = ['one', 'two', 'three'];
       const { user } = render(

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1095,7 +1095,7 @@ describe('<Autocomplete />', () => {
       expect(handleChange.args[0][1]).to.deep.equal([options[0]]);
     });
 
-    it.only('navigates between different tags', async () => {
+    it('navigates between different tags', async () => {
       const handleChange = spy();
       const options = ['one', 'two'];
       const { user } = render(
@@ -1122,7 +1122,7 @@ describe('<Autocomplete />', () => {
       expect(textbox).toHaveFocus();
     });
 
-    it.only('deletes a focused tag when pressing the delete key', async () => {
+    it('deletes a focused tag when pressing the delete key', async () => {
       const handleChange = spy();
       const options = ['one', 'two'];
       const { user } = render(

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -151,6 +151,11 @@ function useAutocomplete(props) {
   const firstFocus = React.useRef(true);
   const inputRef = React.useRef(null);
   const listboxRef = React.useRef(null);
+  // When a chip has DOM focus and the user presses Backspace/Delete, handleKeyDown
+  // performs the deletion (focusedItem is the chip index in that closure) and then
+  // moves DOM focus back to the input. VoiceOver synthesises a spurious Backspace on
+  // the input immediately after — this flag suppresses that one synthetic event.
+  const ignoreNextBackspaceRef = React.useRef(false);
   const windowLostFocus = React.useRef(false);
   const [anchorEl, setAnchorEl] = React.useState(null);
 
@@ -1074,6 +1079,10 @@ function useAutocomplete(props) {
           break;
         case 'Backspace':
           // Remove the value on the left of the "cursor"
+          if (ignoreNextBackspaceRef.current) {
+            ignoreNextBackspaceRef.current = false;
+            break;
+          }
           if (multiple && !readOnly && inputValue === '' && value.length > 0) {
             const index = focusedItem === -1 ? value.length - 1 : focusedItem;
             const newValue = value.slice();
@@ -1081,6 +1090,13 @@ function useAutocomplete(props) {
             handleValue(event, newValue, 'removeOption', {
               option: value[index],
             });
+            // focusedItem is read from the current render's closure. When the
+            // deletion was triggered while a chip had DOM focus (focusedItem !== -1),
+            // VoiceOver fires a synthetic Backspace on the input after returning
+            // focus to it. Set the flag so that spurious event is skipped.
+            if (focusedItem !== -1) {
+              ignoreNextBackspaceRef.current = true;
+            }
           }
           if (!multiple && renderValue && !readOnly && inputValue === '') {
             handleValue(event, null, 'removeOption', { option: value });
@@ -1418,6 +1434,12 @@ function useAutocomplete(props) {
       ...(multiple && { key: index }),
       'data-item-index': index,
       tabIndex: -1,
+      onFocus: () => {
+        // If focus on the item comes not from keyboard events, we update the state via onFocus.
+        if (focusedItem !== index) {
+          setFocusedItem(index);
+        }
+      },
       ...(!readOnly && { onDelete: multiple ? handleItemDelete(index) : handleSingleItemDelete }),
     }),
     getPopupIndicatorProps: () => ({

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -153,7 +153,6 @@ function useAutocomplete(props) {
   const listboxRef = React.useRef(null);
   // VoiceOver synthesises a spurious Backspace on the input after a chip
   // deletion moves DOM focus back to it. This flag suppresses that one event.
-  // It is cleared on the next non-Backspace key or when focus moves to a chip.
   const ignoreNextBackspaceRef = React.useRef(false);
   const windowLostFocus = React.useRef(false);
   const [anchorEl, setAnchorEl] = React.useState(null);
@@ -918,12 +917,6 @@ function useAutocomplete(props) {
       focusItem(-1);
     }
 
-    // Any key other than Backspace proves the VoiceOver spurious event already
-    // fired (or won't), so the suppression flag can be safely cleared.
-    if (event.key !== 'Backspace') {
-      ignoreNextBackspaceRef.current = false;
-    }
-
     // Wait until IME is settled.
     if (event.which !== 229) {
       switch (event.key) {
@@ -1097,9 +1090,15 @@ function useAutocomplete(props) {
             });
             if (focusedItem !== -1) {
               // Suppress the spurious Backspace VoiceOver synthesises on the
-              // input after focus returns to it. Cleared on the next non-Backspace
-              // key or when focus moves to another chip (see getItemProps.onFocus).
+              // input after focus returns to it. Clear it on shortly after
+              // deletion so a later real Backspace is not ignored if the
+              // synthetic follow-up event never arrives.
               ignoreNextBackspaceRef.current = true;
+              setTimeout(() => {
+                if (ignoreNextBackspaceRef.current) {
+                  ignoreNextBackspaceRef.current = false;
+                }
+              }, 0);
             }
           }
           if (!multiple && renderValue && !readOnly && inputValue === '') {
@@ -1439,7 +1438,7 @@ function useAutocomplete(props) {
       'data-item-index': index,
       tabIndex: -1,
       onFocus: () => {
-        // If focus on the item comes not from keyboard events, we update the state via onFocus.
+        // If focus on the item doesn't come from keyboard events, we update the state via onFocus.
         if (focusedItem !== index) {
           setFocusedItem(index);
         }

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -151,10 +151,9 @@ function useAutocomplete(props) {
   const firstFocus = React.useRef(true);
   const inputRef = React.useRef(null);
   const listboxRef = React.useRef(null);
-  // When a chip has DOM focus and the user presses Backspace/Delete, handleKeyDown
-  // performs the deletion (focusedItem is the chip index in that closure) and then
-  // moves DOM focus back to the input. VoiceOver synthesises a spurious Backspace on
-  // the input immediately after — this flag suppresses that one synthetic event.
+  // VoiceOver synthesises a spurious Backspace on the input after a chip
+  // deletion moves DOM focus back to it. This flag suppresses that one event.
+  // It is cleared on the next non-Backspace key or when focus moves to a chip.
   const ignoreNextBackspaceRef = React.useRef(false);
   const windowLostFocus = React.useRef(false);
   const [anchorEl, setAnchorEl] = React.useState(null);
@@ -919,6 +918,12 @@ function useAutocomplete(props) {
       focusItem(-1);
     }
 
+    // Any key other than Backspace proves the VoiceOver spurious event already
+    // fired (or won't), so the suppression flag can be safely cleared.
+    if (event.key !== 'Backspace') {
+      ignoreNextBackspaceRef.current = false;
+    }
+
     // Wait until IME is settled.
     if (event.which !== 229) {
       switch (event.key) {
@@ -1090,11 +1095,10 @@ function useAutocomplete(props) {
             handleValue(event, newValue, 'removeOption', {
               option: value[index],
             });
-            // focusedItem is read from the current render's closure. When the
-            // deletion was triggered while a chip had DOM focus (focusedItem !== -1),
-            // VoiceOver fires a synthetic Backspace on the input after returning
-            // focus to it. Set the flag so that spurious event is skipped.
             if (focusedItem !== -1) {
+              // Suppress the spurious Backspace VoiceOver synthesises on the
+              // input after focus returns to it. Cleared on the next non-Backspace
+              // key or when focus moves to another chip (see getItemProps.onFocus).
               ignoreNextBackspaceRef.current = true;
             }
           }

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -1090,7 +1090,7 @@ function useAutocomplete(props) {
             });
             if (focusedItem !== -1) {
               // Suppress the spurious Backspace VoiceOver synthesises on the
-              // input after focus returns to it. Clear it on shortly after
+              // input after focus returns to it. Clear it shortly after
               // deletion so a later real Backspace is not ignored if the
               // synthetic follow-up event never arrives.
               ignoreNextBackspaceRef.current = true;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

When focus on the selected items, in a multiple selection autocomplete, comes from a non native keyboard event, we are not updating the state with the focused item. In the issue case, the focus comes from VoiceOver navigation. Also, VoiceOver is sending another Backspace event on the `input` immediately after it sent one to the `Chip`.

Consequently, instead of deleting the one focused item, we were deleting 3 items: focused one (actually a Chip delete handler), and 2 from the end, one because focusedItem was -1 (not updating according to VoiceOver focus) and one because of the extra `input` backspace event.

Fixes:
- on item focus, sync the focusedItem state.
- when we delete a chip with backspace, keep the deletion information in ref, and when the second Backspace event on the `input` happens, exit and restore the ref info. This is not ideal, but I can't figure anything better.

Added tests for the focusedItem sync only. The second case, related to VoiceOver sending another Backspace event on top of the Chip one, is impossible to unit test.

Fixes https://github.com/mui/material-ui/issues/44936


