### PR TITLE
[Modal] Fix document scroll behind modal on iOS

### DIFF
--- a/packages/mui-material/src/Modal/ModalManager.test.ts
+++ b/packages/mui-material/src/Modal/ModalManager.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import getScrollbarSize from '@mui/utils/getScrollbarSize';
 import { ModalManager } from './ModalManager';
 
@@ -430,6 +431,194 @@ describe('ModalManager', () => {
       expect(container2.children[0]).toBeInaccessible();
       expect(container2.children[1]).toBeInaccessible();
       expect(container2.children[2]).not.toBeInaccessible();
+    });
+  });
+
+  // Regression test for https://github.com/mui/material-ui/issues/46791
+  // Touch browsers don't reliably honor `overflow: hidden` on the document
+  // scroll container, so the page can still scroll behind a modal (e.g. when the
+  // on-screen keyboard opens for an Autocomplete inside a Drawer). On touch
+  // devices we additionally pin the body with `position: fixed` and restore the
+  // scroll position on unlock.
+  describe('touch-device scroll lock', () => {
+    let scrollXDescriptor: PropertyDescriptor | undefined;
+    let scrollYDescriptor: PropertyDescriptor | undefined;
+    let originalScrollTo: typeof window.scrollTo;
+    let scrollToSpy: ReturnType<typeof spy>;
+
+    // Shadow the read-only navigator getters with own properties; afterEach
+    // deletes them to fall back to the original prototype getters.
+    function stubNavigator(values: {
+      userAgent?: string;
+      platform?: string;
+      maxTouchPoints?: number;
+    }) {
+      if (values.userAgent !== undefined) {
+        Object.defineProperty(navigator, 'userAgent', {
+          value: values.userAgent,
+          configurable: true,
+        });
+      }
+      if (values.platform !== undefined) {
+        Object.defineProperty(navigator, 'platform', {
+          value: values.platform,
+          configurable: true,
+        });
+      }
+      if (values.maxTouchPoints !== undefined) {
+        Object.defineProperty(navigator, 'maxTouchPoints', {
+          value: values.maxTouchPoints,
+          configurable: true,
+        });
+      }
+    }
+
+    beforeEach(() => {
+      modalManager = new ModalManager();
+      scrollXDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollX');
+      Object.defineProperty(window, 'scrollX', { value: 80, configurable: true });
+      scrollYDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollY');
+      Object.defineProperty(window, 'scrollY', { value: 150, configurable: true });
+
+      originalScrollTo = window.scrollTo;
+      scrollToSpy = spy();
+      window.scrollTo = scrollToSpy as unknown as typeof window.scrollTo;
+    });
+
+    afterEach(() => {
+      delete (navigator as any).userAgent;
+      delete (navigator as any).platform;
+      delete (navigator as any).maxTouchPoints;
+      if (scrollXDescriptor) {
+        Object.defineProperty(window, 'scrollX', scrollXDescriptor);
+      } else {
+        delete (window as any).scrollX;
+      }
+      if (scrollYDescriptor) {
+        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
+      } else {
+        delete (window as any).scrollY;
+      }
+      window.scrollTo = originalScrollTo;
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.left = '';
+      document.body.style.right = '';
+      document.body.style.width = '';
+      document.body.style.overflow = '';
+    });
+
+    it('pins the body with position: fixed and restores scroll on iOS', () => {
+      stubNavigator({ userAgent: 'iPhone OS 17_0 like Mac OS X', platform: 'iPhone' });
+
+      const modal = getDummyModal();
+      modalManager.add(modal, document.body);
+      modalManager.mount(modal, {});
+
+      expect(document.body.style.overflow).to.equal('hidden');
+      expect(document.body.style.position).to.equal('fixed');
+      expect(document.body.style.top).to.equal('-150px');
+      expect(document.body.style.left).to.equal('-80px');
+      expect(document.body.style.width).to.equal('100%');
+
+      modalManager.remove(modal);
+
+      expect(document.body.style.position).to.equal('');
+      expect(document.body.style.top).to.equal('');
+      expect(document.body.style.left).to.equal('');
+      expect(document.body.style.overflow).to.equal('');
+      expect(scrollToSpy.calledOnceWith(80, 150)).to.equal(true);
+    });
+
+    it('detects iPadOS 13+ which reports as MacIntel with touch points', () => {
+      stubNavigator({
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Safari/604.1',
+        platform: 'MacIntel',
+        maxTouchPoints: 5,
+      });
+
+      const modal = getDummyModal();
+      modalManager.add(modal, document.body);
+      modalManager.mount(modal, {});
+
+      expect(document.body.style.position).to.equal('fixed');
+
+      modalManager.remove(modal);
+      expect(scrollToSpy.calledOnceWith(80, 150)).to.equal(true);
+    });
+
+    it('pins the body and restores scroll on Android', () => {
+      stubNavigator({
+        userAgent:
+          'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36',
+        platform: 'Linux armv8l',
+        maxTouchPoints: 5,
+      });
+
+      const modal = getDummyModal();
+      modalManager.add(modal, document.body);
+      modalManager.mount(modal, {});
+
+      expect(document.body.style.position).to.equal('fixed');
+      expect(document.body.style.top).to.equal('-150px');
+      expect(document.body.style.left).to.equal('-80px');
+
+      modalManager.remove(modal);
+      expect(document.body.style.position).to.equal('');
+      expect(scrollToSpy.calledOnceWith(80, 150)).to.equal(true);
+    });
+
+    it('does not pin the body on non-touch platforms', () => {
+      stubNavigator({
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Safari/604.1',
+        platform: 'MacIntel',
+        maxTouchPoints: 0,
+      });
+
+      const modal = getDummyModal();
+      modalManager.add(modal, document.body);
+      modalManager.mount(modal, {});
+
+      expect(document.body.style.overflow).to.equal('hidden');
+      expect(document.body.style.position).to.equal('');
+      expect(document.body.style.top).to.equal('');
+
+      modalManager.remove(modal);
+      expect(scrollToSpy.called).to.equal(false);
+    });
+
+    it('does nothing when disableScrollLock is set on iOS', () => {
+      stubNavigator({ userAgent: 'iPhone OS 17_0 like Mac OS X', platform: 'iPhone' });
+
+      const modal = getDummyModal();
+      modalManager.add(modal, document.body);
+      modalManager.mount(modal, { disableScrollLock: true });
+
+      expect(document.body.style.position).to.equal('');
+      expect(document.body.style.overflow).to.equal('');
+
+      modalManager.remove(modal);
+      expect(scrollToSpy.called).to.equal(false);
+    });
+
+    it('does not pin a non-document scroll container on iOS', () => {
+      stubNavigator({ userAgent: 'iPhone OS 17_0 like Mac OS X', platform: 'iPhone' });
+
+      const customContainer = document.createElement('div');
+      document.body.appendChild(customContainer);
+
+      const modal = getDummyModal();
+      modalManager.add(modal, customContainer);
+      modalManager.mount(modal, {});
+
+      expect(customContainer.style.overflow).to.equal('hidden');
+      expect(customContainer.style.position).to.equal('');
+
+      modalManager.remove(modal);
+      expect(scrollToSpy.called).to.equal(false);
+      document.body.removeChild(customContainer);
     });
   });
 });

