### PR TITLE
[breaking change][textarea] Move padding from wrapper to actual element

### DIFF
--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -166,34 +166,6 @@ const FilledInputRoot = styled(InputBaseRoot, {
             paddingRight: 12,
           },
         },
-        {
-          props: ({ ownerState }) => ownerState.multiline,
-          style: {
-            padding: '25px 12px 8px',
-          },
-        },
-        {
-          props: ({ ownerState, size }) => ownerState.multiline && size === 'small',
-          style: {
-            paddingTop: 21,
-            paddingBottom: 4,
-          },
-        },
-        {
-          props: ({ ownerState }) => ownerState.multiline && ownerState.hiddenLabel,
-          style: {
-            paddingTop: 16,
-            paddingBottom: 17,
-          },
-        },
-        {
-          props: ({ ownerState }) =>
-            ownerState.multiline && ownerState.hiddenLabel && ownerState.size === 'small',
-          style: {
-            paddingTop: 8,
-            paddingBottom: 9,
-          },
-        },
       ],
     };
   }),
@@ -258,15 +230,6 @@ const FilledInputInput = styled(InputBaseInput, {
         style: {
           paddingTop: 8,
           paddingBottom: 9,
-        },
-      },
-      {
-        props: ({ ownerState }) => ownerState.multiline,
-        style: {
-          paddingTop: 0,
-          paddingBottom: 0,
-          paddingLeft: 0,
-          paddingRight: 0,
         },
       },
     ],

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -111,18 +111,6 @@ export const InputBaseRoot = styled('div', {
     },
     variants: [
       {
-        props: ({ ownerState }) => ownerState.multiline,
-        style: {
-          padding: '4px 0 5px',
-        },
-      },
-      {
-        props: ({ ownerState, size }) => ownerState.multiline && size === 'small',
-        style: {
-          paddingTop: 1,
-        },
-      },
-      {
         props: ({ ownerState }) => ownerState.fullWidth,
         style: {
           width: '100%',
@@ -230,8 +218,6 @@ export const InputBaseInput = styled('input', {
           style: {
             height: 'auto',
             resize: 'none',
-            padding: 0,
-            paddingTop: 0,
           },
         },
         {

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -96,18 +96,6 @@ const OutlinedInputRoot = styled(InputBaseRoot, {
             paddingRight: 14,
           },
         },
-        {
-          props: ({ ownerState }) => ownerState.multiline,
-          style: {
-            padding: '16.5px 14px',
-          },
-        },
-        {
-          props: ({ ownerState, size }) => ownerState.multiline && size === 'small',
-          style: {
-            padding: '8.5px 14px',
-          },
-        },
       ],
     };
   }),
@@ -156,12 +144,6 @@ const OutlinedInputInput = styled(InputBaseInput, {
         },
         style: {
           padding: '8.5px 14px',
-        },
-      },
-      {
-        props: ({ ownerState }) => ownerState.multiline,
-        style: {
-          padding: 0,
         },
       },
       {

--- a/test/regressions/fixtures/Textarea/Textarea.js
+++ b/test/regressions/fixtures/Textarea/Textarea.js
@@ -19,6 +19,10 @@ function Textarea() {
             fontSize: 13,
             boxSizing: 'border-box',
             border: '10px solid black',
+            padding: 0,
+          },
+          '&.MuiInput-root': {
+            padding: '4px 0 5px',
           },
         }}
         multiline
@@ -29,6 +33,9 @@ function Textarea() {
         sx={{
           width: 200,
           '& .MuiInput-input': { fontSize: 13, boxSizing: 'content-box', padding: '10px' },
+          '&.MuiInput-root': {
+            padding: '4px 0 5px',
+          },
         }}
         multiline
         value={value}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Moves the padding from the wrapper to the `<textarea>`, in the `multiline` case. The reason is that, when user was starting a selection from the edge of the textarea, it could also select outside text, which is not correct. Adding the padding to the textarea makes the selection consider that it started from the textarea element, and won't allow selection outside the element.

To test:
- for any textarea version (outlined, standard, filled), start a selection using pointer from the edge of the textarea, and try to select outside text. it should only select textarea value.
- no regressions for textareas, regardless of the variant: outlined, standard, filled, small, maxrows, minrows.

BREAKING CHANGE: This change might affect user's customizations, if they rely on the fact that the padding value was on the container, and now it's on the textarea. Consequently, we should merge this in a major, and have a Changelog entry for it.

Fixes https://github.com/mui/material-ui/issues/23928