### PR TITLE
[test][toggle button] Add axe tests and docs

### DIFF
--- a/docs/data/material/components/toggle-button/StandaloneToggleButton.js
+++ b/docs/data/material/components/toggle-button/StandaloneToggleButton.js
@@ -10,6 +10,7 @@ export default function StandaloneToggleButton() {
       value="check"
       selected={selected}
       onChange={() => setSelected((prevSelected) => !prevSelected)}
+      aria-label="mark as done"
     >
       <CheckIcon />
     </ToggleButton>

--- a/docs/data/material/components/toggle-button/StandaloneToggleButton.tsx
+++ b/docs/data/material/components/toggle-button/StandaloneToggleButton.tsx
@@ -10,6 +10,7 @@ export default function StandaloneToggleButton() {
       value="check"
       selected={selected}
       onChange={() => setSelected((prevSelected) => !prevSelected)}
+      aria-label="mark as done"
     >
       <CheckIcon />
     </ToggleButton>

--- a/docs/data/material/components/toggle-button/StandaloneToggleButton.tsx.preview
+++ b/docs/data/material/components/toggle-button/StandaloneToggleButton.tsx.preview
@@ -2,6 +2,7 @@
   value="check"
   selected={selected}
   onChange={() => setSelected((prevSelected) => !prevSelected)}
+  aria-label="mark as done"
 >
   <CheckIcon />
 </ToggleButton>

--- a/docs/data/material/components/toggle-button/ToggleButtonA11yColorMatrix.js
+++ b/docs/data/material/components/toggle-button/ToggleButtonA11yColorMatrix.js
@@ -1,0 +1,44 @@
+import Box from '@mui/material/Box';
+import ToggleButton from '@mui/material/ToggleButton';
+
+const colors = [
+  'standard',
+  'primary',
+  'secondary',
+  'error',
+  'info',
+  'success',
+  'warning',
+];
+
+export default function ToggleButtonA11yColorMatrix() {
+  return (
+    <Box
+      sx={{
+        color: 'text.primary',
+        display: 'grid',
+        gap: 1,
+        '& > div': {
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 1,
+        },
+      }}
+    >
+      {[false, true].map((selected) => (
+        <div key={String(selected)}>
+          {colors.map((color) => (
+            <ToggleButton
+              key={`${color}-${selected}`}
+              value={`${color}-${selected}`}
+              color={color}
+              selected={selected}
+            >
+              {color}
+            </ToggleButton>
+          ))}
+        </div>
+      ))}
+    </Box>
+  );
+}

--- a/docs/data/material/components/toggle-button/ToggleButtonA11yColorMatrix.tsx
+++ b/docs/data/material/components/toggle-button/ToggleButtonA11yColorMatrix.tsx
@@ -1,0 +1,44 @@
+import Box from '@mui/material/Box';
+import ToggleButton from '@mui/material/ToggleButton';
+
+const colors = [
+  'standard',
+  'primary',
+  'secondary',
+  'error',
+  'info',
+  'success',
+  'warning',
+] as const;
+
+export default function ToggleButtonA11yColorMatrix() {
+  return (
+    <Box
+      sx={{
+        color: 'text.primary',
+        display: 'grid',
+        gap: 1,
+        '& > div': {
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 1,
+        },
+      }}
+    >
+      {[false, true].map((selected) => (
+        <div key={String(selected)}>
+          {colors.map((color) => (
+            <ToggleButton
+              key={`${color}-${selected}`}
+              value={`${color}-${selected}`}
+              color={color}
+              selected={selected}
+            >
+              {color}
+            </ToggleButton>
+          ))}
+        </div>
+      ))}
+    </Box>
+  );
+}

--- a/docs/data/material/components/toggle-button/ToggleButtonA11yColorMatrix.tsx.preview
+++ b/docs/data/material/components/toggle-button/ToggleButtonA11yColorMatrix.tsx.preview
@@ -1,0 +1,14 @@
+{[false, true].map((selected) => (
+  <div key={String(selected)}>
+    {colors.map((color) => (
+      <ToggleButton
+        key={`${color}-${selected}`}
+        value={`${color}-${selected}`}
+        color={color}
+        selected={selected}
+      >
+        {color}
+      </ToggleButton>
+    ))}
+  </div>
+))}

--- a/docs/data/material/components/toggle-button/ToggleButtonA11yNonNative.js
+++ b/docs/data/material/components/toggle-button/ToggleButtonA11yNonNative.js
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import ToggleButton from '@mui/material/ToggleButton';
+
+const CustomDivButton = React.forwardRef(function CustomDivButton(props, ref) {
+  return <div ref={ref} {...props} />;
+});
+
+export default function ToggleButtonA11yNonNative() {
+  return (
+    <Stack spacing={2} direction="row">
+      <ToggleButton
+        component={CustomDivButton}
+        nativeButton={false}
+        value="on"
+        selected
+      >
+        Non-native pressed
+      </ToggleButton>
+      <ToggleButton component={CustomDivButton} nativeButton={false} value="off">
+        Non-native
+      </ToggleButton>
+      <ToggleButton
+        component={CustomDivButton}
+        nativeButton={false}
+        value="disabled"
+        disabled
+      >
+        Disabled non-native
+      </ToggleButton>
+    </Stack>
+  );
+}

--- a/docs/data/material/components/toggle-button/ToggleButtonA11yNonNative.tsx
+++ b/docs/data/material/components/toggle-button/ToggleButtonA11yNonNative.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import ToggleButton from '@mui/material/ToggleButton';
+
+const CustomDivButton = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(function CustomDivButton(props, ref) {
+  return <div ref={ref} {...props} />;
+});
+
+export default function ToggleButtonA11yNonNative() {
+  return (
+    <Stack spacing={2} direction="row">
+      <ToggleButton
+        component={CustomDivButton}
+        nativeButton={false}
+        value="on"
+        selected
+      >
+        Non-native pressed
+      </ToggleButton>
+      <ToggleButton component={CustomDivButton} nativeButton={false} value="off">
+        Non-native
+      </ToggleButton>
+      <ToggleButton
+        component={CustomDivButton}
+        nativeButton={false}
+        value="disabled"
+        disabled
+      >
+        Disabled non-native
+      </ToggleButton>
+    </Stack>
+  );
+}

--- a/docs/data/material/components/toggle-button/ToggleButtonA11ySemanticStates.js
+++ b/docs/data/material/components/toggle-button/ToggleButtonA11ySemanticStates.js
@@ -1,0 +1,40 @@
+import Stack from '@mui/material/Stack';
+import ToggleButton from '@mui/material/ToggleButton';
+import FormatBoldIcon from '@mui/icons-material/FormatBold';
+
+export default function ToggleButtonA11ySemanticStates() {
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" spacing={2}>
+        <ToggleButton value="off" selected={false}>
+          Not pressed
+        </ToggleButton>
+        <ToggleButton value="on" selected>
+          Pressed
+        </ToggleButton>
+        <ToggleButton value="disabled" disabled>
+          Disabled
+        </ToggleButton>
+      </Stack>
+      <Stack direction="row" spacing={2}>
+        <ToggleButton value="bold-on" selected aria-label="Bold">
+          <FormatBoldIcon />
+        </ToggleButton>
+        <ToggleButton value="bold-off" aria-label="Bold">
+          <FormatBoldIcon />
+        </ToggleButton>
+      </Stack>
+      <Stack direction="row" spacing={2} alignItems="center">
+        <ToggleButton value="small" size="small" aria-label="Bold, small">
+          <FormatBoldIcon />
+        </ToggleButton>
+        <ToggleButton value="medium" size="medium" aria-label="Bold, medium">
+          <FormatBoldIcon />
+        </ToggleButton>
+        <ToggleButton value="large" size="large" aria-label="Bold, large">
+          <FormatBoldIcon />
+        </ToggleButton>
+      </Stack>
+    </Stack>
+  );
+}

--- a/docs/data/material/components/toggle-button/ToggleButtonA11ySemanticStates.js
+++ b/docs/data/material/components/toggle-button/ToggleButtonA11ySemanticStates.js
@@ -24,7 +24,7 @@ export default function ToggleButtonA11ySemanticStates() {
           <FormatBoldIcon />
         </ToggleButton>
       </Stack>
-      <Stack direction="row" spacing={2} alignItems="center">
+      <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
         <ToggleButton value="small" size="small" aria-label="Bold, small">
           <FormatBoldIcon />
         </ToggleButton>

--- a/docs/data/material/components/toggle-button/ToggleButtonA11ySemanticStates.tsx
+++ b/docs/data/material/components/toggle-button/ToggleButtonA11ySemanticStates.tsx
@@ -1,0 +1,40 @@
+import Stack from '@mui/material/Stack';
+import ToggleButton from '@mui/material/ToggleButton';
+import FormatBoldIcon from '@mui/icons-material/FormatBold';
+
+export default function ToggleButtonA11ySemanticStates() {
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" spacing={2}>
+        <ToggleButton value="off" selected={false}>
+          Not pressed
+        </ToggleButton>
+        <ToggleButton value="on" selected>
+          Pressed
+        </ToggleButton>
+        <ToggleButton value="disabled" disabled>
+          Disabled
+        </ToggleButton>
+      </Stack>
+      <Stack direction="row" spacing={2}>
+        <ToggleButton value="bold-on" selected aria-label="Bold">
+          <FormatBoldIcon />
+        </ToggleButton>
+        <ToggleButton value="bold-off" aria-label="Bold">
+          <FormatBoldIcon />
+        </ToggleButton>
+      </Stack>
+      <Stack direction="row" spacing={2} alignItems="center">
+        <ToggleButton value="small" size="small" aria-label="Bold, small">
+          <FormatBoldIcon />
+        </ToggleButton>
+        <ToggleButton value="medium" size="medium" aria-label="Bold, medium">
+          <FormatBoldIcon />
+        </ToggleButton>
+        <ToggleButton value="large" size="large" aria-label="Bold, large">
+          <FormatBoldIcon />
+        </ToggleButton>
+      </Stack>
+    </Stack>
+  );
+}

--- a/docs/data/material/components/toggle-button/ToggleButtonA11ySemanticStates.tsx
+++ b/docs/data/material/components/toggle-button/ToggleButtonA11ySemanticStates.tsx
@@ -24,7 +24,7 @@ export default function ToggleButtonA11ySemanticStates() {
           <FormatBoldIcon />
         </ToggleButton>
       </Stack>
-      <Stack direction="row" spacing={2} alignItems="center">
+      <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
         <ToggleButton value="small" size="small" aria-label="Bold, small">
           <FormatBoldIcon />
         </ToggleButton>

--- a/docs/data/material/components/toggle-button/ToggleButtonA11yTextSpacing.js
+++ b/docs/data/material/components/toggle-button/ToggleButtonA11yTextSpacing.js
@@ -1,0 +1,31 @@
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import ToggleButton from '@mui/material/ToggleButton';
+
+export default function ToggleButtonA11yTextSpacing() {
+  return (
+    <Stack spacing={2} sx={{ maxWidth: 320 }}>
+      <ToggleButton
+        value="settings"
+        selected
+        sx={{
+          justifyContent: 'flex-start',
+          lineHeight: 1.5,
+          letterSpacing: '0.12em',
+          whiteSpace: 'normal',
+          wordSpacing: '0.16em',
+        }}
+      >
+        Review accessibility settings before continuing
+      </ToggleButton>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+        <ToggleButton value="left" sx={{ whiteSpace: 'normal' }}>
+          Align a longer label to the left
+        </ToggleButton>
+        <ToggleButton value="right" sx={{ whiteSpace: 'normal' }}>
+          Align a longer label to the right
+        </ToggleButton>
+      </Box>
+    </Stack>
+  );
+}

--- a/docs/data/material/components/toggle-button/ToggleButtonA11yTextSpacing.tsx
+++ b/docs/data/material/components/toggle-button/ToggleButtonA11yTextSpacing.tsx
@@ -1,0 +1,31 @@
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import ToggleButton from '@mui/material/ToggleButton';
+
+export default function ToggleButtonA11yTextSpacing() {
+  return (
+    <Stack spacing={2} sx={{ maxWidth: 320 }}>
+      <ToggleButton
+        value="settings"
+        selected
+        sx={{
+          justifyContent: 'flex-start',
+          lineHeight: 1.5,
+          letterSpacing: '0.12em',
+          whiteSpace: 'normal',
+          wordSpacing: '0.16em',
+        }}
+      >
+        Review accessibility settings before continuing
+      </ToggleButton>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+        <ToggleButton value="left" sx={{ whiteSpace: 'normal' }}>
+          Align a longer label to the left
+        </ToggleButton>
+        <ToggleButton value="right" sx={{ whiteSpace: 'normal' }}>
+          Align a longer label to the right
+        </ToggleButton>
+      </Box>
+    </Stack>
+  );
+}

--- a/docs/data/material/components/toggle-button/toggle-button.a11y.json
+++ b/docs/data/material/components/toggle-button/toggle-button.a11y.json
@@ -1,0 +1,334 @@
+{
+  "ToggleButtonA11yColorMatrix": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "fail",
+        "tags": ["wcag2aa"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "ToggleButtonA11yNonNative": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-command-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "ToggleButtonA11ySemanticStates": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "ToggleButtonA11yTextSpacing": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "ToggleButtons": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "ToggleButtonsMultiple": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "VerticalToggleButtons": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  }
+}

--- a/packages/mui-material/src/ToggleButton/ToggleButton.test.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.test.js
@@ -5,7 +5,6 @@ import {
   createRenderer,
   screen,
   isJsdom,
-  fireEvent,
   focusVisible,
   simulatePointerDevice,
 } from '@mui/internal-test-utils';
@@ -157,21 +156,118 @@ describe('<ToggleButton />', () => {
     });
   });
 