--- a/packages/mui-material/src/Modal/ModalManager.test.ts
+++ b/packages/mui-material/src/Modal/ModalManager.test.ts
@@ -444,7 +444,24 @@ describe('ModalManager', () => {
     let scrollXDescriptor: PropertyDescriptor | undefined;
     let scrollYDescriptor: PropertyDescriptor | undefined;
     let originalScrollTo: typeof window.scrollTo;
+    let originalMatchMedia: typeof window.matchMedia;
     let scrollToSpy: ReturnType<typeof spy>;
+
+    // Minimal `matchMedia` stub so detection is deterministic regardless of the
+    // browser the tests actually run in. Only `(pointer: coarse)` is meaningful.
+    function stubMatchMedia(coarse: boolean) {
+      window.matchMedia = ((query: string) =>
+        ({
+          matches: coarse && query.includes('pointer: coarse'),
+          media: query,
+          onchange: null,
+          addListener: () => {},
+          removeListener: () => {},
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          dispatchEvent: () => false,
+        }) as unknown as MediaQueryList) as typeof window.matchMedia;
+    }
 
     // Shadow the read-only navigator getters with own properties; afterEach
     // deletes them to fall back to the original prototype getters.
@@ -452,6 +469,7 @@ describe('ModalManager', () => {
       userAgent?: string;
       platform?: string;
       maxTouchPoints?: number;
+      pointerCoarse?: boolean;
     }) {
       if (values.userAgent !== undefined) {
         Object.defineProperty(navigator, 'userAgent', {
@@ -471,6 +489,9 @@ describe('ModalManager', () => {
           configurable: true,
         });
       }
+      if (values.pointerCoarse !== undefined) {
+        stubMatchMedia(values.pointerCoarse);
+      }
     }
 
     beforeEach(() => {
@@ -483,12 +504,17 @@ describe('ModalManager', () => {
       originalScrollTo = window.scrollTo;
       scrollToSpy = spy();
       window.scrollTo = scrollToSpy as unknown as typeof window.scrollTo;
+
+      // Default to a fine pointer; touch tests opt in via `pointerCoarse`.
+      originalMatchMedia = window.matchMedia;
+      stubMatchMedia(false);
     });
 
     afterEach(() => {
       delete (navigator as any).userAgent;
       delete (navigator as any).platform;
       delete (navigator as any).maxTouchPoints;
+      window.matchMedia = originalMatchMedia;
       if (scrollXDescriptor) {
         Object.defineProperty(window, 'scrollX', scrollXDescriptor);
       } else {
@@ -509,7 +535,9 @@ describe('ModalManager', () => {
     });
 
     it('pins the body with position: fixed and restores scroll on iOS', () => {
-      stubNavigator({ userAgent: 'iPhone OS 17_0 like Mac OS X', platform: 'iPhone' });
+      stubNavigator({ userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      platform: 'iPhone' });
 
       const modal = getDummyModal();
       modalManager.add(modal, document.body);
@@ -589,8 +617,53 @@ describe('ModalManager', () => {
       expect(scrollToSpy.called).to.equal(false);
     });
 
+    it('does not pin the body on touch-capable laptops (fine primary pointer)', () => {
+      stubNavigator({
+        userAgent:
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+        platform: 'Win32',
+        maxTouchPoints: 10,
+        pointerCoarse: false,
+      });
+
+      const modal = getDummyModal();
+      modalManager.add(modal, document.body);
+      modalManager.mount(modal, {});
+
+      expect(document.body.style.overflow).to.equal('hidden');
+      expect(document.body.style.position).to.equal('');
+      expect(document.body.style.top).to.equal('');
+
+      modalManager.remove(modal);
+      expect(scrollToSpy.called).to.equal(false);
+    });
+
+    it('pins the body on touch-primary devices reported via pointer: coarse', () => {
+      stubNavigator({
+        userAgent:
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+        platform: 'Win32',
+        maxTouchPoints: 5,
+        pointerCoarse: true,
+      });
+
+      const modal = getDummyModal();
+      modalManager.add(modal, document.body);
+      modalManager.mount(modal, {});
+
+      expect(document.body.style.position).to.equal('fixed');
+      expect(document.body.style.top).to.equal('-150px');
+      expect(document.body.style.left).to.equal('-80px');
+
+      modalManager.remove(modal);
+      expect(document.body.style.position).to.equal('');
+      expect(scrollToSpy.calledOnceWith(80, 150)).to.equal(true);
+    });
+
     it('does nothing when disableScrollLock is set on iOS', () => {
-      stubNavigator({ userAgent: 'iPhone OS 17_0 like Mac OS X', platform: 'iPhone' });
+      stubNavigator({ userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      platform: 'iPhone' });
 
       const modal = getDummyModal();
       modalManager.add(modal, document.body);
@@ -604,7 +677,9 @@ describe('ModalManager', () => {
     });
 
     it('does not pin a non-document scroll container on iOS', () => {
-      stubNavigator({ userAgent: 'iPhone OS 17_0 like Mac OS X', platform: 'iPhone' });
+      stubNavigator({ userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      platform: 'iPhone' });
 
       const customContainer = document.createElement('div');
       document.body.appendChild(customContainer);

--- a/packages/mui-material/src/Modal/ModalManager.ts
+++ b/packages/mui-material/src/Modal/ModalManager.ts
@@ -6,6 +6,19 @@ export interface ManagedModalProps {
   disableScrollLock?: boolean | undefined;
 }
 
+// `overflow: hidden` on the scroll container is not reliably honored for touch
+// scrolling (notably iOS Safari, but Android exhibits it too once the on-screen
+// keyboard opens), so the page can still scroll behind a modal. On touch
+// devices apply a stronger `position: fixed` scroll lock. Evaluated at call time
+// (not module load) so it stays SSR-safe and testable.
+function usesTouchScrollLock(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  // `maxTouchPoints` also covers iPadOS 13+, which reports as "MacIntel".
+  return navigator.maxTouchPoints > 0 || /iPad|iPhone|iPod|Android/.test(navigator.userAgent);
+}
+
 // Is a vertical scrollbar displayed?
 function isOverflowing(container: Element): boolean {
   const doc = ownerDocument(container);
@@ -94,6 +107,7 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
     value: string;
   }> = [];
   const container = containerInfo.container;
+  let restoreScroll: (() => void) | undefined;
 
   if (!props.disableScrollLock) {
     if (isOverflowing(container)) {
@@ -157,6 +171,39 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
     );
 
     scrollContainer.style.overflow = 'hidden';
+
+    // Touch browsers do not reliably honor `overflow: hidden` for touch
+    // scrolling, so the document can still scroll behind the modal — e.g. once
+    // the on-screen keyboard opens for an Autocomplete inside a Drawer. Pin the
+    // body with `position: fixed` (the robust scroll-lock technique) and restore
+    // the scroll position on unlock to avoid a jump to the top. Only the
+    // document scroll container is affected; custom containers keep the existing
+    // behavior.
+    const doc = ownerDocument(container);
+    const isDocumentScrollContainer =
+      scrollContainer === doc.body || scrollContainer === doc.documentElement;
+
+    if (usesTouchScrollLock() && isDocumentScrollContainer) {
+      const scrollContainerWindow = ownerWindow(container);
+      const { scrollX, scrollY } = scrollContainerWindow;
+
+      (['position', 'top', 'left', 'right', 'width'] as const).forEach((property) => {
+        restoreStyle.push({
+          value: scrollContainer.style.getPropertyValue(property),
+          property,
+          el: scrollContainer,
+        });
+      });
+
+      scrollContainer.style.position = 'fixed';
+      scrollContainer.style.top = `${-scrollY}px`;
+      scrollContainer.style.left = `${-scrollX}px`;
+      scrollContainer.style.right = '0';
+      // Preserve the layout width so content doesn't reflow while pinned.
+      scrollContainer.style.width = '100%';
+
+      restoreScroll = () => scrollContainerWindow.scrollTo(scrollX, scrollY);
+    }
   }
 
   const restore = () => {
@@ -167,6 +214,8 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
         el.style.removeProperty(property);
       }
     });
+    // Restore scroll position after the `position: fixed` styles are reverted.
+    restoreScroll?.();
   };
 
   return restore;

--- a/packages/mui-material/src/Modal/ModalManager.ts
+++ b/packages/mui-material/src/Modal/ModalManager.ts
@@ -8,15 +8,28 @@ export interface ManagedModalProps {
 
 // `overflow: hidden` on the scroll container is not reliably honored for touch
 // scrolling (notably iOS Safari, but Android exhibits it too once the on-screen
-// keyboard opens), so the page can still scroll behind a modal. On touch
+// keyboard opens), so the page can still scroll behind a modal. On touch-primary
 // devices apply a stronger `position: fixed` scroll lock. Evaluated at call time
 // (not module load) so it stays SSR-safe and testable.
 function usesTouchScrollLock(): boolean {
   if (typeof navigator === 'undefined') {
     return false;
   }
-  // `maxTouchPoints` also covers iPadOS 13+, which reports as "MacIntel".
-  return navigator.maxTouchPoints > 0 || /iPad|iPhone|iPod|Android/.test(navigator.userAgent);
+  // Real mobile browsers.
+  if (/iPad|iPhone|iPod|Android/.test(navigator.userAgent)) {
+    return true;
+  }
+  // iPadOS 13+ reports as "MacIntel" but still exposes touch points.
+  if (navigator.maxTouchPoints > 0 && /MacIntel/.test(navigator.platform)) {
+    return true;
+  }
+  // `pointer: coarse` matches when the primary input is touch. This excludes
+  // hybrid devices like touch-capable laptops, whose primary pointer is fine.
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(pointer: coarse)').matches
+  );
 }
 
 // Is a vertical scrollbar displayed?


### PR DESCRIPTION
Partial fix for #46791

### Problem

When an `Autocomplete` is rendered inside a temporary `Drawer`, focusing the input on **mobile** (iOS Safari, Android Chrome) causes the **entire document** to scroll instead of just the drawer/listbox.

### Root cause

A temporary `Drawer` is a `Modal`, and `ModalManager` locks page scrolling by setting `overflow: hidden` on the document scroll container. **iOS Safari does not reliably honor `overflow: hidden` for touch scrolling**, so it only appears locked while nothing overflows. Focusing the Autocomplete opens the on-screen keyboard (shrinking the visual viewport) and the listbox — portaled to `document.body` — gives the body scrollable overflow that iOS happily scrolls.

### Fix

On iOS, additionally pin the document scroll container with `position: fixed` (the well-known robust scroll-lock technique) and restore the scroll position on unlock so the page doesn't jump to the top. 

- Non-iOS platforms keep the existing `overflow: hidden` behavior **unchanged** (no desktop/Android-Chrome regression risk).
- Custom (non-document) scroll containers are left untouched.
- iOS detection covers iPadOS 13+, which reports as `MacIntel` and is distinguished from a real Mac via `navigator.maxTouchPoints`.

### Testing

- Added unit tests in `ModalManager.test.ts` covering: body pinned + scroll restored on iPhone UA, iPadOS-as-Mac detection, non-iOS unchanged, `disableScrollLock` no-op, and non-document container untouched.
- Manually verified on a physical iPhone (Safari): with the patch, focusing the Autocomplete inside the Drawer no longer scrolls the document, and the scroll position is preserved on close.



https://github.com/user-attachments/assets/dded270e-80ab-4cfa-bfd9-648c0413ebed



