### PR TITLE
[docs] Remove outdated MUI X v8 notification

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -1,10 +1,5 @@
 [
   {
-    "id": 88,
-    "title": "Introducing MUI X v8",
-    "text": "Powerful new features and highly requested new components. Read the full details in the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-v8\" href=\"https://mui.com/blog/mui-x-v8/\">MUI X v8 announcement blog post</a>."
-  },
-  {
     "id": 89,
     "title": "Material UI and MUI X v9 are here",
     "text": "Unified major versions, new components, improved accessibility and much more. Read the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"material-ui-v9\" href=\"https://mui.com/blog/introducing-mui-v9/\">announcement blog post</a>."


### PR DESCRIPTION
Reported in https://mui-org.slack.com/archives/C011VC970AW/p1780184972185529

<img width="343" height="422" src="https://github.com/user-attachments/assets/fcad0836-adfc-432a-b60a-ce2eb9910265" />