-  describe('accessibility', () => {
-    it('reflects `selected` as `aria-pressed` (WCAG 4.1.2)', () => {
-      const { setProps } = render(
-        <ToggleButton value="bold" selected={false}>
-          Bold
-        </ToggleButton>,
+  describe('WCAG 2.2 conformance', () => {
+    it('2.1.2 No Keyboard Trap: keyboard focus can enter and leave the toggle', async () => {
+      const { user } = render(
+        <React.Fragment>
+          <button type="button">Before</button>
+          <ToggleButton value="x" disableRipple>
+            Middle
+          </ToggleButton>
+          <button type="button">After</button>
+        </React.Fragment>,
       );
-      const button = screen.getByRole('button');
-      expect(button).to.have.attribute('aria-pressed', 'false');
 
-      setProps({ selected: true });
-      expect(button).to.have.attribute('aria-pressed', 'true');
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'Before' })).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'Middle' })).toHaveFocus();
+
+      // Tab moves focus back out of the toggle — it is never captured.
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+
+      // Shift+Tab moves back onto it.
+      await user.tab({ shift: true });
+      expect(screen.getByRole('button', { name: 'Middle' })).toHaveFocus();
     });
 
-    it('keeps the visible label within the accessible name (WCAG 2.5.3)', () => {
+    describe('2.4.3 Focus Order', () => {
+      it('is a single tab stop in natural DOM order with no positive tabIndex', async () => {
+        const { user } = render(
+          <React.Fragment>
+            <button type="button">Before</button>
+            <ToggleButton value="x" disableRipple>
+              Middle
+            </ToggleButton>
+            <button type="button">After</button>
+          </React.Fragment>,
+        );
+        expect(screen.getByRole('button', { name: 'Middle' })).to.have.property('tabIndex', 0);
+
+        await user.tab();
+        expect(screen.getByRole('button', { name: 'Before' })).toHaveFocus();
+        await user.tab();
+        expect(screen.getByRole('button', { name: 'Middle' })).toHaveFocus();
+        await user.tab();
+        expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+      });
+
+      it('removes a disabled toggle from the tab order', async () => {
+        const { user } = render(
+          <React.Fragment>
+            <ToggleButton value="x" disableRipple disabled>
+              Disabled
+            </ToggleButton>
+            <button type="button">After</button>
+          </React.Fragment>,
+        );
+
+        // Tab skips the disabled toggle and lands on the next control.
+        await user.tab();
+        expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+      });
+    });
+
+    // `:focus-visible` is only reliable in a real browser, so this runs there (not jsdom).
+    it.skipIf(isJsdom())(
+      '2.4.7 Focus Visible: disableRipple removes the only focus indicator',
+      () => {
+        render(
+          <ToggleButton value="x" disableRipple>
+            Toggle
+          </ToggleButton>,
+        );
+        const button = screen.getByRole('button');
+
+        simulatePointerDevice();
+        focusVisible(button);
+
+        // Keyboard focus is detected, but `disableRipple` leaves no ripple — the only
+        // focus style the component provides.
+        expect(button).to.have.class(buttonBaseClasses.focusVisible);
+        expect(button.querySelector('.MuiTouchRipple-root')).to.equal(null);
+      },
+    );
+
+    it('2.5.2 Pointer Cancellation: activates on click, but not when released off the target', async () => {
+      const handleChange = spy();
+      const { user } = render(
+        <React.Fragment>
+          <ToggleButton value="x" onChange={handleChange} disableRipple>
+            Pointer cancellation
+          </ToggleButton>
+          <div data-testid="outside" />
+        </React.Fragment>,
+      );
+      const button = screen.getByRole('button', { name: 'Pointer cancellation' });
+
+      // Press on the toggle, move away, then release: nothing runs on the down event,
+      // and releasing off the target cancels the activation.
+      await user.pointer([
+        { keys: '[MouseLeft>]', target: button },
+        { target: screen.getByTestId('outside') },
+        { keys: '[/MouseLeft]' },
+      ]);
+      expect(handleChange.callCount).to.equal(0);
+
+      // A full click — press and release over the target — activates.
+      await user.click(button);
+      expect(handleChange.callCount).to.equal(1);
+    });
+
+    it('2.5.3 Label in Name: the accessible name contains the visible label', () => {
       render(
         <ToggleButton value="bold" aria-label="Bold formatting">
           Bold
@@ -182,42 +278,57 @@ describe('<ToggleButton />', () => {
       expect(button.getAttribute('aria-label')).to.contain(button.textContent);
     });
 
-    it('activates on click, not on `mouseDown` alone (WCAG 2.5.2)', () => {
+    it('3.2.1 On Focus: moving keyboard focus to the toggle does not activate it', async () => {
       const handleChange = spy();
-      render(
+      const { user } = render(
         <ToggleButton value="x" onChange={handleChange} disableRipple>
-          Hello
+          On focus
         </ToggleButton>,
       );
-      const button = screen.getByRole('button');
 
-      fireEvent.mouseDown(button);
+      await user.tab();
+      expect(screen.getByRole('button')).toHaveFocus();
+      // Focus alone changes no context.
+      expect(handleChange.callCount).to.equal(0);
+    });
+
+    it('3.2.2 On Input: the pressed state changes only from explicit activation', async () => {
+      const handleChange = spy();
+      const { user } = render(
+        <ToggleButton value="x" onChange={handleChange} selected disableRipple>
+          Pressed
+        </ToggleButton>,
+      );
+
+      // Rendering in the pressed state does not activate the toggle on its own.
       expect(handleChange.callCount).to.equal(0);
 
-      button.click();
+      // The change is surfaced only when the user explicitly activates it.
+      await user.click(screen.getByRole('button', { name: 'Pressed' }));
       expect(handleChange.callCount).to.equal(1);
     });
 
-    // `:focus-visible` is only reliable in a real browser, so this runs there (not jsdom).
-    it.skipIf(isJsdom())(
-      'leaves no focus indicator (the ripple) under `disableRipple` (WCAG 2.4.7)',
-      () => {
-        render(
-          <ToggleButton value="x" disableRipple>
-            Hello
-          </ToggleButton>,
+    it('4.1.2 Name, Role, Value: reflects the selected state as aria-pressed', async () => {
+      function ControlledToggle() {
+        const [selected, setSelected] = React.useState(false);
+        return (
+          <ToggleButton
+            value="bold"
+            selected={selected}
+            onChange={() => setSelected((prev) => !prev)}
+            disableRipple
+          >
+            Bold
+          </ToggleButton>
         );
-        const button = screen.getByRole('button');
+      }
+      const { user } = render(<ControlledToggle />);
+      const button = screen.getByRole('button');
+      expect(button).to.have.attribute('aria-pressed', 'false');
 
-        simulatePointerDevice();
-        focusVisible(button);
-
-        // Keyboard focus is detected, but `disableRipple` leaves no visible indicator:
-        // the ripple is the only focus style the component provides.
-        expect(button).to.have.class(buttonBaseClasses.focusVisible);
-        expect(button.querySelector('.MuiTouchRipple-root')).to.equal(null);
-      },
-    );
+      await user.click(button);
+      expect(button).to.have.attribute('aria-pressed', 'true');
+    });
   });
 
   describe.skipIf(!isJsdom())('server-side', () => {

--- a/packages/mui-material/src/ToggleButton/ToggleButton.test.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.test.js
@@ -1,9 +1,16 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
+import {
+  createRenderer,
+  screen,
+  isJsdom,
+  fireEvent,
+  focusVisible,
+  simulatePointerDevice,
+} from '@mui/internal-test-utils';
 import ToggleButton, { toggleButtonClasses as classes } from '@mui/material/ToggleButton';
-import ButtonBase from '@mui/material/ButtonBase';
+import ButtonBase, { buttonBaseClasses } from '@mui/material/ButtonBase';
 import describeConformance from '../../test/describeConformance';
 
 describe('<ToggleButton />', () => {
@@ -148,6 +155,69 @@ describe('<ToggleButton />', () => {
       expect(errorSpy.mock.calls.length).to.equal(0);
       errorSpy.mockRestore();
     });
+  });
+
+  describe('accessibility', () => {
+    it('reflects `selected` as `aria-pressed` (WCAG 4.1.2)', () => {
+      const { setProps } = render(
+        <ToggleButton value="bold" selected={false}>
+          Bold
+        </ToggleButton>,
+      );
+      const button = screen.getByRole('button');
+      expect(button).to.have.attribute('aria-pressed', 'false');
+
+      setProps({ selected: true });
+      expect(button).to.have.attribute('aria-pressed', 'true');
+    });
+
+    it('keeps the visible label within the accessible name (WCAG 2.5.3)', () => {
+      render(
+        <ToggleButton value="bold" aria-label="Bold formatting">
+          Bold
+        </ToggleButton>,
+      );
+
+      const button = screen.getByRole('button');
+      expect(button.getAttribute('aria-label')).to.contain(button.textContent);
+    });
+
+    it('activates on click, not on `mouseDown` alone (WCAG 2.5.2)', () => {
+      const handleChange = spy();
+      render(
+        <ToggleButton value="x" onChange={handleChange} disableRipple>
+          Hello
+        </ToggleButton>,
+      );
+      const button = screen.getByRole('button');
+
+      fireEvent.mouseDown(button);
+      expect(handleChange.callCount).to.equal(0);
+
+      button.click();
+      expect(handleChange.callCount).to.equal(1);
+    });
+
+    // `:focus-visible` is only reliable in a real browser, so this runs there (not jsdom).
+    it.skipIf(isJsdom())(
+      'leaves no focus indicator (the ripple) under `disableRipple` (WCAG 2.4.7)',
+      () => {
+        render(
+          <ToggleButton value="x" disableRipple>
+            Hello
+          </ToggleButton>,
+        );
+        const button = screen.getByRole('button');
+
+        simulatePointerDevice();
+        focusVisible(button);
+
+        // Keyboard focus is detected, but `disableRipple` leaves no visible indicator:
+        // the ripple is the only focus style the component provides.
+        expect(button).to.have.class(buttonBaseClasses.focusVisible);
+        expect(button.querySelector('.MuiTouchRipple-root')).to.equal(null);
+      },
+    );
   });
 
   describe.skipIf(!isJsdom())('server-side', () => {

--- a/packages/mui-material/src/ToggleButton/accessibility.md
+++ b/packages/mui-material/src/ToggleButton/accessibility.md
@@ -1,0 +1,361 @@
+# Toggle Button accessibility conformance
+
+Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility.md).
+
+| Result                | Count |
+| :-------------------- | :---- |
+| ✅ Supports           | 20    |
+| ⚠️ Partially Supports | 4     |
+| ❌ Does Not Support   | 0     |
+| ➖ Not Applicable     | 31    |
+| 🚩 Unverified         | 17/24 |
+
+## Known gaps
+
+- ⚠️ **1.4.1 Use of Color.** For the color variants (`primary`, `error`, `info`, `success`), the selected and unselected labels are near-identical in grayscale lightness, so the pressed state is conveyed almost entirely by hue.
+- ⚠️ **1.4.3 Contrast (Minimum).** When selected, the `primary`, `error`, `info`, and `warning` labels (their `color.main` text over the tinted selected background) fall short of 4.5:1.
+- ⚠️ **1.4.11 Non-text Contrast.** The focus indicator is the ripple; `disableRipple`/`disableFocusRipple` remove it, leaving no focus indicator. The selected-state fill is untested for 3:1.
+- ⚠️ **2.4.7 Focus Visible.** `disableRipple`/`disableFocusRipple` remove the only keyboard focus indicator; the Toggle Button has no box-shadow fallback.
+
+## Success criteria
+
+### 🔍 Manual
+
+#### 1.3.2 Meaningful Sequence · A
+
+`🚩 Unverified` · `✅ Supports` · `○ Author`
+
+- The Toggle Button is one control. Its children render in DOM order; a decorative MUI icon is `aria-hidden`, leaving the label (text or `aria-label`) as the exposed content.
+- Order carries meaning only across several toggles, which the surrounding layout (often a `ToggleButtonGroup`) sets. Confirm that reading order matches the visual order.
+
+**Manual testing steps**
+
+1. Open a demo with a row of toggles (`ToggleButtons`).
+2. Press <kbd>Tab</kbd> repeatedly and note the order the toggles receive focus.
+3. Compare that order to the visual left-to-right order.
+
+**Pass:** focus order matches the visual order. Watch for layouts that reorder toggles visually without changing the DOM.
+
+#### 1.3.3 Sensory Characteristics · A
+
+`🚩 Unverified` · `✅ Supports` · `○ Author`
+
+- A toggle with text or an `aria-label` can be identified by name, not only by shape, color, or position.
+- Instructions in the surrounding content must not rely on color, shape, or position alone (for example, "the highlighted button").
+
+**Manual testing steps**
+
+1. Find any product copy that tells users to operate a toggle.
+2. Check that it names the toggle by its label, not only by color, shape, size, or position.
+
+**Pass:** no instruction relies on "the highlighted one" or "the button on the left" without naming it.
+
+#### 1.4.5 Images of Text · AA
+
+`🚩 Unverified` · `✅ Supports` · `○ Author`
+
+- A text label is live CSS text; the component never renders it as an image.
+- This fails only if an image of text, or an icon font spelling words, is passed as the children. Use real text or an icon with an `aria-label`.
+
+**Manual testing steps**
+
+1. Open a toggle with a text label and try to select the text with the mouse, or zoom in.
+2. Confirm it behaves like real text (selectable, stays crisp), not a picture.
+
+**Pass:** labels are live text. No toggle uses an image of text.
+
+#### 2.4.11 Focus Not Obscured (Minimum) · AA
+
+`🚩 Unverified` · `✅ Supports` · `○ Author`
+
+- The Toggle Button is an ordinary focusable element and never places itself behind other content. Obscuring comes from sticky headers, banners, or overlays in the surrounding layout.
+- Confirm by moving focus to a toggle beneath any sticky or overlay content at several scroll positions. At least part of it must stay visible.
+
+**Manual testing steps**
+
+1. In a page that has a sticky header, footer, or banner, press <kbd>Tab</kbd> to move focus onto a toggle near it.
+2. Scroll so the toggle sits under the sticky element, then <kbd>Tab</kbd> to it again.
+
+**Pass:** at least part of the focused toggle stays visible, never fully covered.
+
+#### 3.2.4 Consistent Identification · AA
+
+`🚩 Unverified` · `✅ Supports` · `○ Author`
+
+- The component produces one stable accessible name per set of props, the precondition for consistent identification.
+- Consistency is a cross-page property. Confirm that toggles with the same function share a label and icon, and that one label is not reused for different functions.
+
+**Manual testing steps**
+
+1. List the toggles that do the same job across the product (for example, every "Bold").
+2. Compare their labels and icons.
+
+**Pass:** the same job uses the same label and icon, and no single label is reused for different jobs.
+
+### 🔁 Hybrid
+
+#### 1.1.1 Non-text Content · A
+
+`✅ Supports` · `◐ Shared`
+
+- A MUI `SvgIcon` child defaults to `aria-hidden` + `focusable="false"`, so it does not contribute to the name; the name comes from the children text or an `aria-label`. axe-core confirms a non-empty name (`button-name` on the native-button demos, `aria-command-name` on the non-native host).
+- An icon-only toggle has no accessible name unless the author sets an `aria-label`, as every icon toggle in the demos does. Whether the name conveys meaning needs an assistive-technology review.
+
+**Manual testing steps**
+
+1. Open `ToggleButtonA11ySemanticStates` with a screen reader running (NVDA with Chrome, or VoiceOver with Safari).
+2. <kbd>Tab</kbd> to each toggle and confirm it announces the visible label or `aria-label`, and does not read out the icon.
+3. For any icon-only toggle in the product, confirm it has an `aria-label` describing the action.
+
+**Pass:** every toggle's announced name matches its purpose, and decorative icons are silent.
+
+#### 1.3.1 Info and Relationships · A
+
+`✅ Supports` · `◐ Shared`
+
+- The component sets the role (`button`, or `role="button"` for a non-native host), the pressed state through `aria-pressed` (`ToggleButton.js`), and the disabled state. axe-core's ARIA rules (`aria-allowed-attr`, `aria-valid-attr-value`, and `aria-roles` where a non-default role is present) pass across the demos.
+- Grouping relationships (a `role="group"` and its label) belong to `ToggleButtonGroup`, not the single toggle. Whether a runtime state change is announced needs an assistive-technology review.
+
+**Manual testing steps**
+
+1. Open `ToggleButtonA11ySemanticStates` and `ToggleButtonA11yNonNative` with a screen reader running.
+2. Confirm the plain toggle announces "button", the selected one announces its pressed state, the disabled one announces its disabled state, and the custom one announces "button".
+
+**Pass:** role and state match the visual presentation for every variant.
+
+#### 1.4.1 Use of Color · A
+
+`🚩 Unverified` · `⚠️ Partially Supports` · `● Component`
+
+- A toggle's purpose comes from its label or icon, not color, so the control itself is not identified by color alone.
+- The pressed state is the gap. For `standard`, selecting darkens the label from `action.active` to `text.primary`, a clear lightness change. For the color variants the selected label switches to `color.main`, which is almost the same lightness as the unselected `action.active` (in grayscale `primary` differs by about 0.0003, `error` by 0.017), and the only other cue is a roughly 1.1:1 fill, so a `primary`/`error`/`info`/`success` toggle's pressed state is conveyed almost entirely by hue.
+
+**Manual testing steps**
+
+1. Open `ColorToggleButton` or `ToggleButtonA11yColorMatrix`.
+2. Turn on a grayscale view (in Chrome DevTools: Rendering tab, Emulate vision deficiencies, Achromatopsia).
+3. Confirm each toggle can still be told apart, and that a selected toggle is still distinguishable from an unselected one.
+
+**Pass:** the control's meaning survives without color. The `standard` selected state stays distinguishable; the color variants do not, since their pressed cue is hue-dominant.
+
+#### 1.4.3 Contrast (Minimum) · AA
+
+`⚠️ Partially Supports` · `● Component`
+
+- When selected, a toggle uses `color.main` as the label color over a `color.main`-tinted background (`ToggleButton.js`). The `primary`, `error`, `info`, and `warning` labels fall short of 4.5:1; `ToggleButtonA11yColorMatrix` records the `color-contrast` failure in [`toggle-button.a11y.json`](../../../../docs/data/material/components/toggle-button/toggle-button.a11y.json) (rule-level pass/fail only). The unselected label (`action.active`) and the `standard` selected label pass.
+- axe-core `color-contrast` checks the resting state. The `:hover` colors and custom palettes need a visual check. Disabled toggles are exempt.
+
+**Manual testing steps**
+
+1. Open `ToggleButtonA11yColorMatrix`. With a contrast checker (the color picker in browser DevTools shows a ratio), check each selected label against its background.
+2. Repeat with the pointer hovering, since `:hover` changes the background.
+3. Check any custom theme colors the product uses.
+
+**Pass:** at least 4.5:1, or 3:1 for large text, in the resting and hover states. Disabled is exempt; selected `primary`, `error`, `info`, and `warning` are the known failures.
+
+#### 1.4.11 Non-text Contrast · AA
+
+`🚩 Unverified` · `⚠️ Partially Supports` · `● Component`
+
+- The label or icon identifies the control, so WCAG does not require the `divider` border to reach 3:1. The pieces that do need 3:1 are the focus indicator and the visual cue that marks the pressed state.
+- The focus indicator is the ripple; `disableRipple`/`disableFocusRipple` remove it, so it can be absent entirely. The selected-state fill (`action.selectedOpacity`, 0.08) is faint and untested against the unselected state. Disabled toggles are exempt.
+
+**Manual testing steps**
+
+1. Open `ToggleButtons`. Press <kbd>Tab</kbd> to a toggle so its focus indicator shows, and measure the indicator against the colors next to it.
+2. Measure a selected toggle's fill (and any meaningful icon) against the unselected state and the background.
+3. Set `disableRipple` or `disableFocusRipple` on a toggle (no demo ships these) and repeat: the focus indicator should be gone.
+
+**Pass:** the focus indicator and any meaningful icon are each at least 3:1, and the pressed state stays identifiable. Disabled parts are exempt.
+
+#### 1.4.12 Text Spacing · AA
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- A text label wraps when `white-space: normal` is set and the toggle height comes from padding, not a fixed height, so the WCAG text-spacing values grow the toggle without clipping.
+- No axe-core rule covers this (`avoid-inline-spacing` only inspects inline `style`, but `sx` compiles to a class); a `ToggleButtonA11yTextSpacing` screenshot guards the rendered spacing layout against regressions. Inject the spacing values through a stylesheet to check for clipping.
+
+**Manual testing steps**
+
+1. Open `ToggleButtonA11yTextSpacing`.
+2. Apply the WCAG text-spacing values. The quickest way is to run this in the DevTools console: `document.head.insertAdjacentHTML('beforeend','<style>*{line-height:1.5!important;letter-spacing:.12em!important;word-spacing:.16em!important}</style>')`.
+3. Look for cut-off, clipped, or overlapping label text.
+
+**Pass:** all label text stays visible and the toggle still works.
+
+#### 2.4.6 Headings and Labels · AA
+
+`✅ Supports` · `◐ Shared`
+
+- The accessible name serves as the control's label. axe-core confirms it is present (`button-name` on the native-button demos, `aria-command-name` on the non-native host).
+- Whether the label describes the action (a clear `aria-label` against a vague one) is a content decision, confirmed with a manual review.
+
+**Manual testing steps**
+
+1. Read each toggle's label, or its `aria-label`, out of context.
+2. Ask whether it says what the toggle does.
+
+**Pass:** every label describes its action ("Bold", not "B").
+
+#### 2.4.7 Focus Visible · AA
+
+`🚩 Unverified` · `⚠️ Partially Supports` · `● Component`
+
+- Keyboard focus shows the `.Mui-focusVisible` ripple (suppressed for mouse). The component sets no other focus style.
+- `disableRipple` removes every ripple and `disableFocusRipple` removes the focus ripple, so either prop leaves the toggle with no visible focus indicator (the `disableRipple` prop documents this).
+
+**Manual testing steps**
+
+1. Open `ToggleButtons` and `StandaloneToggleButton`. Press <kbd>Tab</kbd> to move to each toggle.
+2. Confirm a clear focus indicator appears, and that it looks different from the selected style.
+3. Click a toggle with the mouse and confirm the indicator does not appear (it is keyboard-only).
+4. Set `disableRipple` or `disableFocusRipple` on a toggle (no demo ships these) and <kbd>Tab</kbd> to it.
+
+**Pass:** every keyboard-focused toggle shows a visible indicator, including under `disableRipple` and `disableFocusRipple`.
+
+#### 2.5.3 Label in Name · A
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- When a toggle has a visible text label, that text is the accessible name (the children become the name). An icon-only toggle has no visible text, so its `aria-label` is the name.
+- An `aria-label` that omits or reorders the visible words breaks this. Compare the visible text to the computed name.
+
+**Manual testing steps**
+
+1. Open the accessibility tree (in Chrome DevTools: Elements panel, Accessibility tab) and select a toggle with a visible text label.
+2. Compare its computed Name to the words shown on screen.
+3. Optional: with Voice Control (macOS) or Dragon, say "click [label]" and confirm it activates.
+
+**Pass:** the visible text appears in the accessible name. An `aria-label` that drops or reorders the visible words fails.
+
+#### 4.1.2 Name, Role, Value · A
+
+`✅ Supports` · `◐ Shared`
+
+- A native `<button>` (or `role="button"` for a non-native host) sets the role; `aria-pressed` reflects `selected` for the on/off state, the W3C-prescribed mechanism for a toggle button (distinct from a switch's `aria-checked`); `disabled` sets state. axe-core `button-name` (with `aria-command-name` covering the non-native host), the other `aria-*` rules, and `nested-interactive` all pass.
+- axe-core covers the mechanical layer (a name is present, `aria-pressed` is a valid and permitted value). Whether the name is meaningful, and whether the pressed state matches the visual state and is announced on change, needs an assistive-technology review.
+
+**Manual testing steps**
+
+1. Open `ToggleButtonA11ySemanticStates`, `ToggleButtonA11yNonNative`, and `ToggleButtonsMultiple` with a screen reader running.
+2. <kbd>Tab</kbd> to each toggle and confirm the announced name, role, and pressed or disabled state are correct.
+3. Activate a toggle and confirm the pressed/not-pressed change is announced.
+
+**Pass:** name, role, and state are correct for every variant, and state changes are announced.
+
+### ⚙️ Automated
+
+#### 1.4.4 Resize Text · AA
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- Typography is set in rem and em, so the label and toggle scale with browser zoom or font size rather than staying pixel-fixed.
+- A fixed-pixel container in the surrounding layout could clip at 200%.
+
+**Manual testing steps**
+
+1. Open the Toggle Button demos and set browser zoom to 200% (<kbd>Ctrl</kbd> or <kbd>Cmd</kbd> and <kbd>+</kbd>).
+2. Confirm labels are fully visible and toggles still work.
+
+**Pass:** nothing is clipped or cut off at 200%.
+
+#### 1.4.10 Reflow · AA
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- A toggle sizes to its content, so it reflows on its own. Horizontal overflow at 320 CSS pixels comes from the surrounding layout, such as a wide `ToggleButtonGroup` that does not wrap.
+
+**Manual testing steps**
+
+1. Open the Toggle Button demos and set the window, or the DevTools device toolbar, to 320 CSS pixels wide.
+2. Confirm there is no sideways scrolling and all toggles are reachable.
+
+**Pass:** content reflows with no horizontal scroll.
+
+#### 2.1.1 Keyboard · A
+
+`✅ Supports` · `● Component`
+
+- A native toggle and a non-native `role="button"` activate with <kbd>Enter</kbd> and <kbd>Space</kbd>. Disabled toggles leave the tab order.
+- Confirmed by interaction tests in [`../ButtonBase/ButtonBase.test.js`](../ButtonBase/ButtonBase.test.js) (<kbd>Enter</kbd> and <kbd>Space</kbd> activation, disabled non-native cases) and [`./ToggleButton.test.js`](./ToggleButton.test.js) (click activation, disabled).
+
+#### 2.1.2 No Keyboard Trap · A
+
+`🚩 Unverified` · `✅ Supports` · `● Component`
+
+- A single focusable control that installs no focus-capturing loop. <kbd>Tab</kbd> moves in and out, and a disabled toggle leaves the tab order (the `disabled` attribute on native buttons, `tabIndex=-1` on non-native).
+
+#### 2.4.3 Focus Order · A
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- The component sits in natural DOM order with no positive `tabIndex`, and a disabled toggle leaves the order, so it is one correct focus stop.
+- Order across toggles is the surrounding layout's responsibility.
+
+#### 2.5.2 Pointer Cancellation · A
+
+`🚩 Unverified` · `✅ Supports` · `● Component`
+
+- Activation runs on `click`, fired on pointer-up over the target. `onMouseDown` only starts the ripple, and releasing off the target cancels, so nothing runs on the down event.
+
+#### 2.5.8 Target Size (Minimum) · AA
+
+`✅ Supports` · `● Component`
+
+- Default sizes meet the 24 by 24 CSS pixel minimum (a `medium` icon toggle is about 48 pixels). axe-core `target-size` confirms this across the Toggle Button demos in [`toggle-button.a11y.json`](../../../../docs/data/material/components/toggle-button/toggle-button.a11y.json).
+- Not covered: `sx` or `size` overrides that shrink a custom toggle, or hit-area changes under browser zoom.
+
+#### 3.2.1 On Focus · A
+
+`🚩 Unverified` · `✅ Supports` · `● Component`
+
+- Focus triggers only the focus-visible ripple and `onFocus` callbacks. There is no navigation, dialog, or focus move, so focus alone changes no context.
+
+#### 3.2.2 On Input · A
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- Toggling the pressed state (`selected`, exposed as `aria-pressed`) changes no context on its own.
+- Whether an author's `onChange` handler couples that change to navigation or a new window without warning is an author decision.
+
+## Not applicable
+
+- **1.3.5 Identify Input Purpose (AA).** Not an input.
+- **1.4.13 Content on Hover or Focus (AA).**
+- **2.1.4 Character Key Shortcuts (A).** The only keys are <kbd>Enter</kbd> and <kbd>Space</kbd> which are not shortcuts.
+- **2.2.2 Pause, Stop, Hide (A).** Nothing moves or auto-updates.
+- **2.4.4 Link Purpose (In Context) (A).** A button, not a link. `href` is inherited from ButtonBase, but a toggle used as a link carries a meaningless `aria-pressed`, so link usage is outside the documented toggle pattern.
+- **2.5.7 Dragging Movements (AA, new in 2.2).** No drag interactions.
+- **3.1.1 Language of Page (A), 3.1.2 Language of Parts (AA).** Authoring concern.
+- **3.2.3 Consistent Navigation (AA).** Inapplicable in isolation.
+- **3.2.6 Consistent Help (A, new in 2.2).** Inapplicable in isolation.
+- **3.3.2 Labels or Instructions (A).** Limited by WCAG to data-entry controls; it excludes interactive widgets not associated with data entry, and a toggle button is one.
+- **3.3.7 Redundant Entry (A, new in 2.2).** Covers repopulating previously entered data. The toggle captures none.
+- **3.3.8 Accessible Authentication (Minimum) (AA, new in 2.2).** The paste, autofill, and cognitive-test duty falls on the credential fields, not a toggle.
+- **4.1.3 Status Messages (AA).** No status message; state is exposed through `aria-pressed`.
+- **Time-based media (1.2.1 to 1.2.5).** No audio or video.
+- **Audio Control (1.4.2).** Emits no audio.
+- **Orientation (1.3.4).** Sets no orientation lock; a layout concern.
+- **Bypass Blocks (2.4.1), Page Titled (2.4.2), Multiple Ways (2.4.5).** Page or site structure concerns.
+- **Timing Adjustable (2.2.1).** Sets no time limit.
+- **Three Flashes or Below Threshold (2.3.1).** Nothing flashes (one ripple of about 550 ms).
+- **Pointer Gestures (2.5.1), Motion Actuation (2.5.4).** Activates on a simple click; reads no device motion.
+- **Error Identification (3.3.1), Error Suggestion (3.3.3), Error Prevention (3.3.4).** The toggle collects and validates no input; these belong to the form or process.
+
+## Level AAA
+
+The following SC are applicable but out of scope:
+
+- **2.3.3 Animation from Interactions.** The ripple's `scale()` animation honors `prefers-reduced-motion` when the theme sets `motion.reducedMotion` to `system` (follows the OS) or `always`; `disableRipple` also removes it. The default is `never`, so OS reduced-motion is not honored by default. `🚩`
+- **2.4.13 Focus Appearance.** The focus indicator is unlikely to meet the area and 3:1 thresholds, especially with `disableRipple`. `🚩`
+- **2.5.5 Target Size (Enhanced), 44 px.** The `small` size (about 40 px) is below 44 px. `🚩`
+- **1.4.6 Contrast (Enhanced), 7:1.** Palettes target the AA 4.5:1, so several selected colors fall short of 7:1. `🚩`
+- Also touched, in the same shape as their A and AA siblings: **1.3.6 Identify Purpose, 1.4.9 Images of Text (No Exception), 2.1.3 Keyboard (No Exception), 2.4.12 Focus Not Obscured (Enhanced)**.
+
+## Scope and test environment
+
+- **Standard.** WCAG 2.2, Level A and AA.
+- **Component version.** `@mui/material` 9.1.2.
+- **Scope.** The Toggle Button component in isolation, rendered through its documented API.
+- **Automated.** axe-core via Playwright test harness (results in [`toggle-button.a11y.json`](../../../../docs/data/material/components/toggle-button/toggle-button.a11y.json)), plus interaction tests in `ButtonBase.test.js` and `ToggleButton.test.js`.
+- **Assistive-technology review.** Not yet performed. `🚩` criteria are assessed from source pending a review with NVDA, JAWS, and VoiceOver.

--- a/packages/mui-material/src/ToggleButton/accessibility.md
+++ b/packages/mui-material/src/ToggleButton/accessibility.md
@@ -8,7 +8,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 | ⚠️ Partially Supports | 4     |
 | ❌ Does Not Support   | 0     |
 | ➖ Not Applicable     | 31    |
-| 🚩 Flagged            | 10/24 |
+| 🚩 Flagged            | 5/24  |
 
 ## Known gaps
 
@@ -23,7 +23,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.3.2 Meaningful Sequence · A
 
-`🚩` · `✅ Supports` · `○ Author`
+`✅ Supports` · `○ Author`
 
 - The Toggle Button is one control. Its children render in DOM order; a decorative MUI icon is `aria-hidden`, leaving the label (text or `aria-label`) as the exposed content.
 - Order carries meaning only across several toggles, which the surrounding layout (often a `ToggleButtonGroup`) sets. Confirm that reading order matches the visual order.
@@ -37,7 +37,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.3.3 Sensory Characteristics · A
 
-`🚩` · `✅ Supports` · `○ Author`
+`✅ Supports` · `○ Author`
 
 - A toggle with text or an `aria-label` can be identified by name, not only by shape, color, or position.
 - Instructions in the surrounding content must not rely on color, shape, or position alone (for example, "the highlighted button").
@@ -65,7 +65,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.4.5 Images of Text · AA
 
-`🚩` · `✅ Supports` · `○ Author`
+`✅ Supports` · `○ Author`
 
 - A text label is live CSS text; the component never renders it as an image.
 - This fails only if an image of text, or an icon font spelling words, is passed as the children. Use real text or an icon with an `aria-label`.
@@ -91,7 +91,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 2.4.11 Focus Not Obscured (Minimum) · AA
 
-`🚩` · `✅ Supports` · `○ Author`
+`✅ Supports` · `○ Author`
 
 - The Toggle Button is an ordinary focusable element and never places itself behind other content. Obscuring comes from sticky headers, banners, or overlays in the surrounding layout.
 - Confirm by moving focus to a toggle beneath any sticky or overlay content at several scroll positions. At least part of it must stay visible.
@@ -105,7 +105,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 3.2.4 Consistent Identification · AA
 
-`🚩` · `✅ Supports` · `○ Author`
+`✅ Supports` · `○ Author`
 
 - The component produces one stable accessible name per set of props, the precondition for consistent identification.
 - Consistency is a cross-page property. Confirm that toggles with the same function share a label and icon, and that one label is not reused for different functions.

--- a/packages/mui-material/src/ToggleButton/accessibility.md
+++ b/packages/mui-material/src/ToggleButton/accessibility.md
@@ -8,7 +8,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 | ⚠️ Partially Supports | 4     |
 | ❌ Does Not Support   | 0     |
 | ➖ Not Applicable     | 31    |
-| 🚩 Flagged            | 14/24 |
+| 🚩 Flagged            | 10/24 |
 
 ## Known gaps
 
@@ -30,9 +30,8 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 **Manual testing steps**
 
-1. Open a demo with a row of toggles (`ToggleButtons`).
-2. Press <kbd>Tab</kbd> repeatedly and note the order the toggles receive focus.
-3. Compare that order to the visual left-to-right order.
+1. In a UI with a series of toggle buttons (typically a `ToggleButtonGroup`), press <kbd>Tab</kbd> repeatedly and note the order the toggles receive focus.
+2. Compare that order to the visual left-to-right order.
 
 **Pass:** focus order matches the visual order. Watch for layouts that reorder toggles visually without changing the DOM.
 
@@ -59,7 +58,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 **Manual testing steps**
 
-1. Open the Toggle Button demos and set browser zoom to 200% (<kbd>Ctrl</kbd> or <kbd>Cmd</kbd> and <kbd>+</kbd>).
+1. In a UI with toggle buttons, set browser zoom to 200% (<kbd>Ctrl</kbd> or <kbd>Cmd</kbd> and <kbd>+</kbd>).
 2. Confirm labels are fully visible and toggles still work.
 
 **Pass:** nothing is clipped or cut off at 200%.
@@ -73,8 +72,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 **Manual testing steps**
 
-1. Open a toggle with a text label and try to select the text with the mouse, or zoom in.
-2. Confirm it behaves like real text (selectable, stays crisp), not a picture.
+1. Select a toggle button's label with the mouse (or zoom in) and confirm it behaves like real text (selectable, stays crisp), not a picture.
 
 **Pass:** labels are live text. No toggle uses an image of text.
 
@@ -86,7 +84,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 **Manual testing steps**
 
-1. Open the Toggle Button demos and set the window, or the DevTools device toolbar, to 320 CSS pixels wide.
+1. In a UI with toggle buttons, set the window (or the DevTools device toolbar) to 320 CSS pixels wide.
 2. Confirm there is no sideways scrolling and all toggles are reachable.
 
 **Pass:** content reflows with no horizontal scroll.
@@ -130,9 +128,8 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 **Manual testing steps**
 
-1. Open `ToggleButtonA11ySemanticStates` with a screen reader running (NVDA with Chrome, or VoiceOver with Safari).
-2. <kbd>Tab</kbd> to each toggle and confirm it announces the visible label or `aria-label`, and does not read out the icon.
-3. For any icon-only toggle in the product, confirm it has an `aria-label` describing the action.
+1. With a screen reader running (NVDA with Chrome, or VoiceOver with Safari), <kbd>Tab</kbd> to toggle buttons that carry an icon and confirm each announces the visible label or `aria-label`, not the icon.
+2. For any icon-only toggle in the product, confirm it has an `aria-label` describing the action.
 
 **Pass:** every toggle's announced name matches its purpose, and decorative icons are silent.
 
@@ -145,8 +142,8 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 **Manual testing steps**
 
-1. Open `ToggleButtonA11ySemanticStates` and `ToggleButtonA11yNonNative` with a screen reader running.
-2. Confirm the plain toggle announces "button", the selected one announces its pressed state, the disabled one announces its disabled state, and the custom one announces "button".
+1. With a screen reader running, focus a selected toggle, an unselected toggle, a disabled toggle, and a non-native (`role="button"`) toggle.
+2. Confirm the unselected toggle announces "button", the selected one announces its pressed state, the disabled one announces its disabled state, and the non-native one announces "button".
 
 **Pass:** role and state match the visual presentation for every variant.
 
@@ -159,9 +156,8 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 **Manual testing steps**
 
-1. Open `ColorToggleButton` or `ToggleButtonA11yColorMatrix`.
-2. Turn on a grayscale view (in Chrome DevTools: Rendering tab, Emulate vision deficiencies, Achromatopsia).
-3. Confirm each toggle can still be told apart, and that a selected toggle is still distinguishable from an unselected one.
+1. In a UI with color-variant toggle buttons (a `ToggleButtonGroup` with a `color`), turn on a grayscale view (in Chrome DevTools: Rendering tab, Emulate vision deficiencies, Achromatopsia).
+2. Confirm each toggle can still be told apart, and that a selected toggle is still distinguishable from an unselected one.
 
 **Pass:** the control's meaning survives without color. The `standard` selected state stays distinguishable; the color variants do not, since their pressed cue is hue-dominant.
 
@@ -174,7 +170,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 **Manual testing steps**
 
-1. Open `ToggleButtonA11yColorMatrix`. With a contrast checker (the color picker in browser DevTools shows a ratio), check each selected label against its background.
+1. With a contrast checker (the color picker in browser DevTools shows a ratio), check each selected toggle's label against its background, across the color variants in use.
 2. Repeat with the pointer hovering, since `:hover` changes the background.
 3. Check any custom theme colors the product uses.
 
@@ -189,7 +185,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 **Manual testing steps**
 
-1. Open `ToggleButtons`. Press <kbd>Tab</kbd> to a toggle so its focus indicator shows, and measure the indicator against the colors next to it.
+1. Press <kbd>Tab</kbd> to a toggle so its focus indicator shows, and measure the indicator against the colors next to it.
 2. Measure a selected toggle's fill (and any meaningful icon) against the unselected state and the background.
 3. Set `disableRipple` or `disableFocusRipple` on a toggle (no demo ships these) and repeat: the focus indicator should be gone.
 
@@ -204,9 +200,8 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 **Manual testing steps**
 
-1. Open `ToggleButtonA11yTextSpacing`.
-2. Apply the WCAG text-spacing values. The quickest way is to run this in the DevTools console: `document.head.insertAdjacentHTML('beforeend','<style>*{line-height:1.5!important;letter-spacing:.12em!important;word-spacing:.16em!important}</style>')`.
-3. Look for cut-off, clipped, or overlapping label text.
+1. On a toggle button with a long label, apply the WCAG text-spacing values. The quickest way is to run this in the DevTools console: `document.head.insertAdjacentHTML('beforeend','<style>*{line-height:1.5!important;letter-spacing:.12em!important;word-spacing:.16em!important}</style>')`.
+2. Look for cut-off, clipped, or overlapping label text.
 
 **Pass:** all label text stays visible and the toggle still works.
 
@@ -229,11 +224,12 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 `⚠️ Partially Supports` · `● Component`
 
 - Keyboard focus shows the `.Mui-focusVisible` ripple (suppressed for mouse). The component sets no other focus style.
-- `disableRipple` removes every ripple and `disableFocusRipple` removes the focus ripple, so either prop leaves the toggle with no visible focus indicator (the `disableRipple` prop documents this). [`ToggleButton.test.js`](./ToggleButton.test.js) confirms a keyboard-focused toggle renders no ripple under `disableRipple`.
+- `disableRipple` removes every ripple and `disableFocusRipple` removes the focus ripple, so either prop leaves the toggle with no visible focus indicator (the `disableRipple` prop documents this).
+- Confirmed by a unit test in [`./ToggleButton.test.js`](./ToggleButton.test.js) (no focus ripple under `disableRipple`).
 
 **Manual testing steps**
 
-1. Open `ToggleButtons` and `StandaloneToggleButton`. Press <kbd>Tab</kbd> to move to each toggle.
+1. Press <kbd>Tab</kbd> to move focus across toggle buttons (standalone and within a `ToggleButtonGroup`).
 2. Confirm a clear focus indicator appears, and that it looks different from the selected style.
 3. Click a toggle with the mouse and confirm the indicator does not appear (it is keyboard-only).
 4. Set `disableRipple` or `disableFocusRipple` on a toggle (no demo ships these) and <kbd>Tab</kbd> to it.
@@ -244,8 +240,9 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 `✅ Supports` · `◐ Shared`
 
-- When a toggle has a visible text label, that text is the accessible name (the children become the name). An icon-only toggle has no visible text, so its `aria-label` is the name. [`ToggleButton.test.js`](./ToggleButton.test.js) confirms the accessible name contains the visible label.
+- When a toggle has a visible text label, that text is the accessible name (the children become the name). An icon-only toggle has no visible text, so its `aria-label` is the name.
 - An `aria-label` that omits or reorders the visible words breaks this. Compare the visible text to the computed name.
+- Confirmed by a unit test in [`./ToggleButton.test.js`](./ToggleButton.test.js) (the accessible name contains the visible label).
 
 **Manual testing steps**
 
@@ -259,13 +256,14 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 `✅ Supports` · `◐ Shared`
 
-- A native `<button>` (or `role="button"` for a non-native host) sets the role; `aria-pressed` reflects `selected` for the on/off state, the W3C-prescribed mechanism for a toggle button (distinct from a switch's `aria-checked`); `disabled` sets state. axe-core `button-name` (with `aria-command-name` covering the non-native host), the other `aria-*` rules, and `nested-interactive` all pass; [`ToggleButton.test.js`](./ToggleButton.test.js) also unit-tests that `aria-pressed` reflects and flips with `selected`.
+- A native `<button>` (or `role="button"` for a non-native host) sets the role; `aria-pressed` reflects `selected` for the on/off state, the W3C-prescribed mechanism for a toggle button (distinct from a switch's `aria-checked`); `disabled` sets state. axe-core `button-name` (with `aria-command-name` covering the non-native host), the other `aria-*` rules, and `nested-interactive` all pass.
 - axe-core covers the mechanical layer (a name is present, `aria-pressed` is a valid and permitted value). Whether the name is meaningful, and whether the pressed state matches the visual state and is announced on change, needs an assistive-technology review.
+- Confirmed by a unit test in [`./ToggleButton.test.js`](./ToggleButton.test.js) (`aria-pressed` reflects `selected`).
 
 **Manual testing steps**
 
-1. Open `ToggleButtonA11ySemanticStates`, `ToggleButtonA11yNonNative`, and `ToggleButtonsMultiple` with a screen reader running.
-2. <kbd>Tab</kbd> to each toggle and confirm the announced name, role, and pressed or disabled state are correct.
+1. With a screen reader running, <kbd>Tab</kbd> to each toggle variant in use (native, non-native `role="button"`, selected, unselected, disabled), typically within a `ToggleButtonGroup`.
+2. Confirm the announced name, role, and pressed or disabled state are correct.
 3. Activate a toggle and confirm the pressed/not-pressed change is announced.
 
 **Pass:** name, role, and state are correct for every variant, and state changes are announced.
@@ -281,22 +279,25 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 2.1.2 No Keyboard Trap · A
 
-`🚩` · `✅ Supports` · `● Component`
+`✅ Supports` · `● Component`
 
 - A single focusable control that installs no focus-capturing loop. <kbd>Tab</kbd> moves in and out, and a disabled toggle leaves the tab order (the `disabled` attribute on native buttons, `tabIndex=-1` on non-native).
+- Confirmed by a unit test in [`./ToggleButton.test.js`](./ToggleButton.test.js) (<kbd>Tab</kbd> is not intercepted, and focus moves away freely).
 
 #### 2.4.3 Focus Order · A
 
-`🚩` · `✅ Supports` · `◐ Shared`
+`✅ Supports` · `◐ Shared`
 
 - The component sits in natural DOM order with no positive `tabIndex`, and a disabled toggle leaves the order, so it is one correct focus stop.
 - Order across toggles is the surrounding layout's responsibility.
+- Confirmed by a unit test in [`./ToggleButton.test.js`](./ToggleButton.test.js) (default `tabIndex` is `0`; a disabled toggle leaves the order).
 
 #### 2.5.2 Pointer Cancellation · A
 
 `✅ Supports` · `● Component`
 
-- Activation runs on `click`, fired on pointer-up over the target. `onMouseDown` only starts the ripple, and releasing off the target cancels, so nothing runs on the down event. [`ToggleButton.test.js`](./ToggleButton.test.js) confirms `onChange` fires on click but not on `mouseDown` alone.
+- Activation runs on `click`, fired on pointer-up over the target. `onMouseDown` only starts the ripple, and releasing off the target cancels, so nothing runs on the down event.
+- Confirmed by a unit test in [`./ToggleButton.test.js`](./ToggleButton.test.js) (a pointer released off the target does not activate; `click` does).
 
 #### 2.5.8 Target Size (Minimum) · AA
 
@@ -307,16 +308,18 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 3.2.1 On Focus · A
 
-`🚩` · `✅ Supports` · `● Component`
+`✅ Supports` · `● Component`
 
 - Focus triggers only the focus-visible ripple and `onFocus` callbacks. There is no navigation, dialog, or focus move, so focus alone changes no context.
+- Confirmed by a unit test in [`./ToggleButton.test.js`](./ToggleButton.test.js) (focusing the toggle does not activate it).
 
 #### 3.2.2 On Input · A
 
-`🚩` · `✅ Supports` · `◐ Shared`
+`✅ Supports` · `◐ Shared`
 
 - Toggling the pressed state (`selected`, exposed as `aria-pressed`) changes no context on its own.
 - Whether an author's `onChange` handler couples that change to navigation or a new window without warning is an author decision.
+- Confirmed by a unit test in [`./ToggleButton.test.js`](./ToggleButton.test.js) (the pressed state does not activate the toggle on its own).
 
 ## Not applicable
 

--- a/packages/mui-material/src/ToggleButton/accessibility.md
+++ b/packages/mui-material/src/ToggleButton/accessibility.md
@@ -8,7 +8,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 | ⚠️ Partially Supports | 4     |
 | ❌ Does Not Support   | 0     |
 | ➖ Not Applicable     | 31    |
-| 🚩 Unverified         | 17/24 |
+| 🚩 Unverified         | 14/24 |
 
 ## Known gaps
 
@@ -199,10 +199,10 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 2.4.7 Focus Visible · AA
 
-`🚩 Unverified` · `⚠️ Partially Supports` · `● Component`
+`⚠️ Partially Supports` · `● Component`
 
 - Keyboard focus shows the `.Mui-focusVisible` ripple (suppressed for mouse). The component sets no other focus style.
-- `disableRipple` removes every ripple and `disableFocusRipple` removes the focus ripple, so either prop leaves the toggle with no visible focus indicator (the `disableRipple` prop documents this).
+- `disableRipple` removes every ripple and `disableFocusRipple` removes the focus ripple, so either prop leaves the toggle with no visible focus indicator (the `disableRipple` prop documents this). [`ToggleButton.test.js`](./ToggleButton.test.js) confirms a keyboard-focused toggle renders no ripple under `disableRipple`.
 
 **Manual testing steps**
 
@@ -215,9 +215,9 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 2.5.3 Label in Name · A
 
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+`✅ Supports` · `◐ Shared`
 
-- When a toggle has a visible text label, that text is the accessible name (the children become the name). An icon-only toggle has no visible text, so its `aria-label` is the name.
+- When a toggle has a visible text label, that text is the accessible name (the children become the name). An icon-only toggle has no visible text, so its `aria-label` is the name. [`ToggleButton.test.js`](./ToggleButton.test.js) confirms the accessible name contains the visible label.
 - An `aria-label` that omits or reorders the visible words breaks this. Compare the visible text to the computed name.
 
 **Manual testing steps**
@@ -232,7 +232,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 `✅ Supports` · `◐ Shared`
 
-- A native `<button>` (or `role="button"` for a non-native host) sets the role; `aria-pressed` reflects `selected` for the on/off state, the W3C-prescribed mechanism for a toggle button (distinct from a switch's `aria-checked`); `disabled` sets state. axe-core `button-name` (with `aria-command-name` covering the non-native host), the other `aria-*` rules, and `nested-interactive` all pass.
+- A native `<button>` (or `role="button"` for a non-native host) sets the role; `aria-pressed` reflects `selected` for the on/off state, the W3C-prescribed mechanism for a toggle button (distinct from a switch's `aria-checked`); `disabled` sets state. axe-core `button-name` (with `aria-command-name` covering the non-native host), the other `aria-*` rules, and `nested-interactive` all pass; [`ToggleButton.test.js`](./ToggleButton.test.js) also unit-tests that `aria-pressed` reflects and flips with `selected`.
 - axe-core covers the mechanical layer (a name is present, `aria-pressed` is a valid and permitted value). Whether the name is meaningful, and whether the pressed state matches the visual state and is announced on change, needs an assistive-technology review.
 
 **Manual testing steps**
@@ -294,9 +294,9 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 2.5.2 Pointer Cancellation · A
 
-`🚩 Unverified` · `✅ Supports` · `● Component`
+`✅ Supports` · `● Component`
 
-- Activation runs on `click`, fired on pointer-up over the target. `onMouseDown` only starts the ripple, and releasing off the target cancels, so nothing runs on the down event.
+- Activation runs on `click`, fired on pointer-up over the target. `onMouseDown` only starts the ripple, and releasing off the target cancels, so nothing runs on the down event. [`ToggleButton.test.js`](./ToggleButton.test.js) confirms `onChange` fires on click but not on `mouseDown` alone.
 
 #### 2.5.8 Target Size (Minimum) · AA
 

--- a/packages/mui-material/src/ToggleButton/accessibility.md
+++ b/packages/mui-material/src/ToggleButton/accessibility.md
@@ -8,7 +8,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 | ⚠️ Partially Supports | 4     |
 | ❌ Does Not Support   | 0     |
 | ➖ Not Applicable     | 31    |
-| 🚩 Unverified         | 14/24 |
+| 🚩 Flagged            | 14/24 |
 
 ## Known gaps
 
@@ -23,7 +23,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.3.2 Meaningful Sequence · A
 
-`🚩 Unverified` · `✅ Supports` · `○ Author`
+`🚩` · `✅ Supports` · `○ Author`
 
 - The Toggle Button is one control. Its children render in DOM order; a decorative MUI icon is `aria-hidden`, leaving the label (text or `aria-label`) as the exposed content.
 - Order carries meaning only across several toggles, which the surrounding layout (often a `ToggleButtonGroup`) sets. Confirm that reading order matches the visual order.
@@ -38,7 +38,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.3.3 Sensory Characteristics · A
 
-`🚩 Unverified` · `✅ Supports` · `○ Author`
+`🚩` · `✅ Supports` · `○ Author`
 
 - A toggle with text or an `aria-label` can be identified by name, not only by shape, color, or position.
 - Instructions in the surrounding content must not rely on color, shape, or position alone (for example, "the highlighted button").
@@ -52,7 +52,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.4.4 Resize Text · AA
 
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+`🚩` · `✅ Supports` · `◐ Shared`
 
 - Typography is set in rem and em, so the label and toggle scale with browser zoom or font size rather than staying pixel-fixed.
 - A fixed-pixel container in the surrounding layout could clip at 200%.
@@ -66,7 +66,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.4.5 Images of Text · AA
 
-`🚩 Unverified` · `✅ Supports` · `○ Author`
+`🚩` · `✅ Supports` · `○ Author`
 
 - A text label is live CSS text; the component never renders it as an image.
 - This fails only if an image of text, or an icon font spelling words, is passed as the children. Use real text or an icon with an `aria-label`.
@@ -80,7 +80,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.4.10 Reflow · AA
 
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+`🚩` · `✅ Supports` · `◐ Shared`
 
 - A toggle sizes to its content, so it reflows on its own. Horizontal overflow at 320 CSS pixels comes from the surrounding layout, such as a wide `ToggleButtonGroup` that does not wrap.
 
@@ -93,7 +93,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 2.4.11 Focus Not Obscured (Minimum) · AA
 
-`🚩 Unverified` · `✅ Supports` · `○ Author`
+`🚩` · `✅ Supports` · `○ Author`
 
 - The Toggle Button is an ordinary focusable element and never places itself behind other content. Obscuring comes from sticky headers, banners, or overlays in the surrounding layout.
 - Confirm by moving focus to a toggle beneath any sticky or overlay content at several scroll positions. At least part of it must stay visible.
@@ -107,7 +107,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 3.2.4 Consistent Identification · AA
 
-`🚩 Unverified` · `✅ Supports` · `○ Author`
+`🚩` · `✅ Supports` · `○ Author`
 
 - The component produces one stable accessible name per set of props, the precondition for consistent identification.
 - Consistency is a cross-page property. Confirm that toggles with the same function share a label and icon, and that one label is not reused for different functions.
@@ -152,7 +152,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.4.1 Use of Color · A
 
-`🚩 Unverified` · `⚠️ Partially Supports` · `● Component`
+`🚩` · `⚠️ Partially Supports` · `● Component`
 
 - A toggle's purpose comes from its label or icon, not color, so the control itself is not identified by color alone.
 - The pressed state is the gap. For `standard`, selecting darkens the label from `action.active` to `text.primary`, a clear lightness change. For the color variants the selected label switches to `color.main`, which is almost the same lightness as the unselected `action.active` (in grayscale `primary` differs by about 0.0003, `error` by 0.017), and the only other cue is a roughly 1.1:1 fill, so a `primary`/`error`/`info`/`success` toggle's pressed state is conveyed almost entirely by hue.
@@ -182,7 +182,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.4.11 Non-text Contrast · AA
 
-`🚩 Unverified` · `⚠️ Partially Supports` · `● Component`
+`🚩` · `⚠️ Partially Supports` · `● Component`
 
 - The label or icon identifies the control, so WCAG does not require the `divider` border to reach 3:1. The pieces that do need 3:1 are the focus indicator and the visual cue that marks the pressed state.
 - The focus indicator is the ripple; `disableRipple`/`disableFocusRipple` remove it, so it can be absent entirely. The selected-state fill (`action.selectedOpacity`, 0.08) is faint and untested against the unselected state. Disabled toggles are exempt.
@@ -197,7 +197,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.4.12 Text Spacing · AA
 
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+`🚩` · `✅ Supports` · `◐ Shared`
 
 - A text label wraps when `white-space: normal` is set and the toggle height comes from padding, not a fixed height, so the WCAG text-spacing values grow the toggle without clipping.
 - No axe-core rule covers this (`avoid-inline-spacing` only inspects inline `style`, but `sx` compiles to a class); a `ToggleButtonA11yTextSpacing` screenshot guards the rendered spacing layout against regressions. Inject the spacing values through a stylesheet to check for clipping.
@@ -281,13 +281,13 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 2.1.2 No Keyboard Trap · A
 
-`🚩 Unverified` · `✅ Supports` · `● Component`
+`🚩` · `✅ Supports` · `● Component`
 
 - A single focusable control that installs no focus-capturing loop. <kbd>Tab</kbd> moves in and out, and a disabled toggle leaves the tab order (the `disabled` attribute on native buttons, `tabIndex=-1` on non-native).
 
 #### 2.4.3 Focus Order · A
 
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+`🚩` · `✅ Supports` · `◐ Shared`
 
 - The component sits in natural DOM order with no positive `tabIndex`, and a disabled toggle leaves the order, so it is one correct focus stop.
 - Order across toggles is the surrounding layout's responsibility.
@@ -307,13 +307,13 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 3.2.1 On Focus · A
 
-`🚩 Unverified` · `✅ Supports` · `● Component`
+`🚩` · `✅ Supports` · `● Component`
 
 - Focus triggers only the focus-visible ripple and `onFocus` callbacks. There is no navigation, dialog, or focus move, so focus alone changes no context.
 
 #### 3.2.2 On Input · A
 
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+`🚩` · `✅ Supports` · `◐ Shared`
 
 - Toggling the pressed state (`selected`, exposed as `aria-pressed`) changes no context on its own.
 - Whether an author's `onChange` handler couples that change to navigation or a new window without warning is an author decision.

--- a/packages/mui-material/src/ToggleButton/accessibility.md
+++ b/packages/mui-material/src/ToggleButton/accessibility.md
@@ -50,6 +50,20 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 **Pass:** no instruction relies on "the highlighted one" or "the button on the left" without naming it.
 
+#### 1.4.4 Resize Text · AA
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- Typography is set in rem and em, so the label and toggle scale with browser zoom or font size rather than staying pixel-fixed.
+- A fixed-pixel container in the surrounding layout could clip at 200%.
+
+**Manual testing steps**
+
+1. Open the Toggle Button demos and set browser zoom to 200% (<kbd>Ctrl</kbd> or <kbd>Cmd</kbd> and <kbd>+</kbd>).
+2. Confirm labels are fully visible and toggles still work.
+
+**Pass:** nothing is clipped or cut off at 200%.
+
 #### 1.4.5 Images of Text · AA
 
 `🚩 Unverified` · `✅ Supports` · `○ Author`
@@ -63,6 +77,19 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 2. Confirm it behaves like real text (selectable, stays crisp), not a picture.
 
 **Pass:** labels are live text. No toggle uses an image of text.
+
+#### 1.4.10 Reflow · AA
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- A toggle sizes to its content, so it reflows on its own. Horizontal overflow at 320 CSS pixels comes from the surrounding layout, such as a wide `ToggleButtonGroup` that does not wrap.
+
+**Manual testing steps**
+
+1. Open the Toggle Button demos and set the window, or the DevTools device toolbar, to 320 CSS pixels wide.
+2. Confirm there is no sideways scrolling and all toggles are reachable.
+
+**Pass:** content reflows with no horizontal scroll.
 
 #### 2.4.11 Focus Not Obscured (Minimum) · AA
 
@@ -244,33 +271,6 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 **Pass:** name, role, and state are correct for every variant, and state changes are announced.
 
 ### ⚙️ Automated
-
-#### 1.4.4 Resize Text · AA
-
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
-
-- Typography is set in rem and em, so the label and toggle scale with browser zoom or font size rather than staying pixel-fixed.
-- A fixed-pixel container in the surrounding layout could clip at 200%.
-
-**Manual testing steps**
-
-1. Open the Toggle Button demos and set browser zoom to 200% (<kbd>Ctrl</kbd> or <kbd>Cmd</kbd> and <kbd>+</kbd>).
-2. Confirm labels are fully visible and toggles still work.
-
-**Pass:** nothing is clipped or cut off at 200%.
-
-#### 1.4.10 Reflow · AA
-
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
-
-- A toggle sizes to its content, so it reflows on its own. Horizontal overflow at 320 CSS pixels comes from the surrounding layout, such as a wide `ToggleButtonGroup` that does not wrap.
-
-**Manual testing steps**
-
-1. Open the Toggle Button demos and set the window, or the DevTools device toolbar, to 320 CSS pixels wide.
-2. Confirm there is no sideways scrolling and all toggles are reachable.
-
-**Pass:** content reflows with no horizontal scroll.
 
 #### 2.1.1 Keyboard · A
 

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, screen } from '@mui/internal-test-utils';
@@ -296,6 +297,64 @@ describe('<ToggleButtonGroup />', () => {
       expect(button).not.to.have.class(classes.firstButton);
       expect(button).not.to.have.class(classes.middleButton);
       expect(button).not.to.have.class(classes.lastButton);
+    });
+  });
+
+  describe('WCAG 2.2 conformance', () => {
+    describe('1.3.1 Info and Relationships', () => {
+      it('exposes the group role on the root', () => {
+        render(
+          <ToggleButtonGroup value="left">
+            <ToggleButton value="left">Left</ToggleButton>
+            <ToggleButton value="right">Right</ToggleButton>
+          </ToggleButtonGroup>,
+        );
+
+        expect(screen.getByRole('group')).not.to.equal(null);
+      });
+    });
+
+    describe('4.1.2 Name, Role, Value', () => {
+      it('names the group from its aria-label', () => {
+        render(
+          <ToggleButtonGroup value="left" aria-label="text alignment">
+            <ToggleButton value="left">Left</ToggleButton>
+            <ToggleButton value="right">Right</ToggleButton>
+          </ToggleButtonGroup>,
+        );
+
+        expect(screen.getByRole('group', { name: 'text alignment' })).not.to.equal(null);
+      });
+
+      it('reflects the exclusive selection as aria-pressed on the children', async () => {
+        function ControlledGroup() {
+          const [alignment, setAlignment] = React.useState('left');
+          return (
+            <ToggleButtonGroup
+              value={alignment}
+              exclusive
+              onChange={(event, newAlignment) => setAlignment(newAlignment)}
+              aria-label="text alignment"
+            >
+              <ToggleButton value="left" disableRipple>
+                Left
+              </ToggleButton>
+              <ToggleButton value="right" disableRipple>
+                Right
+              </ToggleButton>
+            </ToggleButtonGroup>
+          );
+        }
+
+        const { user } = render(<ControlledGroup />);
+        const [left, right] = screen.getAllByRole('button');
+        expect(left).to.have.attribute('aria-pressed', 'true');
+        expect(right).to.have.attribute('aria-pressed', 'false');
+
+        await user.click(right);
+        expect(left).to.have.attribute('aria-pressed', 'false');
+        expect(right).to.have.attribute('aria-pressed', 'true');
+      });
     });
   });
 });

--- a/packages/mui-material/src/ToggleButtonGroup/accessibility.md
+++ b/packages/mui-material/src/ToggleButtonGroup/accessibility.md
@@ -1,0 +1,151 @@
+# ToggleButtonGroup accessibility conformance
+
+Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility.md).
+
+ToggleButtonGroup coordinates a set of [Toggle Button](../ToggleButton/accessibility.md) children, so this report rates only the criteria that exist or change because of the grouping. Each toggle's own conformance (contrast, target size, label in name, focus indicator, keyboard activation, and the rest) is rated in the [Toggle Button report](../ToggleButton/accessibility.md) and listed under [Inherited from Toggle Button](#inherited-from-toggle-button).
+
+Unlike a radio group, ToggleButtonGroup adds no roving tab order and no arrow-key navigation: it wraps the toggles in a `role="group"` container, and each toggle stays an independent tab stop that activates on its own. Keyboard operation and focus order are therefore inherited per toggle, not rated here.
+
+| Result                          | Count |
+| :------------------------------ | :---- |
+| ✅ Supports                     | 4     |
+| ⚠️ Partially Supports           | 0     |
+| ❌ Does Not Support             | 0     |
+| ➖ Not Applicable               | 31    |
+| ↗ Inherited (see Toggle Button) | 20    |
+| 🚩 Flagged                      | 2/4   |
+
+The first rows and Not Applicable count the 4 group-level criteria plus the 31 that do not apply; Inherited adds the 20 item-level criteria rated in Toggle Button (4 + 31 + 20 = 55). Flagged is the ratio of source-assessed to applicable group-level criteria; inherited criteria are excluded.
+
+## Known gaps
+
+No group-level gaps.
+
+## Success criteria
+
+### 🔍 Manual
+
+#### 1.4.10 Reflow · AA
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- Each toggle sizes to its content, but the group owns the layout: a horizontal group is `display: inline-flex` and does not wrap (`ToggleButtonGroup.js`), so a wide row of toggles can overflow horizontally at 320 CSS pixels.
+- The component provides `orientation="vertical"` as the escape hatch; the author keeps the group within 320 pixels by switching orientation or limiting the number of toggles.
+
+**Manual testing steps**
+
+1. In a UI with a horizontal toggle button group, set the window (or the DevTools device toolbar) to 320 CSS pixels wide.
+2. Confirm there is no sideways scrolling and every toggle is reachable, switching the group to vertical orientation if the row does not fit.
+
+**Pass:** content reflows with no horizontal scroll.
+
+### 🔁 Hybrid
+
+#### 1.3.1 Info and Relationships · A
+
+`✅ Supports` · `◐ Shared`
+
+- ToggleButtonGroup sets `role="group"` on its root (`ToggleButtonGroup.js`), so the toggles are exposed as one related set. axe-core's `aria-roles` and `aria-allowed-attr` pass across the group demos.
+- The group's accessible name is the author's to set with `aria-label` or `aria-labelledby`; without one the grouping is exposed but unnamed.
+- Confirmed by a unit test in [`./ToggleButtonGroup.test.js`](./ToggleButtonGroup.test.js).
+
+**Manual testing steps**
+
+1. With a screen reader running, move focus into the group and confirm the group and its name are announced (for example, "text alignment, group").
+2. Render a group with no `aria-label` and confirm the group is exposed but unnamed.
+
+**Pass:** the toggles are exposed as one group, named when the author supplies a label.
+
+#### 2.4.6 Headings and Labels · AA
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- The group's label comes from the author's `aria-label`, the documented pattern ("text alignment" and "text formatting" in the demos).
+- Whether the wording describes the set of choices depends on author content, a vague group label ("Options") would fail.
+
+**Manual testing steps**
+
+1. Read each toggle group's `aria-label`.
+2. Confirm it describes the set of choices ("text alignment", not "Options").
+
+**Pass:** every group label describes the set of toggles it contains.
+
+#### 4.1.2 Name, Role, Value · A
+
+`✅ Supports` · `◐ Shared`
+
+- The group's role and value are met: `role="group"` names the relationship, and the selected value is exposed by each child's `aria-pressed`, which the group drives from its `value` and `exclusive` props (`ToggleButtonGroup.js`). axe-core `aria-roles`, `button-name`, and `nested-interactive` pass across the group demos.
+- The group's name is the shared part, supplied by the author's `aria-label`.
+- Confirmed by a unit test in [`./ToggleButtonGroup.test.js`](./ToggleButtonGroup.test.js).
+
+**Manual testing steps**
+
+1. With a screen reader running, focus each toggle in a group and confirm the group role, its author-supplied name, and each toggle's pressed state are announced.
+2. Activate a toggle and confirm the pressed change is announced.
+
+**Pass:** the group exposes its role and author-supplied name, and each toggle's pressed state and its changes are announced.
+
+## Inherited from Toggle Button
+
+- **1.1.1 Non-text Content (A).** Each toggle's icon handling and label-derived name.
+- **1.3.2 Meaningful Sequence (A).** Each toggle's DOM-order content.
+- **1.3.3 Sensory Characteristics (A).** Each toggle's reliance on its label, not sensory cues.
+- **1.4.1 Use of Color (A).** Each toggle's selected-state color cue.
+- **1.4.3 Contrast (Minimum) (AA).** Each toggle's label against its background.
+- **1.4.4 Resize Text (AA).** Each toggle's rem-sized label.
+- **1.4.5 Images of Text (AA).** Each toggle's live-text label.
+- **1.4.11 Non-text Contrast (AA).** Each toggle's focus indicator and selected fill.
+- **1.4.12 Text Spacing (AA).** Each toggle's label under spacing overrides.
+- **2.1.1 Keyboard (A).** Each toggle's <kbd>Enter</kbd> and <kbd>Space</kbd> activation.
+- **2.1.2 No Keyboard Trap (A).** Each toggle as a single focusable control.
+- **2.4.3 Focus Order (A).** Each toggle as one tab stop in DOM order.
+- **2.4.7 Focus Visible (AA).** Each toggle's focus ripple.
+- **2.4.11 Focus Not Obscured (Minimum) (AA).** Each toggle's focus visibility.
+- **2.5.2 Pointer Cancellation (A).** Each toggle activating on pointer-up.
+- **2.5.3 Label in Name (A).** Each toggle's accessible name containing its label.
+- **2.5.8 Target Size (Minimum) (AA).** Each toggle's padded target.
+- **3.2.1 On Focus (A).** Each toggle changing nothing on focus.
+- **3.2.2 On Input (A).** Each toggle changing only its pressed state.
+- **3.2.4 Consistent Identification (AA).** Each toggle's stable label.
+
+## Not applicable
+
+- **1.3.5 Identify Input Purpose (AA).** Not an input; collects no user data through `autocomplete`.
+- **1.4.13 Content on Hover or Focus (AA).** The group shows no additional content on hover or focus; a `Tooltip` wrapper would own this.
+- **2.1.4 Character Key Shortcuts (A).** The only keys are <kbd>Enter</kbd> and <kbd>Space</kbd>, which are not single-character shortcuts.
+- **2.2.2 Pause, Stop, Hide (A).** Nothing moves or auto-updates.
+- **2.4.4 Link Purpose (In Context) (A).** The group renders no links.
+- **2.5.7 Dragging Movements (AA, new in 2.2).** Toggles select on tap or click; no drag operation.
+- **3.1.1 Language of Page (A), 3.1.2 Language of Parts (AA).** The group emits no `<html lang>` and no text of its own.
+- **3.2.3 Consistent Navigation (AA).** Covers repeated navigation across a set of pages, not a single group.
+- **3.2.6 Consistent Help (A, new in 2.2).** Covers consistent placement of help across pages.
+- **3.3.2 Labels or Instructions (A).** Limited by WCAG to data-entry controls, and it excludes interactive components not associated with data entry. The group's children are toggle buttons (`aria-pressed`, `role="button"`), not form fields, so the group is outside this criterion. (This is where ToggleButtonGroup differs from a radio group, whose native radios are data entry.)
+- **3.3.7 Redundant Entry (A, new in 2.2).** Covers repopulating previously entered data. The group captures none.
+- **3.3.8 Accessible Authentication (Minimum) (AA, new in 2.2).** The paste, autofill, and cognitive-test duty falls on the credential fields, not a toggle group.
+- **4.1.3 Status Messages (AA).** The group emits no status messages; the selected value is exposed through each toggle's `aria-pressed`.
+- **Time-based media (1.2.1 to 1.2.5).** No audio or video.
+- **Audio Control (1.4.2).** Emits no audio.
+- **Orientation (1.3.4).** Sets no orientation lock; the `orientation` prop is a layout choice, not a display-orientation restriction.
+- **Bypass Blocks (2.4.1), Page Titled (2.4.2), Multiple Ways (2.4.5).** Page or site structure concerns, not a single group.
+- **Timing Adjustable (2.2.1).** Sets no time limit.
+- **Three Flashes or Below Threshold (2.3.1).** Nothing flashes.
+- **Pointer Gestures (2.5.1), Motion Actuation (2.5.4).** Toggles activate on a simple click; the group reads no device motion.
+- **Error Identification (3.3.1), Error Suggestion (3.3.3), Error Prevention (3.3.4).** The group collects and validates no input; these belong to the form or process.
+
+## Level AAA
+
+The following SC are applicable but out of scope, and are item-level:
+
+- **2.3.3 Animation from Interactions.** Each toggle's ripple `scale()` animation honors `prefers-reduced-motion` when the theme sets `motion.reducedMotion` to `system` or `always`; `disableRipple` also removes it. The default is `never`. `🚩`
+- **2.4.13 Focus Appearance.** Each toggle's focus ripple is unlikely to meet the area and 3:1 thresholds, and `disableRipple` removes it. `🚩`
+- **2.5.5 Target Size (Enhanced), 44 px.** Each toggle's `small` size (about 40 px) is below 44 px. `🚩`
+- **1.4.6 Contrast (Enhanced), 7:1.** Palettes target the AA 4.5:1, so several selected toggle colors fall short of 7:1. `🚩`
+- Also touched, in the same shape as their A and AA siblings: **1.3.6 Identify Purpose, 1.4.9 Images of Text (No Exception), 2.1.3 Keyboard (No Exception), 2.4.12 Focus Not Obscured (Enhanced)**.
+
+## Scope and test environment
+
+- **Standard.** WCAG 2.2, Level A and AA.
+- **Component version.** `@mui/material` 9.1.2.
+- **Scope.** The ToggleButtonGroup component coordinating two or more `ToggleButton` children, with an author-supplied `aria-label` for the group's name, rendered through the documented API. Each toggle's item-level conformance is inherited from the [Toggle Button report](../ToggleButton/accessibility.md).
+- **Automated.** axe-core via the Playwright visual-regression harness. The group compositions share the Toggle Button demo slug, so their results are recorded in [`toggle-button.a11y.json`](../../../../docs/data/material/components/toggle-button/toggle-button.a11y.json), plus interaction tests in [`ToggleButtonGroup.test.js`](./ToggleButtonGroup.test.js).
+- **Assistive-technology review.** Not yet performed. Flagged criteria are assessed from source pending a review with NVDA, JAWS, and VoiceOver.

--- a/test/regressions/a11y/axe.ts
+++ b/test/regressions/a11y/axe.ts
@@ -57,6 +57,11 @@ interface RecordA11yOptions {
   slug: string;
   demo: string;
   /**
+   * `visual` asserts only rules that need real rendered CSS. `all` asserts
+   * every axe violation/incomplete not listed in `skipAssertions`.
+   */
+  assertions?: 'visual' | 'all';
+  /**
    * Rule ids whose violations are recorded but not asserted on. The rule
    * still runs and still lands in the results JSON — only the test-failing
    * assertion is suppressed.
@@ -74,7 +79,7 @@ interface RecordA11yOptions {
 export function recordA11y(
   ctx: TestContext,
   results: AxeResults,
-  { slug, demo, skipAssertions = [] }: RecordA11yOptions,
+  { slug, demo, assertions = 'visual', skipAssertions = [] }: RecordA11yOptions,
 ): void {
   const rules: Record<string, RuleEntry> = {};
   const buckets: ReadonlyArray<[AxeResults['passes'], RuleStatus]> = [
@@ -100,22 +105,20 @@ export function recordA11y(
   (ctx.task.meta as { a11y?: A11yMeta }).a11y = meta;
 
   const skip = new Set(skipAssertions);
-  const visualViolations = results.violations.filter(
-    (v) => VISUAL_RULES.includes(v.id) && !skip.has(v.id),
-  );
-  const visualIncomplete = results.incomplete.filter(
-    (v) => VISUAL_RULES.includes(v.id) && !skip.has(v.id),
-  );
+  const shouldAssert = (ruleId: string) =>
+    !skip.has(ruleId) && (assertions === 'all' || VISUAL_RULES.includes(ruleId));
+  const assertedViolations = results.violations.filter((v) => shouldAssert(v.id));
+  const assertedIncomplete = results.incomplete.filter((v) => shouldAssert(v.id));
 
   const failures: string[] = [];
-  if (visualViolations.length > 0) {
+  if (assertedViolations.length > 0) {
     failures.push(
-      `${visualViolations.length} axe violation(s):\n\n${formatResults(visualViolations)}`,
+      `${assertedViolations.length} axe violation(s):\n\n${formatResults(assertedViolations)}`,
     );
   }
-  if (visualIncomplete.length > 0) {
+  if (assertedIncomplete.length > 0) {
     failures.push(
-      `${visualIncomplete.length} axe incomplete (needs review):\n\n${formatResults(visualIncomplete)}`,
+      `${assertedIncomplete.length} axe incomplete (needs review):\n\n${formatResults(assertedIncomplete)}`,
     );
   }
   if (failures.length > 0) {

--- a/test/regressions/demoMeta.test.ts
+++ b/test/regressions/demoMeta.test.ts
@@ -49,6 +49,28 @@ describe('getConfig', () => {
     expect(
       getConfig(A11Y_RULES, 'docs/data/material/components/buttons/ColorButtons'),
     ).to.deep.include({ enabled: true });
+    expect(
+      getConfig(A11Y_RULES, 'docs/data/material/components/toggle-button/ToggleButtons'),
+    ).to.deep.include({ enabled: true, assertions: 'all' });
+    expect(
+      getConfig(
+        A11Y_RULES,
+        'docs/data/material/components/toggle-button/ToggleButtonA11ySemanticStates',
+      ),
+    ).to.deep.include({ enabled: true, assertions: 'all' });
+  });
+
+  it('allows a known Toggle Button color-contrast fixture to record failures without asserting them', () => {
+    expect(
+      getConfig(
+        A11Y_RULES,
+        'docs/data/material/components/toggle-button/ToggleButtonA11yColorMatrix',
+      ),
+    ).to.deep.include({
+      enabled: true,
+      assertions: 'all',
+      skipAssertions: ['color-contrast'],
+    });
   });
 
   it('returns undefined for a demo outside a brace-glob enrolment', () => {
@@ -56,6 +78,10 @@ describe('getConfig', () => {
     expect(getConfig(A11Y_RULES, 'docs/data/material/components/buttons/DisabledButtons')).to.equal(
       undefined,
     );
+    // StandaloneToggleButton is a docs demo that is not enrolled for axe assertions.
+    expect(
+      getConfig(A11Y_RULES, 'docs/data/material/components/toggle-button/StandaloneToggleButton'),
+    ).to.equal(undefined);
   });
 
   it('honours last-match-wins when multiple rules apply', () => {

--- a/test/regressions/demoMeta.ts
+++ b/test/regressions/demoMeta.ts
@@ -37,6 +37,11 @@ export interface A11yRule {
   /** Minimatch glob against `docs/data/material/components/{slug}/{Demo}`. */
   test: string;
   enabled?: boolean;
+  /**
+   * `visual` asserts rules that depend on rendered CSS. `all` asserts every
+   * axe violation/incomplete that is not listed in `skipAssertions`.
+   */
+  assertions?: 'visual' | 'all';
   /** Axe rule IDs recorded into results JSON but not asserted on. */
   skipAssertions?: string[];
 }
@@ -143,6 +148,22 @@ export const SCREENSHOT_RULES: ScreenshotRule[] = [
     viewportWidth: 1440,
     waitForSelector: '.MuiDataGrid-row:not(.MuiDataGrid-rowSkeleton) .MuiDataGrid-cell',
   },
+  { test: 'docs/data/material/components/toggle-button/ToggleButtonA11y*', enabled: false }, // A11y-only coverage fixtures
+  {
+    test: 'docs/data/material/components/toggle-button/ToggleButtonA11yTextSpacing',
+    enabled: true,
+  }, // Visual regression for text spacing (1.4.12); adds no unique axe coverage
+];
+
+// toggle-button docs demos enrolled for axe assertions; the remaining demos add
+// no axe coverage beyond the fixtures below.
+const TOGGLE_BUTTON_A11Y_DEMOS = [
+  'ToggleButtons',
+  'ToggleButtonsMultiple',
+  'VerticalToggleButtons',
+  'ToggleButtonA11yNonNative',
+  'ToggleButtonA11ySemanticStates',
+  'ToggleButtonA11yTextSpacing',
 ];
 
 /**
@@ -154,6 +175,17 @@ export const SCREENSHOT_RULES: ScreenshotRule[] = [
  */
 export const A11Y_RULES: A11yRule[] = [
   { test: 'docs/data/material/components/buttons/{BasicButtons,ColorButtons}', enabled: true },
+  {
+    test: `docs/data/material/components/toggle-button/{${TOGGLE_BUTTON_A11Y_DEMOS.join(',')}}`,
+    enabled: true,
+    assertions: 'all',
+  },
+  {
+    test: 'docs/data/material/components/toggle-button/ToggleButtonA11yColorMatrix',
+    enabled: true,
+    assertions: 'all',
+    skipAssertions: ['color-contrast'],
+  },
 ];
 
 export interface ParsedRoute {

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -219,6 +219,7 @@ async function main() {
               recordA11y({ task }, results, {
                 slug: parsed.slug,
                 demo: parsed.demo,
+                assertions: a11yRule.assertions,
                 skipAssertions: a11yRule.skipAssertions,
               });
             }


### PR DESCRIPTION
ToggleButton
| Result                | Count |
| :-------------------- | :---- |
| ✅ Supports           | 20    |
| ⚠️ Partially Supports | 4     |
| ❌ Does Not Support   | 0     |
| ➖ Not Applicable     | 31    |

ToggleButtonGroup
| Result                         | Count |
| :----------------------------- | :---- |
| ✅ Supports                    | 4     |
| ⚠️ Partially Supports          | 0     |
| ❌ Does Not Support            | 0     |
| ➖ Not Applicable              | 31    |
| ↗ Inherited from Toggle Button | 20    |

Doc:
- [ToggleButton](https://github.com/mj12albert/material-ui/blob/wcag-toggle-button/packages/mui-material/src/ToggleButton/accessibility.md)
- [ToggleButtonGroup](https://github.com/mj12albert/material-ui/blob/wcag-toggle-button/packages/mui-material/src/ToggleButtonGroup/accessibility.md)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
