### PR TITLE
[tooltip] Fix onOpen/onClose callback not firing due to stale state in React 18 batching

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -280,6 +280,10 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   });
 
   let open = openState;
+  const openRef = React.useRef(open);
+  React.useLayoutEffect(() => {
+    openRef.current = open;
+  });
 
   if (process.env.NODE_ENV !== 'production') {
     // TODO: uncomment once we enable eslint-plugin-react-compiler // eslint-disable-next-line react-compiler/react-compiler
@@ -329,9 +333,11 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     // The mouseover event will trigger for every nested element in the tooltip.
     // We can skip rerendering when the tooltip is already open.
     // We are using the mouseover event instead of the mouseenter event to fix a hide/show issue.
+    const wasOpen = openRef.current;
+    openRef.current = true;
     setOpenState(true);
 
-    if (onOpen && !open) {
+    if (onOpen && !wasOpen) {
       onOpen(event);
     }
   };
@@ -341,12 +347,14 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
      * @param {React.SyntheticEvent | Event} event
      */
     (event) => {
+      const wasOpen = openRef.current;
       hystersisTimer.start(800 + leaveDelay, () => {
         hystersisOpen = false;
       });
       setOpenState(false);
+      openRef.current = false;
 
-      if (onClose && open) {
+      if (onClose && wasOpen) {
         onClose(event);
       }
 

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -451,6 +451,38 @@ describe('<Tooltip />', () => {
     expect(eventLog).to.deep.equal(['mouseover', 'open', 'mouseleave', 'close']);
   });
 
+  it('should call onClose when controlled close follows a delayed open before rerender', () => {
+    const eventLog = [];
+    render(
+      <Tooltip
+        enterDelay={100}
+        title="Hello World"
+        onOpen={() => eventLog.push('open')}
+        onClose={() => eventLog.push('close')}
+        open={false}
+      >
+        <button
+          id="testChild"
+          onMouseLeave={() => eventLog.push('mouseleave')}
+          onMouseOver={() => eventLog.push('mouseover')}
+          type="submit"
+        >
+          Hello World
+        </button>
+      </Tooltip>,
+    );
+
+    fireEvent.mouseOver(screen.getByRole('button'));
+    clock.tick(100);
+
+    expect(eventLog).to.deep.equal(['mouseover', 'open']);
+
+    fireEvent.mouseLeave(screen.getByRole('button'));
+    clock.tick(0);
+
+    expect(eventLog).to.deep.equal(['mouseover', 'open', 'mouseleave', 'close']);
+  });
+
   it('should not call onOpen again if already open', () => {
     const eventLog = [];
     render(


### PR DESCRIPTION
## Problem

In React 18's automatic batching, `setOpenState` does not trigger an immediate re-render. When `handleClose` checks the `open` variable right after `setOpenState`, it may read a stale value, causing `onClose` to be silently skipped. The same issue affects `handleOpen`.

This is most noticeable in controlled mode where the `open` prop is managed externally: after mouseLeave triggers internal close logic, `onClose` never fires, leaving the parent's state out of sync.

## Fix

Use a `useRef` to track the last known open state, synced after each render via `useLayoutEffect`. Both `handleOpen` and `handleClose` capture `wasOpen = openRef.current` `before` updating the ref, then use `wasOpen` for the callback guard condition instead of the potentially stale `open` variable.

## Test

Added a test case that verifies `onClose` is called when a controlled tooltip (`open={false}`) is internally opened via mouseOver with `enterDelay` and then immediately closed via mouseLeave — without waiting for a re-render between the two events.