### PR TITLE
[test][radio] Add axe+WCAG test coverage and docs

### DIFF
--- a/docs/data/material/components/radio-buttons/ColorRadioButtons.js
+++ b/docs/data/material/components/radio-buttons/ColorRadioButtons.js
@@ -14,7 +14,7 @@ export default function ColorRadioButtons() {
     onChange: handleChange,
     value: item,
     name: 'color-radio-button-demo',
-    inputProps: { 'aria-label': item },
+    slotProps: { input: { 'aria-label': item } },
   });
 
   return (

--- a/docs/data/material/components/radio-buttons/ColorRadioButtons.tsx
+++ b/docs/data/material/components/radio-buttons/ColorRadioButtons.tsx
@@ -14,7 +14,7 @@ export default function ColorRadioButtons() {
     onChange: handleChange,
     value: item,
     name: 'color-radio-button-demo',
-    inputProps: { 'aria-label': item },
+    slotProps: { input: { 'aria-label': item } },
   });
 
   return (

--- a/docs/data/material/components/radio-buttons/SizeRadioButtons.js
+++ b/docs/data/material/components/radio-buttons/SizeRadioButtons.js
@@ -12,7 +12,7 @@ export default function SizeRadioButtons() {
     onChange: handleChange,
     value: item,
     name: 'size-radio-button-demo',
-    inputProps: { 'aria-label': item },
+    slotProps: { input: { 'aria-label': item } },
   });
 
   return (

--- a/docs/data/material/components/radio-buttons/SizeRadioButtons.tsx
+++ b/docs/data/material/components/radio-buttons/SizeRadioButtons.tsx
@@ -12,7 +12,7 @@ export default function SizeRadioButtons() {
     onChange: handleChange,
     value: item,
     name: 'size-radio-button-demo',
-    inputProps: { 'aria-label': item },
+    slotProps: { input: { 'aria-label': item } },
   });
 
   return (

--- a/docs/data/material/components/radio-buttons/radio-buttons.a11y.json
+++ b/docs/data/material/components/radio-buttons/radio-buttons.a11y.json
@@ -1,0 +1,514 @@
+{
+  "ColorRadioButtons": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "form-field-multiple-labels": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "label": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "ControlledRadioButtonsGroup": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "form-field-multiple-labels": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "label": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "CustomizedRadios": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "form-field-multiple-labels": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "label": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "ErrorRadios": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "form-field-multiple-labels": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "label": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "RadioButtons": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "form-field-multiple-labels": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "label": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "RadioButtonsGroup": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "form-field-multiple-labels": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "label": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "RowRadioButtonsGroup": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "form-field-multiple-labels": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "label": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "SizeRadioButtons": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "form-field-multiple-labels": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "label": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "UseRadioGroup": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "form-field-multiple-labels": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "label": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  }
+}

--- a/packages/mui-material/src/Radio/Radio.test.js
+++ b/packages/mui-material/src/Radio/Radio.test.js
@@ -150,33 +150,22 @@ describe('<Radio />', () => {
     expect(screen.queryByRole('radio', { name: 'A' })).not.to.equal(null);
   });
 
-  it('selects the radio with the Space key (WCAG 2.1.1 Keyboard)', async () => {
-    const handleChange = spy();
-    const { user } = render(<Radio value="a" onChange={handleChange} />);
-    const radio = screen.getByRole('radio');
+  describe('WCAG 2.2 conformance', () => {
+    it('2.1.1 Keyboard: Space selects the focused radio', async () => {
+      const handleChange = spy();
+      const { user } = render(<Radio value="a" onChange={handleChange} />);
+      const radio = screen.getByRole('radio');
 
-    await act(async () => {
-      radio.focus();
+      await act(async () => {
+        radio.focus();
+      });
+
+      await user.keyboard('[Space]');
+      expect(radio).to.have.property('checked', true);
+      expect(handleChange.callCount).to.equal(1);
     });
 
-    await user.keyboard('[Space]');
-    expect(radio).to.have.property('checked', true);
-    expect(handleChange.callCount).to.equal(1);
-  });
-
-  // Deterministic checks for the WCAG success criteria the report rates as
-  // automatable. See packages/mui-material/src/Radio/accessibility.md.
-  describe('WCAG conformance', () => {
-    it('exposes an accessible name matching the visible label (2.5.3 Label in Name)', () => {
-      render(<FormControlLabel control={<Radio />} label="Express delivery" />);
-      // getByRole with `name` only resolves if the accessible name matches the visible label.
-      expect(screen.getByRole('radio', { name: 'Express delivery' })).to.have.property(
-        'checked',
-        false,
-      );
-    });
-
-    it('does not trap keyboard focus (2.1.2 No Keyboard Trap)', async () => {
+    it('2.1.2 No Keyboard Trap: keyboard focus can enter and leave the radio', async () => {
       const { user } = render(
         <React.Fragment>
           <button type="button">before</button>
@@ -197,7 +186,7 @@ describe('<Radio />', () => {
       expect(document.activeElement).to.equal(radio);
     });
 
-    it('is a single tab stop in DOM order (2.4.3 Focus Order)', async () => {
+    it('2.4.3 Focus Order: is a single tab stop in DOM order', async () => {
       const { user } = render(
         <React.Fragment>
           <button type="button">first</button>
@@ -216,7 +205,7 @@ describe('<Radio />', () => {
       expect(document.activeElement).to.equal(last);
     });
 
-    it('activates on the pointer up-event, not the down-event (2.5.2 Pointer Cancellation)', async () => {
+    it('2.5.2 Pointer Cancellation: activates on the pointer up-event, not the down-event', async () => {
       const handleChange = spy();
       const { user } = render(<Radio value="a" onChange={handleChange} />);
       const radio = screen.getByRole('radio');
@@ -232,7 +221,16 @@ describe('<Radio />', () => {
       expect(handleChange.callCount).to.equal(1);
     });
 
-    it('does not change context or state on focus (3.2.1 On Focus)', async () => {
+    it('2.5.3 Label in Name: the accessible name matches the visible label', () => {
+      render(<FormControlLabel control={<Radio />} label="Express delivery" />);
+      // getByRole with `name` only resolves if the accessible name matches the visible label.
+      expect(screen.getByRole('radio', { name: 'Express delivery' })).to.have.property(
+        'checked',
+        false,
+      );
+    });
+
+    it('3.2.1 On Focus: moving focus to the radio changes no context or state', async () => {
       const handleChange = spy();
       const { user } = render(<Radio value="a" onChange={handleChange} />);
       const radio = screen.getByRole('radio');
@@ -244,7 +242,7 @@ describe('<Radio />', () => {
       expect(handleChange.callCount).to.equal(0);
     });
 
-    it('changes only its value on selection, firing onChange (3.2.2 On Input)', async () => {
+    it('3.2.2 On Input: selecting changes only the value and fires onChange', async () => {
       const handleChange = spy();
       const { user } = render(<Radio value="a" onChange={handleChange} />);
       const radio = screen.getByRole('radio');

--- a/packages/mui-material/src/Radio/Radio.test.js
+++ b/packages/mui-material/src/Radio/Radio.test.js
@@ -1,7 +1,10 @@
+import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
+import { spy } from 'sinon';
+import { act, createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import Radio, { radioClasses as classes } from '@mui/material/Radio';
 import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import ButtonBase from '@mui/material/ButtonBase';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import switchBaseClasses from '../internal/switchBaseClasses';
@@ -145,5 +148,111 @@ describe('<Radio />', () => {
     render(<Radio slotProps={{ input: { 'aria-label': 'A' } }} />);
 
     expect(screen.queryByRole('radio', { name: 'A' })).not.to.equal(null);
+  });
+
+  it('selects the radio with the Space key (WCAG 2.1.1 Keyboard)', async () => {
+    const handleChange = spy();
+    const { user } = render(<Radio value="a" onChange={handleChange} />);
+    const radio = screen.getByRole('radio');
+
+    await act(async () => {
+      radio.focus();
+    });
+
+    await user.keyboard('[Space]');
+    expect(radio).to.have.property('checked', true);
+    expect(handleChange.callCount).to.equal(1);
+  });
+
+  // Deterministic checks for the WCAG success criteria the report rates as
+  // automatable. See packages/mui-material/src/Radio/accessibility.md.
+  describe('WCAG conformance', () => {
+    it('exposes an accessible name matching the visible label (2.5.3 Label in Name)', () => {
+      render(<FormControlLabel control={<Radio />} label="Express delivery" />);
+      // getByRole with `name` only resolves if the accessible name matches the visible label.
+      expect(screen.getByRole('radio', { name: 'Express delivery' })).to.have.property(
+        'checked',
+        false,
+      );
+    });
+
+    it('does not trap keyboard focus (2.1.2 No Keyboard Trap)', async () => {
+      const { user } = render(
+        <React.Fragment>
+          <button type="button">before</button>
+          <Radio value="a" />
+          <button type="button">after</button>
+        </React.Fragment>,
+      );
+      const before = screen.getByRole('button', { name: 'before' });
+      const after = screen.getByRole('button', { name: 'after' });
+      const radio = screen.getByRole('radio');
+
+      before.focus();
+      await user.tab();
+      expect(document.activeElement).to.equal(radio);
+      await user.tab();
+      expect(document.activeElement).to.equal(after);
+      await user.tab({ shift: true });
+      expect(document.activeElement).to.equal(radio);
+    });
+
+    it('is a single tab stop in DOM order (2.4.3 Focus Order)', async () => {
+      const { user } = render(
+        <React.Fragment>
+          <button type="button">first</button>
+          <Radio value="a" />
+          <button type="button">last</button>
+        </React.Fragment>,
+      );
+      const first = screen.getByRole('button', { name: 'first' });
+      const radio = screen.getByRole('radio');
+      const last = screen.getByRole('button', { name: 'last' });
+
+      first.focus();
+      await user.tab();
+      expect(document.activeElement).to.equal(radio);
+      await user.tab();
+      expect(document.activeElement).to.equal(last);
+    });
+
+    it('activates on the pointer up-event, not the down-event (2.5.2 Pointer Cancellation)', async () => {
+      const handleChange = spy();
+      const { user } = render(<Radio value="a" onChange={handleChange} />);
+      const radio = screen.getByRole('radio');
+
+      // Press without releasing: the down-event must not select.
+      await user.pointer({ keys: '[MouseLeft>]', target: radio });
+      expect(radio).to.have.property('checked', false);
+      expect(handleChange.callCount).to.equal(0);
+
+      // Releasing over the target completes the activation.
+      await user.pointer({ keys: '[/MouseLeft]', target: radio });
+      expect(radio).to.have.property('checked', true);
+      expect(handleChange.callCount).to.equal(1);
+    });
+
+    it('does not change context or state on focus (3.2.1 On Focus)', async () => {
+      const handleChange = spy();
+      const { user } = render(<Radio value="a" onChange={handleChange} />);
+      const radio = screen.getByRole('radio');
+
+      await user.tab();
+
+      expect(document.activeElement).to.equal(radio);
+      expect(radio).to.have.property('checked', false);
+      expect(handleChange.callCount).to.equal(0);
+    });
+
+    it('changes only its value on selection, firing onChange (3.2.2 On Input)', async () => {
+      const handleChange = spy();
+      const { user } = render(<Radio value="a" onChange={handleChange} />);
+      const radio = screen.getByRole('radio');
+
+      await user.click(radio);
+
+      expect(radio).to.have.property('checked', true);
+      expect(handleChange.callCount).to.equal(1);
+    });
   });
 });

--- a/packages/mui-material/src/Radio/accessibility.md
+++ b/packages/mui-material/src/Radio/accessibility.md
@@ -1,0 +1,372 @@
+# Radio accessibility conformance
+
+Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility.md).
+
+| Result                | Count |
+| :-------------------- | :---- |
+| ✅ Supports           | 22    |
+| ⚠️ Partially Supports | 3     |
+| ❌ Does Not Support   | 0     |
+| ➖ Not Applicable     | 30    |
+| 🚩 Unverified         | 12/25 |
+
+## Known gaps
+
+- ⚠️ **1.4.11 Non-text Contrast.** The default dot and circle clear 3:1 (`warning` is the tightest at 3.11:1), but the keyboard focus indicator is untested and `disableRipple`/`disableFocusRipple` or custom icons can drop below 3:1 (the `CustomizedRadios` unchecked circle is about 1.1:1 against the page).
+- ⚠️ **2.4.7 Focus Visible.** `disableRipple`/`disableFocusRipple` removes the default focus indicator (the focus ripple), leaving none unless the author adds `.Mui-focusVisible` styling.
+- ⚠️ **3.3.2 Labels or Instructions.** The component ships no visible label, and the basic demos use a `slotProps.input` `aria-label` only (a name for assistive technology, but no label presented to all users). A visible label via `FormControlLabel` or adjacent text is required.
+
+## Success criteria
+
+### 🔍 Manual
+
+#### 1.3.2 Meaningful Sequence · A
+
+`🚩 Unverified` · `✅ Supports` · `○ Author`
+
+- The radio is one control: the hidden `<input>` followed by the `aria-hidden` dot and circle, with `FormControlLabel` placing the label and control in source order, so the exposed reading order matches the visual order. The component applies no CSS reordering to itself.
+- Order carries meaning only across several controls, which the surrounding layout sets. `labelPlacement="bottom"` or `"start"` flips the label and control visually, so confirm the reading order of a group like `FormControlLabelPlacement` still matches its visual order.
+
+**Manual testing steps**
+
+1. Open `RadioButtonsGroup` and press <kbd>Tab</kbd> and the arrow keys through the options, noting the focus order.
+2. Compare that order to the visual top-to-bottom order.
+3. Watch for `labelPlacement` or flex layouts that reorder a row visually without changing the DOM.
+
+**Pass:** focus and reading order match the visual order.
+
+#### 1.3.3 Sensory Characteristics · A
+
+`🚩 Unverified` · `✅ Supports` · `○ Author`
+
+- The component renders no instructional text of its own, so it introduces no shape-, color-, or position-only instructions.
+- Surrounding copy must not rely on sensory characteristics alone (for example "select the green option" or "the option on the right"). That is authored content.
+
+**Manual testing steps**
+
+1. Review the copy near a radio group for sensory-only references.
+2. Check that each also names the option by its label.
+
+**Pass:** no instruction relies on color, shape, size, or position without naming the control.
+
+#### 1.4.4 Resize Text · AA
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- The dot and circle are an `SvgIcon` whose size comes from `fontSize` in `rem` (medium 24px = 1.5rem, small 20px = 1.25rem) with a `1em` box, so they scale with browser zoom or root font size; the label is normal text. Nothing is pixel-fixed.
+- A fixed-pixel container in the surrounding layout could clip at 200%.
+
+**Manual testing steps**
+
+1. Set browser zoom to 200% and confirm the radio, label, and helper text are fully visible and the control still selects.
+2. Test a long label inside a constrained-width container.
+
+**Pass:** nothing is clipped or cut off at 200%.
+
+#### 1.4.5 Images of Text · AA
+
+`🚩 Unverified` · `✅ Supports` · `○ Author`
+
+- Labels and helper text render as live DOM text; the dot and circle are vector graphics, not images of text, and they carry no textual information.
+- This fails only if an author passes an image of text as the label, or supplies an `icon`/`checkedIcon` that is an image of text. Use real text unless it is a logo.
+
+**Manual testing steps**
+
+1. Inspect the label and helper nodes and confirm they are selectable live text, not `<img>` or background images of text.
+2. Confirm no label, `icon`, or `checkedIcon` uses an image of text.
+
+**Pass:** labels and helper text are live text.
+
+#### 1.4.10 Reflow · AA
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- The radio is a small inline-flex control with no fixed min-width and no horizontal-overflow layout of its own, so it reflows into a 320 CSS pixel viewport.
+- Real failures usually come from the surrounding layout. A `row` group like `RowRadioButtonsGroup` that does not wrap can overflow at 320 pixels.
+
+**Manual testing steps**
+
+1. Set the viewport to 320 CSS pixels wide (or 400% zoom at 1280px) and confirm radio rows stack with no horizontal scrollbar.
+2. Confirm any multi-column group collapses to one column.
+
+**Pass:** content reflows to one column with no two-dimensional scrolling and no loss of function.
+
+#### 2.4.11 Focus Not Obscured (Minimum) · AA
+
+`🚩 Unverified` · `✅ Supports` · `○ Author`
+
+- The radio is an ordinary focusable control and never places itself behind other content. Obscuring comes from sticky headers, banners, or overlays in the surrounding layout.
+- Confirm by moving focus to a radio beneath any sticky or overlay content at several scroll positions. At least part of it must stay visible.
+
+**Manual testing steps**
+
+1. In a page with a sticky header, footer, or banner, scroll so a radio sits under the sticky element.
+2. Press <kbd>Tab</kbd> to move focus onto it.
+
+**Pass:** at least part of the focused radio stays visible, never fully covered.
+
+#### 3.2.4 Consistent Identification · AA
+
+`🚩 Unverified` · `✅ Supports` · `○ Author`
+
+- The component exposes whatever name the author supplies, stably per props, which is the precondition for consistent identification.
+- Consistency is a cross-page property. Confirm that radios with the same function share a label, and that one label is not reused for different functions.
+
+**Manual testing steps**
+
+1. List the radio options that do the same job across the product.
+2. Compare their labels.
+
+**Pass:** the same function uses the same label, and no label is reused for different functions.
+
+### 🔁 Hybrid
+
+#### 1.1.1 Non-text Content · A
+
+`✅ Supports` · `◐ Shared`
+
+- The default `RadioButton*` icons, and any MUI `SvgIcon` passed via `icon`/`checkedIcon`, default to `aria-hidden`, so they stay decorative; the accessible name comes from the label, not the dot.
+- The name is not self-supplied: a bare `<Radio />` has none. It is satisfied when the author wraps it in `FormControlLabel` (a real `<label>`) or passes `slotProps.input` `aria-label`/`aria-labelledby`, as the docs instruct. Covered by axe-core.
+
+**Manual testing steps**
+
+1. Render `<FormControlLabel control={<Radio />} label="Standard shipping" />` and confirm the accessibility tree shows `role=radio` named "Standard shipping".
+2. Render a bare `<Radio />` and confirm it has an empty name, the failure mode authors must avoid.
+3. Confirm the dot and circle SVGs are `aria-hidden`.
+
+**Pass:** every radio exposes a non-empty accessible name and the dot and circle stay `aria-hidden`.
+
+#### 1.3.1 Info and Relationships · A
+
+`✅ Supports` · `◐ Shared`
+
+- The native `<input type="radio">` exposes role and checked state; `required` and `disabled` map to the native attributes; `FormControlLabel` associates the label through a real `<label>`; and a shared `name` ties the options into one native group. Covered by axe-core. The group's `role="radiogroup"` relationship is rated in the [RadioGroup report](../RadioGroup/accessibility.md).
+- Two relationships are the author's to connect. `FormHelperText` is a bare `<p>` with no `aria-describedby`, so helper and error text (as in `ErrorRadios`) are not tied to the control. Add `aria-describedby` in the application.
+
+**Manual testing steps**
+
+1. Render `<FormControlLabel control={<Radio required />} label="Express" />` and confirm `role=radio`, the name, `required`, and the wrapping `<label>`.
+2. In `ErrorRadios`, confirm the error `FormHelperText` is not tied to the group (no `aria-describedby`).
+
+**Pass:** role, state, and label association are programmatically determinable, and any helper or error text is tied to the control via author-supplied `aria-describedby`.
+
+#### 1.4.1 Use of Color · A
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- State is conveyed by the dot's presence, not color: an empty circle (unchecked) and a circle with a filled dot (checked). A color-blind user can tell the two apart.
+- The group error state is color-only: `FormHelperText` conveys it through red text. Pair it with text or an icon. That is author content.
+
+**Manual testing steps**
+
+1. Render a checked and an unchecked radio and view in grayscale (DevTools Rendering, Emulate vision deficiencies, Achromatopsia); confirm the dot still distinguishes them.
+2. Render an error `FormHelperText` in grayscale and confirm "error" is still perceivable without the red.
+
+**Pass:** checked and unchecked are distinguishable by the dot, and any error state is conveyed by more than color.
+
+#### 1.4.3 Contrast (Minimum) · AA
+
+`✅ Supports` · `◐ Shared`
+
+- This criterion governs the visible text (the label and helper text), not the dot or circle, which is covered by 1.4.11. The label uses `text.primary` (about 16:1 on white, 18:1 on the dark background) and helper text uses `text.secondary` (about 5.7:1); error helper text `error.main` computes `4.98:1` on white, the tightest text case but above the `4.5:1` threshold. Covered by axe-core; the disabled label text is exempt.
+- The component renders no text on a colored fill, so unlike a contained button there is no label-on-background risk. Custom label colors or a colored container behind the row are the author's to check. Disabled text is exempt.
+
+**Manual testing steps**
+
+1. Measure the label and helper text against the real background in light and dark themes.
+2. Pay attention to light-mode error text (`#d32f2f`, about `5:1`) on any non-white background.
+3. Re-check any custom label color.
+
+**Pass:** label and helper or error text meet `4.5:1` (`3:1` for large text) against the actual background.
+
+#### 1.4.11 Non-text Contrast · AA
+
+`🚩 Unverified` · `⚠️ Partially Supports` · `● Component`
+
+- This criterion, not 1.4.3, governs the dot and circle at 3:1, and every default state passes against the default page background (`#fff` light, `#121212` dark). In light mode `warning` is the tightest at `3.11:1`, `info` `3.86:1`, the default `primary` dot `4.60:1`, and the unchecked `text.secondary` circle `5.74:1`; dark mode clears `3:1` with room to spare (`error`, the lowest, is about `5:1`). `warning.main` is tuned in the palette as "closest to orange[800] that pass 3:1", so a colored container behind the radio eats its small headroom first. Disabled (`action.disabled`, about `1.9:1`) is exempt.
+- The gaps are the focus indicator and customization. The keyboard focus indicator's contrast is untested, and `disableRipple`/`disableFocusRipple` removes it. Custom icons can fall below 3:1: the `CustomizedRadios` unchecked circle is `#f5f8fa` with a faint inset border, about `1.1:1` against the page.
+
+**Manual testing steps**
+
+1. Measure the unchecked circle and each checked color (`primary` through `warning`) against the background; confirm `3:1`, checking `warning` specifically.
+2. Measure the keyboard focus indicator against the colors next to it.
+3. Audit any custom icons (the `CustomizedRadios` unchecked circle is a known fail) and treat disabled as exempt.
+
+**Pass:** the dot and circle in every active state and the focus indicator are `3:1` against adjacent colors; disabled is exempt.
+
+#### 1.4.12 Text Spacing · AA
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- The component sets no text styles of its own and no fixed heights that would clip under user text-spacing overrides; the label is normal flowing text that wraps, and the dot and circle are fixed vectors unaffected by spacing.
+- Whether a long label clips depends on the author's container, not the radio.
+
+**Manual testing steps**
+
+1. Apply the WCAG text-spacing overrides via the DevTools console: `document.head.insertAdjacentHTML('beforeend','<style>*{line-height:1.5!important;letter-spacing:.12em!important;word-spacing:.16em!important}</style>')`.
+2. Confirm labels and helper text are not clipped or overlapping and the control still selects.
+
+**Pass:** applying the text-spacing overrides causes no clipping, overlap, or loss of text or function.
+
+#### 2.4.6 Headings and Labels · AA
+
+`✅ Supports` · `◐ Shared`
+
+- The component renders whatever label the author supplies; descriptiveness is a content decision. This criterion does not require a label to exist, only that any provided label describes its purpose. axe-core covers that a name is present; whether it is descriptive is a manual review. The group's own legend is rated in the [RadioGroup report](../RadioGroup/accessibility.md).
+- A vague label ("Option 1") would fail, and the component cannot enforce wording.
+
+**Manual testing steps**
+
+1. Read each radio label.
+2. Confirm each describes the option ("Express delivery", not "Option 1").
+
+**Pass:** every provided label describes its purpose.
+
+#### 2.4.7 Focus Visible · AA
+
+`🚩 Unverified` · `⚠️ Partially Supports` · `● Component`
+
+- `ButtonBase` removes the user-agent outline (`outline: 0`). In the default configuration keyboard focus adds the `.Mui-focusVisible` class plus a centered focus ripple, so an indicator is shown.
+- `disableRipple` or `disableFocusRipple` removes the default focus indicator (the focus ripple), leaving none unless the author adds `.Mui-focusVisible` styles. The `CustomizedRadios` demo does this, re-adding a 2px outline.
+
+**Manual testing steps**
+
+1. Press <kbd>Tab</kbd> to a default `<Radio />` and confirm a visible focus indicator appears.
+2. Press <kbd>Tab</kbd> to a `<Radio disableRipple />` (or `disableFocusRipple`) with no custom styles and confirm none appears.
+3. Click with the mouse and confirm the indicator is keyboard-only.
+
+**Pass:** every keyboard-focused radio shows a visible indicator, including `disableRipple` via author-supplied styles. Today a bare `disableRipple` radio shows none.
+
+#### 2.5.3 Label in Name · A
+
+`✅ Supports` · `◐ Shared`
+
+- With `FormControlLabel` and a string label, the accessible name equals the visible text, so the name contains the label. Covered by unit tests.
+- A `slotProps.input` `aria-label` that differs from the visible text breaks this. Keep the visible words in the name.
+
+**Manual testing steps**
+
+1. Render `<FormControlLabel control={<Radio />} label="Express delivery" />` and confirm the accessible name contains "Express delivery".
+2. If an `aria-label` is set, confirm it includes the visible text.
+3. Try a voice command speaking the visible label and confirm it activates the radio.
+
+**Pass:** the accessible name contains the visible label text.
+
+#### 3.3.2 Labels or Instructions · A
+
+`🚩 Unverified` · `⚠️ Partially Supports` · `◐ Shared`
+
+- A label must be presented to all users, not only exposed to assistive technology. The Understanding document is explicit that a name exposed only to assistive technology (an `aria-label`) can pass 4.1.2 yet fail this criterion.
+- The component ships no visible label, and the basic demos (`RadioButtons`, `ColorRadioButtons`, `SizeRadioButtons`) supply only `slotProps.input` `aria-label`, a name for assistive technology with no visible label. `FormControlLabel`, as used in `RadioButtonsGroup` and `RowRadioButtonsGroup`, is the conforming pattern.
+
+**Manual testing steps**
+
+1. For each radio, confirm a visible label or instruction is shown to all users.
+2. Flag instances that rely on an `aria-label` only (no visible text).
+3. Confirm bare radios are wrapped in `FormControlLabel` or paired with visible instructions.
+
+**Pass:** each radio has a visible label or instruction. An `aria-label`-only radio fails.
+
+#### 4.1.2 Name, Role, Value · A
+
+`✅ Supports` · `◐ Shared`
+
+- Role, checked, and disabled are met natively: the native `<input type="radio">` exposes `role=radio`, the checked state, the value, and change notification with no ARIA needed; `disabled` maps to native `disabled` and `required` to native `required`. Unlike a checkbox, a radio has no `indeterminate` state, so it sets no `aria-checked` and raises no ARIA-in-HTML conflict. Covered by axe-core and unit tests.
+- The name is the shared part: it comes from the author's `FormControlLabel` or `aria-label`. The group's name, role, and selected value are rated in the [RadioGroup report](../RadioGroup/accessibility.md). One caveat: `readOnly` sets the native `readonly` attribute, which has no effect on a radio and is not exposed to assistive technology. Use `disabled` if that state must be conveyed.
+
+**Manual testing steps**
+
+1. Render a labeled radio and confirm `role=radio` with a non-empty name in the accessibility tree.
+2. Select it with a screen reader running and confirm the state change is announced.
+3. Confirm the unselected options announce as "not checked".
+
+**Pass:** the role, the checked or unchecked and disabled state with change notification, and an author-supplied accessible name are all programmatically determinable.
+
+### ⚙️ Automated
+
+#### 2.1.1 Keyboard · A
+
+`✅ Supports` · `● Component`
+
+- The native `<input type="radio">` is the single focusable control (the root span is `role: undefined`, `tabIndex: null`), so the browser provides <kbd>Tab</kbd> focus and <kbd>Space</kbd> selection with no timing or path dependence, matching the [APG radio pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio/). Disabled leaves the tab order. Arrow-key movement between grouped radios is rated in the [RadioGroup report](../RadioGroup/accessibility.md).
+- Covered by unit tests.
+
+#### 2.1.2 No Keyboard Trap · A
+
+`✅ Supports` · `● Component`
+
+- A single native input with standard <kbd>Tab</kbd> in and out. It installs no focus-capturing handlers and no containment logic, so focus cannot be trapped. Covered by unit tests.
+
+#### 2.4.3 Focus Order · A
+
+`✅ Supports` · `◐ Shared`
+
+- The radio is one focusable element in natural DOM order, with no positive `tabIndex` and no reordering, so it is one correct focus stop. Covered by unit tests; the group's roving tab order is rated in the [RadioGroup report](../RadioGroup/accessibility.md).
+- Order across controls is the surrounding layout's responsibility.
+
+#### 2.5.2 Pointer Cancellation · A
+
+`✅ Supports` · `● Component`
+
+- Selecting runs on the native input's `click`, fired on pointer-up over the target. Nothing selects on the down event (the ripple starts there but is decorative), and releasing off the control cancels. Covered by unit tests.
+
+#### 2.5.8 Target Size (Minimum) · AA
+
+`✅ Supports` · `◐ Shared`
+
+- The target is the padded root, not the icon (the input fills it at 100%): medium is a 24px icon plus 2 by 9px padding = 42px, and `size="small"` is 38px, both above the 24 by 24 CSS pixel minimum. Covered by axe-core.
+- It would drop below 24px only if an author both shrinks the icon and removes the padding. Custom `sx`/`size` overrides and hit-area changes under browser zoom are not covered.
+
+#### 3.2.1 On Focus · A
+
+`✅ Supports` · `● Component`
+
+- Focusing the input only moves focus and shows the focus indicator. There is no navigation, dialog, or content change on focus, and the component registers no `onFocus` side effects. Covered by unit tests.
+
+#### 3.2.2 On Input · A
+
+`✅ Supports` · `◐ Shared`
+
+- Selecting only sets the checked state and fires `onChange`; per the Understanding document, changing a control's value is not a change of context. Covered by unit tests.
+- An author `onChange` that navigates or submits without warning would be an author-side failure.
+
+## Not applicable
+
+- **1.3.5 Identify Input Purpose (AA).** Covers inputs that collect information about the user through `autocomplete`. A radio choice is not one of those input purposes.
+- **1.4.13 Content on Hover or Focus (AA).** Needs additional content such as a tooltip or popover. The radio only restyles itself; a `Tooltip` wrapper would own this.
+- **2.1.4 Character Key Shortcuts (A).** The only keys are <kbd>Space</kbd> and the arrow keys, and only while focused. There is no single-character shortcut.
+- **2.2.2 Pause, Stop, Hide (A).** No auto-starting moving, blinking, or auto-updating content.
+- **2.4.4 Link Purpose (In Context) (A).** The component renders no links.
+- **2.5.7 Dragging Movements (AA, new in 2.2).** Covers drag operations. The radio selects by tap or click.
+- **3.1.1 Language of Page (A), 3.1.2 Language of Parts (AA).** The component emits no `<html lang>` and no text of its own. A foreign-language label is the author's phrase to mark.
+- **3.2.3 Consistent Navigation (AA).** Covers repeated navigation across a set of pages, not a single control.
+- **3.2.6 Consistent Help (A, new in 2.2).** Covers consistent placement of help across pages.
+- **3.3.7 Redundant Entry (A, new in 2.2).** Covers repopulating previously entered data. The radio captures none.
+- **3.3.8 Accessible Authentication (Minimum) (AA, new in 2.2).** The paste, autofill, and cognitive-test duty falls on the credential fields, not a radio.
+- **4.1.3 Status Messages (AA).** The radio emits no status messages; its checked-state change is covered by 4.1.2.
+- **Time-based media (1.2.1 to 1.2.5).** No audio or video.
+- **Audio Control (1.4.2).** Emits no audio.
+- **Orientation (1.3.4).** Sets no orientation lock; a layout concern.
+- **Bypass Blocks (2.4.1), Page Titled (2.4.2), Multiple Ways (2.4.5).** Page or site structure, not a single control.
+- **Timing Adjustable (2.2.1).** Sets no time limit.
+- **Three Flashes or Below Threshold (2.3.1).** Nothing flashes.
+- **Pointer Gestures (2.5.1), Motion Actuation (2.5.4).** Selects on a simple click; reads no device motion.
+- **Error Identification (3.3.1), Error Suggestion (3.3.3), Error Prevention (3.3.4).** A radio collects a boolean choice and supports `required`, but in isolation it raises no error state or message of its own; error detection and messaging belong to the form or validation process. When an author shows an error (as `ErrorRadios` does), tie it to the group with `aria-describedby` (tracked under 1.3.1).
+
+## Level AAA
+
+The following SC are applicable but out of scope:
+
+- **2.3.3 Animation from Interactions.** The ripple's `scale()` animation honors `prefers-reduced-motion` when the theme sets `motion.reducedMotion` to `system` (follows the OS) or `always`; `disableRipple` also removes it. The default is `never`, so OS reduced-motion is not honored by default. `🚩`
+- **2.4.13 Focus Appearance.** The focus ripple is unlikely to meet the area and 3:1 thresholds, and `disableRipple` removes it. `🚩`
+- **2.5.5 Target Size (Enhanced), 44 px.** Default sizes (42px medium, 38px small) are below 44px. `🚩`
+- **1.4.6 Contrast (Enhanced), 7:1.** The label (`text.primary`, about 16:1) clears 7:1, but helper text (about 5:1) and the dot and circle fall short where the 7:1 text bar applies. `🚩`
+- Also touched, in the same shape as their A and AA siblings: **1.3.6 Identify Purpose, 1.4.9 Images of Text (No Exception), 2.1.3 Keyboard (No Exception), 2.4.12 Focus Not Obscured (Enhanced)**.
+
+## Scope and test environment
+
+- **Standard.** WCAG 2.2, Level A and AA.
+- **Component version.** `@mui/material` 9.1.2.
+- **Scope.** The Radio component and its documented composition with `FormControlLabel`, `FormControl`/`FormLabel`, and `FormHelperText`, rendered through the documented API. Group-level coordination (the `radiogroup` role, arrow-key navigation, and the group's name) is rated in the [RadioGroup report](../RadioGroup/accessibility.md).
+- **Automated.** axe-core via the Playwright visual-regression harness (results in [`radio-buttons.a11y.json`](../../../../docs/data/material/components/radio-buttons/radio-buttons.a11y.json)), plus interaction tests in [`Radio.test.js`](./Radio.test.js). Dot and circle contrast is computed from the theme tokens, since no axe rule covers non-text contrast.
+- **Assistive-technology review.** Not yet performed. `🚩` criteria are assessed from source pending a review with NVDA, JAWS, and VoiceOver.

--- a/packages/mui-material/src/Radio/accessibility.md
+++ b/packages/mui-material/src/Radio/accessibility.md
@@ -8,7 +8,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 | ⚠️ Partially Supports | 2     |
 | ❌ Does Not Support   | 0     |
 | ➖ Not Applicable     | 30    |
-| 🚩 Flagged            | 12/25 |
+| 🚩 Flagged            | 6/25  |
 
 ## Known gaps
 
@@ -21,7 +21,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.3.2 Meaningful Sequence · A
 
-`🚩` · `✅ Supports` · `○ Author`
+`✅ Supports` · `○ Author`
 
 - The radio is one control: the hidden `<input>` followed by the `aria-hidden` dot and circle, with `FormControlLabel` placing the label and control in source order, so the reading order matches the visual order.
 - Order carries meaning only across several controls, which the surrounding layout sets. `labelPlacement="bottom"` flips the label and control vertically, so confirm the reading order of a group like `FormControlLabelPlacement` still matches its visual order.
@@ -36,7 +36,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.3.3 Sensory Characteristics · A
 
-`🚩` · `✅ Supports` · `○ Author`
+`✅ Supports` · `○ Author`
 
 - The component renders no instructional text of its own.
 - The author is responsible for ensuring surrounding copy does not rely on sensory characteristics alone (for example "select the green option" or "the option on the right").
@@ -64,7 +64,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.4.5 Images of Text · AA
 
-`🚩` · `✅ Supports` · `○ Author`
+`✅ Supports` · `○ Author`
 
 - Labels and helper text render as live DOM text; the dot and circle are vector graphics without any textual information.
 - This fails only if an author passes an image of text as the label, or supplies an `icon`/`checkedIcon` that is an image of text. Use real text unless it is a logo.
@@ -92,7 +92,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 2.4.11 Focus Not Obscured (Minimum) · AA
 
-`🚩` · `✅ Supports` · `○ Author`
+`✅ Supports` · `○ Author`
 
 - The radio is an ordinary focusable control and never places itself behind other content. Obscuring comes from sticky headers, banners, or overlays in the surrounding layout.
 - Confirm by moving focus to a radio beneath any sticky or overlay content at several scroll positions. At least part of it must stay visible.
@@ -106,7 +106,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 3.2.4 Consistent Identification · AA
 
-`🚩` · `✅ Supports` · `○ Author`
+`✅ Supports` · `○ Author`
 
 - The component exposes whatever name the author supplies.
 - Consistency is a cross-page property. Confirm that radios with the same function share a label, and that one label is not reused for different functions.
@@ -120,10 +120,10 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 3.3.2 Labels or Instructions · A
 
-`🚩` · `✅ Supports` · `○ Author`
+`✅ Supports` · `○ Author`
 
 - A visible label or instruction is the author's content to supply; the component renders a real `<label>` when wrapped in `FormControlLabel`, which is the recommended composition for the radio component.
-- `aria-label`-only radios would fail this SC in a real-world use-case.
+- `aria-label`-only radios would fail this SC in a real-world use case.
 
 **Manual testing steps**
 

--- a/packages/mui-material/src/Radio/accessibility.md
+++ b/packages/mui-material/src/Radio/accessibility.md
@@ -4,17 +4,16 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 | Result                | Count |
 | :-------------------- | :---- |
-| ✅ Supports           | 22    |
-| ⚠️ Partially Supports | 3     |
+| ✅ Supports           | 23    |
+| ⚠️ Partially Supports | 2     |
 | ❌ Does Not Support   | 0     |
 | ➖ Not Applicable     | 30    |
-| 🚩 Unverified         | 12/25 |
+| 🚩 Flagged            | 12/25 |
 
 ## Known gaps
 
 - ⚠️ **1.4.11 Non-text Contrast.** The default dot and circle clear 3:1 (`warning` is the tightest at 3.11:1), but the keyboard focus indicator is untested and `disableRipple`/`disableFocusRipple` or custom icons can drop below 3:1 (the `CustomizedRadios` unchecked circle is about 1.1:1 against the page).
-- ⚠️ **2.4.7 Focus Visible.** `disableRipple`/`disableFocusRipple` removes the default focus indicator (the focus ripple), leaving none unless the author adds `.Mui-focusVisible` styling.
-- ⚠️ **3.3.2 Labels or Instructions.** The component ships no visible label, and the basic demos use a `slotProps.input` `aria-label` only (a name for assistive technology, but no label presented to all users). A visible label via `FormControlLabel` or adjacent text is required.
+- ⚠️ **2.4.7 Focus Visible.** `disableRipple`/`disableFocusRipple` removes the focus ripple, leaving none unless the author adds `.Mui-focusVisible` styling.
 
 ## Success criteria
 
@@ -22,14 +21,14 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.3.2 Meaningful Sequence · A
 
-`🚩 Unverified` · `✅ Supports` · `○ Author`
+`🚩` · `✅ Supports` · `○ Author`
 
-- The radio is one control: the hidden `<input>` followed by the `aria-hidden` dot and circle, with `FormControlLabel` placing the label and control in source order, so the exposed reading order matches the visual order. The component applies no CSS reordering to itself.
-- Order carries meaning only across several controls, which the surrounding layout sets. `labelPlacement="bottom"` or `"start"` flips the label and control visually, so confirm the reading order of a group like `FormControlLabelPlacement` still matches its visual order.
+- The radio is one control: the hidden `<input>` followed by the `aria-hidden` dot and circle, with `FormControlLabel` placing the label and control in source order, so the reading order matches the visual order.
+- Order carries meaning only across several controls, which the surrounding layout sets. `labelPlacement="bottom"` flips the label and control vertically, so confirm the reading order of a group like `FormControlLabelPlacement` still matches its visual order.
 
 **Manual testing steps**
 
-1. Open `RadioButtonsGroup` and press <kbd>Tab</kbd> and the arrow keys through the options, noting the focus order.
+1. Render a `RadioGroup` with several labeled `Radio` options, then press <kbd>Tab</kbd> and the arrow keys through them, noting the focus order.
 2. Compare that order to the visual top-to-bottom order.
 3. Watch for `labelPlacement` or flex layouts that reorder a row visually without changing the DOM.
 
@@ -37,10 +36,10 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.3.3 Sensory Characteristics · A
 
-`🚩 Unverified` · `✅ Supports` · `○ Author`
+`🚩` · `✅ Supports` · `○ Author`
 
-- The component renders no instructional text of its own, so it introduces no shape-, color-, or position-only instructions.
-- Surrounding copy must not rely on sensory characteristics alone (for example "select the green option" or "the option on the right"). That is authored content.
+- The component renders no instructional text of its own.
+- The author is responsible for ensuring surrounding copy does not rely on sensory characteristics alone (for example "select the green option" or "the option on the right").
 
 **Manual testing steps**
 
@@ -51,10 +50,10 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.4.4 Resize Text · AA
 
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+`🚩` · `✅ Supports` · `◐ Shared`
 
-- The dot and circle are an `SvgIcon` whose size comes from `fontSize` in `rem` (medium 24px = 1.5rem, small 20px = 1.25rem) with a `1em` box, so they scale with browser zoom or root font size; the label is normal text. Nothing is pixel-fixed.
-- A fixed-pixel container in the surrounding layout could clip at 200%.
+- The dot and circle are an `SvgIcon` whose size comes from `fontSize` in `rem` (medium 24px = 1.5rem, small 20px = 1.25rem) with a `1em` box, so they scale with browser zoom or root font size; the label is normal text. No pixel units are used.
+- A fixed-pixel container in the surrounding layout could cause clipping at 200%.
 
 **Manual testing steps**
 
@@ -65,9 +64,9 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.4.5 Images of Text · AA
 
-`🚩 Unverified` · `✅ Supports` · `○ Author`
+`🚩` · `✅ Supports` · `○ Author`
 
-- Labels and helper text render as live DOM text; the dot and circle are vector graphics, not images of text, and they carry no textual information.
+- Labels and helper text render as live DOM text; the dot and circle are vector graphics without any textual information.
 - This fails only if an author passes an image of text as the label, or supplies an `icon`/`checkedIcon` that is an image of text. Use real text unless it is a logo.
 
 **Manual testing steps**
@@ -79,10 +78,10 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 1.4.10 Reflow · AA
 
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+`🚩` · `✅ Supports` · `◐ Shared`
 
 - The radio is a small inline-flex control with no fixed min-width and no horizontal-overflow layout of its own, so it reflows into a 320 CSS pixel viewport.
-- Real failures usually come from the surrounding layout. A `row` group like `RowRadioButtonsGroup` that does not wrap can overflow at 320 pixels.
+- Real failures usually come from the surrounding layout, such as a wide non-wrapping row of labeled radios or a fixed-width container (a default `row` group still wraps, since `FormGroup` keeps `flex-wrap: wrap`).
 
 **Manual testing steps**
 
@@ -93,7 +92,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 2.4.11 Focus Not Obscured (Minimum) · AA
 
-`🚩 Unverified` · `✅ Supports` · `○ Author`
+`🚩` · `✅ Supports` · `○ Author`
 
 - The radio is an ordinary focusable control and never places itself behind other content. Obscuring comes from sticky headers, banners, or overlays in the surrounding layout.
 - Confirm by moving focus to a radio beneath any sticky or overlay content at several scroll positions. At least part of it must stay visible.
@@ -107,9 +106,9 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 3.2.4 Consistent Identification · AA
 
-`🚩 Unverified` · `✅ Supports` · `○ Author`
+`🚩` · `✅ Supports` · `○ Author`
 
-- The component exposes whatever name the author supplies, stably per props, which is the precondition for consistent identification.
+- The component exposes whatever name the author supplies.
 - Consistency is a cross-page property. Confirm that radios with the same function share a label, and that one label is not reused for different functions.
 
 **Manual testing steps**
@@ -118,6 +117,21 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 2. Compare their labels.
 
 **Pass:** the same function uses the same label, and no label is reused for different functions.
+
+#### 3.3.2 Labels or Instructions · A
+
+`🚩` · `✅ Supports` · `○ Author`
+
+- A visible label or instruction is the author's content to supply; the component renders a real `<label>` when wrapped in `FormControlLabel`, which is the recommended composition for the radio component.
+- `aria-label`-only radios would fail this SC in a real-world use-case.
+
+**Manual testing steps**
+
+1. For each radio, confirm a visible label or instruction is shown to all users.
+2. Flag instances that rely on an `aria-label` only (no visible text).
+3. Confirm bare radios are wrapped in `FormControlLabel` or paired with visible instructions.
+
+**Pass:** each radio has a visible label or instruction.
 
 ### 🔁 Hybrid
 
@@ -146,21 +160,19 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 **Manual testing steps**
 
 1. Render `<FormControlLabel control={<Radio required />} label="Express" />` and confirm `role=radio`, the name, `required`, and the wrapping `<label>`.
-2. In `ErrorRadios`, confirm the error `FormHelperText` is not tied to the group (no `aria-describedby`).
 
 **Pass:** role, state, and label association are programmatically determinable, and any helper or error text is tied to the control via author-supplied `aria-describedby`.
 
 #### 1.4.1 Use of Color · A
 
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+`🚩` · `✅ Supports` · `◐ Shared`
 
-- State is conveyed by the dot's presence, not color: an empty circle (unchecked) and a circle with a filled dot (checked). A color-blind user can tell the two apart.
-- The group error state is color-only: `FormHelperText` conveys it through red text. Pair it with text or an icon. That is author content.
+- State is conveyed by the dot's presence and not color - an empty circle (unchecked) and a circle with a filled dot (checked)
+- The group error state is color-only: `FormHelperText` conveys it through red text. The author is responsible for associating it with error text.
 
 **Manual testing steps**
 
 1. Render a checked and an unchecked radio and view in grayscale (DevTools Rendering, Emulate vision deficiencies, Achromatopsia); confirm the dot still distinguishes them.
-2. Render an error `FormHelperText` in grayscale and confirm "error" is still perceivable without the red.
 
 **Pass:** checked and unchecked are distinguishable by the dot, and any error state is conveyed by more than color.
 
@@ -175,31 +187,29 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 1. Measure the label and helper text against the real background in light and dark themes.
 2. Pay attention to light-mode error text (`#d32f2f`, about `5:1`) on any non-white background.
-3. Re-check any custom label color.
 
 **Pass:** label and helper or error text meet `4.5:1` (`3:1` for large text) against the actual background.
 
 #### 1.4.11 Non-text Contrast · AA
 
-`🚩 Unverified` · `⚠️ Partially Supports` · `● Component`
+`🚩` · `⚠️ Partially Supports` · `● Component`
 
 - This criterion, not 1.4.3, governs the dot and circle at 3:1, and every default state passes against the default page background (`#fff` light, `#121212` dark). In light mode `warning` is the tightest at `3.11:1`, `info` `3.86:1`, the default `primary` dot `4.60:1`, and the unchecked `text.secondary` circle `5.74:1`; dark mode clears `3:1` with room to spare (`error`, the lowest, is about `5:1`). `warning.main` is tuned in the palette as "closest to orange[800] that pass 3:1", so a colored container behind the radio eats its small headroom first. Disabled (`action.disabled`, about `1.9:1`) is exempt.
-- The gaps are the focus indicator and customization. The keyboard focus indicator's contrast is untested, and `disableRipple`/`disableFocusRipple` removes it. Custom icons can fall below 3:1: the `CustomizedRadios` unchecked circle is `#f5f8fa` with a faint inset border, about `1.1:1` against the page.
 
 **Manual testing steps**
 
 1. Measure the unchecked circle and each checked color (`primary` through `warning`) against the background; confirm `3:1`, checking `warning` specifically.
 2. Measure the keyboard focus indicator against the colors next to it.
-3. Audit any custom icons (the `CustomizedRadios` unchecked circle is a known fail) and treat disabled as exempt.
+3. Audit any custom `icon`/`checkedIcon` (a low-contrast custom icon is a common fail) and treat disabled as exempt.
 
 **Pass:** the dot and circle in every active state and the focus indicator are `3:1` against adjacent colors; disabled is exempt.
 
 #### 1.4.12 Text Spacing · AA
 
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+`🚩` · `✅ Supports` · `◐ Shared`
 
 - The component sets no text styles of its own and no fixed heights that would clip under user text-spacing overrides; the label is normal flowing text that wraps, and the dot and circle are fixed vectors unaffected by spacing.
-- Whether a long label clips depends on the author's container, not the radio.
+- Whether a long label clips depends on the author's container.
 
 **Manual testing steps**
 
@@ -212,7 +222,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 `✅ Supports` · `◐ Shared`
 
-- The component renders whatever label the author supplies; descriptiveness is a content decision. This criterion does not require a label to exist, only that any provided label describes its purpose. axe-core covers that a name is present; whether it is descriptive is a manual review. The group's own legend is rated in the [RadioGroup report](../RadioGroup/accessibility.md).
+- The component renders whatever label the author supplies. This criterion does not require a label to exist, only that any provided label describes its purpose. axe-core covers that a name is present; whether it is descriptive is a manual review. The group's own legend is rated in the [RadioGroup report](../RadioGroup/accessibility.md).
 - A vague label ("Option 1") would fail, and the component cannot enforce wording.
 
 **Manual testing steps**
@@ -224,18 +234,17 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 #### 2.4.7 Focus Visible · AA
 
-`🚩 Unverified` · `⚠️ Partially Supports` · `● Component`
+`🚩` · `⚠️ Partially Supports` · `● Component`
 
-- `ButtonBase` removes the user-agent outline (`outline: 0`). In the default configuration keyboard focus adds the `.Mui-focusVisible` class plus a centered focus ripple, so an indicator is shown.
-- `disableRipple` or `disableFocusRipple` removes the default focus indicator (the focus ripple), leaving none unless the author adds `.Mui-focusVisible` styles. The `CustomizedRadios` demo does this, re-adding a 2px outline.
+- The focus ripple serves as focus visible indicator
+- `disableRipple` or `disableFocusRipple` removes the focus indicator (the focus ripple), relying on the author to add it with `.Mui-focusVisible` styles.
 
 **Manual testing steps**
 
 1. Press <kbd>Tab</kbd> to a default `<Radio />` and confirm a visible focus indicator appears.
-2. Press <kbd>Tab</kbd> to a `<Radio disableRipple />` (or `disableFocusRipple`) with no custom styles and confirm none appears.
-3. Click with the mouse and confirm the indicator is keyboard-only.
+2. Click with the mouse and confirm the indicator is keyboard-only.
 
-**Pass:** every keyboard-focused radio shows a visible indicator, including `disableRipple` via author-supplied styles. Today a bare `disableRipple` radio shows none.
+**Pass:** every keyboard-focused radio shows a visible indicator, including `disableRipple` via author-supplied styles.
 
 #### 2.5.3 Label in Name · A
 
@@ -252,27 +261,12 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 **Pass:** the accessible name contains the visible label text.
 
-#### 3.3.2 Labels or Instructions · A
-
-`🚩 Unverified` · `⚠️ Partially Supports` · `◐ Shared`
-
-- A label must be presented to all users, not only exposed to assistive technology. The Understanding document is explicit that a name exposed only to assistive technology (an `aria-label`) can pass 4.1.2 yet fail this criterion.
-- The component ships no visible label, and the basic demos (`RadioButtons`, `ColorRadioButtons`, `SizeRadioButtons`) supply only `slotProps.input` `aria-label`, a name for assistive technology with no visible label. `FormControlLabel`, as used in `RadioButtonsGroup` and `RowRadioButtonsGroup`, is the conforming pattern.
-
-**Manual testing steps**
-
-1. For each radio, confirm a visible label or instruction is shown to all users.
-2. Flag instances that rely on an `aria-label` only (no visible text).
-3. Confirm bare radios are wrapped in `FormControlLabel` or paired with visible instructions.
-
-**Pass:** each radio has a visible label or instruction. An `aria-label`-only radio fails.
-
 #### 4.1.2 Name, Role, Value · A
 
 `✅ Supports` · `◐ Shared`
 
 - Role, checked, and disabled are met natively: the native `<input type="radio">` exposes `role=radio`, the checked state, the value, and change notification with no ARIA needed; `disabled` maps to native `disabled` and `required` to native `required`. Unlike a checkbox, a radio has no `indeterminate` state, so it sets no `aria-checked` and raises no ARIA-in-HTML conflict. Covered by axe-core and unit tests.
-- The name is the shared part: it comes from the author's `FormControlLabel` or `aria-label`. The group's name, role, and selected value are rated in the [RadioGroup report](../RadioGroup/accessibility.md). One caveat: `readOnly` sets the native `readonly` attribute, which has no effect on a radio and is not exposed to assistive technology. Use `disabled` if that state must be conveyed.
+- The individual radio's name relies on author-supplied `FormControlLabel` or `aria-label`. The group's name, role, and selected value are rated in the [RadioGroup report](../RadioGroup/accessibility.md).
 
 **Manual testing steps**
 
@@ -288,7 +282,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 `✅ Supports` · `● Component`
 
-- The native `<input type="radio">` is the single focusable control (the root span is `role: undefined`, `tabIndex: null`), so the browser provides <kbd>Tab</kbd> focus and <kbd>Space</kbd> selection with no timing or path dependence, matching the [APG radio pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio/). Disabled leaves the tab order. Arrow-key movement between grouped radios is rated in the [RadioGroup report](../RadioGroup/accessibility.md).
+- The native `<input type="radio">` is the single focusable control (the root span is `role: undefined`, `tabIndex: null`), so the browser provides <kbd>Tab</kbd> focus and <kbd>Space</kbd> selection with no timing or path dependence, matching the [APG radio pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio/). Disabled leaves the tab order. Arrow-key movement between grouped radios is covered in the [RadioGroup report](../RadioGroup/accessibility.md).
 - Covered by unit tests.
 
 #### 2.1.2 No Keyboard Trap · A
@@ -332,7 +326,7 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 ## Not applicable
 
-- **1.3.5 Identify Input Purpose (AA).** Covers inputs that collect information about the user through `autocomplete`. A radio choice is not one of those input purposes.
+- **1.3.5 Identify Input Purpose (AA).** Covers fields that autofill the user's own data through `autocomplete`. Those purposes map to text-entry and `select` controls (`sex`, for example, is free-form text), not radio buttons, so even a "Gender" radio group is outside this criterion.
 - **1.4.13 Content on Hover or Focus (AA).** Needs additional content such as a tooltip or popover. The radio only restyles itself; a `Tooltip` wrapper would own this.
 - **2.1.4 Character Key Shortcuts (A).** The only keys are <kbd>Space</kbd> and the arrow keys, and only while focused. There is no single-character shortcut.
 - **2.2.2 Pause, Stop, Hide (A).** No auto-starting moving, blinking, or auto-updating content.
@@ -355,8 +349,6 @@ Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility
 
 ## Level AAA
 
-The following SC are applicable but out of scope:
-
 - **2.3.3 Animation from Interactions.** The ripple's `scale()` animation honors `prefers-reduced-motion` when the theme sets `motion.reducedMotion` to `system` (follows the OS) or `always`; `disableRipple` also removes it. The default is `never`, so OS reduced-motion is not honored by default. `🚩`
 - **2.4.13 Focus Appearance.** The focus ripple is unlikely to meet the area and 3:1 thresholds, and `disableRipple` removes it. `🚩`
 - **2.5.5 Target Size (Enhanced), 44 px.** Default sizes (42px medium, 38px small) are below 44px. `🚩`
@@ -369,4 +361,4 @@ The following SC are applicable but out of scope:
 - **Component version.** `@mui/material` 9.1.2.
 - **Scope.** The Radio component and its documented composition with `FormControlLabel`, `FormControl`/`FormLabel`, and `FormHelperText`, rendered through the documented API. Group-level coordination (the `radiogroup` role, arrow-key navigation, and the group's name) is rated in the [RadioGroup report](../RadioGroup/accessibility.md).
 - **Automated.** axe-core via the Playwright visual-regression harness (results in [`radio-buttons.a11y.json`](../../../../docs/data/material/components/radio-buttons/radio-buttons.a11y.json)), plus interaction tests in [`Radio.test.js`](./Radio.test.js). Dot and circle contrast is computed from the theme tokens, since no axe rule covers non-text contrast.
-- **Assistive-technology review.** Not yet performed. `🚩` criteria are assessed from source pending a review with NVDA, JAWS, and VoiceOver.
+- **Assistive-technology review.** Not yet performed. Flagged criteria are assessed from source pending a review with NVDA, JAWS, and VoiceOver.

--- a/packages/mui-material/src/RadioGroup/RadioGroup.test.js
+++ b/packages/mui-material/src/RadioGroup/RadioGroup.test.js
@@ -19,12 +19,6 @@ describe('<RadioGroup />', () => {
     skip: ['componentProp', 'themeDefaultProps', 'themeStyleOverrides', 'themeVariants'],
   }));
 
-  it('the root component has the radiogroup role', () => {
-    const { container } = render(<RadioGroup value="" />);
-
-    expect(container.firstChild).to.have.attribute('role', 'radiogroup');
-  });
-
   it('should fire the onBlur callback', () => {
     const handleBlur = spy();
     const { container } = render(<RadioGroup value="" onBlur={handleBlur} />);
@@ -77,21 +71,6 @@ describe('<RadioGroup />', () => {
     fireEvent.click(radios[1]);
 
     expect(radios[1].checked).to.equal(true);
-  });
-
-  it('should have a default name', () => {
-    render(
-      <RadioGroup>
-        <Radio value="zero" />
-        <Radio value="one" />
-      </RadioGroup>,
-    );
-
-    const [arbitraryRadio, ...radios] = screen.getAllByRole('radio');
-    // `name` **property** will always be a string even if the **attribute** is omitted
-    expect(arbitraryRadio.name).not.to.equal('');
-    // all input[type="radio"] have the same name
-    expect(new Set(radios.map((radio) => radio.name))).to.have.length(1);
   });
 
   it('should support number value', () => {
@@ -423,11 +402,32 @@ describe('<RadioGroup />', () => {
     expect(radiogroup).not.to.have.class(classes.error);
   });
 
-  // Browser-only: native radio arrow-key navigation and roving tab order are not
-  // implemented by jsdom. See packages/mui-material/src/RadioGroup/accessibility.md.
-  describe('WCAG conformance', () => {
+  describe('WCAG 2.2 conformance', () => {
+    describe('1.3.1 Info and Relationships', () => {
+      it('exposes the radiogroup role on the root', () => {
+        const { container } = render(<RadioGroup value="" />);
+
+        expect(container.firstChild).to.have.attribute('role', 'radiogroup');
+      });
+
+      it('shares one generated name across all radios', () => {
+        render(
+          <RadioGroup>
+            <Radio value="zero" />
+            <Radio value="one" />
+          </RadioGroup>,
+        );
+
+        const [arbitraryRadio, ...radios] = screen.getAllByRole('radio');
+        // `name` **property** will always be a string even if the **attribute** is omitted
+        expect(arbitraryRadio.name).not.to.equal('');
+        // all input[type="radio"] have the same name
+        expect(new Set(radios.map((radio) => radio.name))).to.have.length(1);
+      });
+    });
+
     it.skipIf(isJsdom())(
-      'roves selection with the arrow keys as a single tab stop (WCAG 2.1.1, 2.4.3)',
+      '2.1.1 Keyboard, 2.4.3 Focus Order: arrow keys rove selection as a single tab stop',
       async () => {
         const { user } = render(
           <React.Fragment>

--- a/packages/mui-material/src/RadioGroup/RadioGroup.test.js
+++ b/packages/mui-material/src/RadioGroup/RadioGroup.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
-import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
+import { act, createRenderer, fireEvent, isJsdom, screen } from '@mui/internal-test-utils';
 import FormGroup from '@mui/material/FormGroup';
 import Radio from '@mui/material/Radio';
 import RadioGroup, { useRadioGroup, radioGroupClasses as classes } from '@mui/material/RadioGroup';
@@ -421,5 +421,49 @@ describe('<RadioGroup />', () => {
     expect(radiogroup).to.have.class(classes.root);
     expect(radiogroup).to.have.class(classes.row);
     expect(radiogroup).not.to.have.class(classes.error);
+  });
+
+  // Browser-only: native radio arrow-key navigation and roving tab order are not
+  // implemented by jsdom. See packages/mui-material/src/RadioGroup/accessibility.md.
+  describe('WCAG conformance', () => {
+    it.skipIf(isJsdom())(
+      'roves selection with the arrow keys as a single tab stop (WCAG 2.1.1, 2.4.3)',
+      async () => {
+        const { user } = render(
+          <React.Fragment>
+            <button type="button">before</button>
+            <RadioGroup name="pet" defaultValue="cat">
+              <Radio value="cat" disableRipple slotProps={{ input: { 'aria-label': 'Cat' } }} />
+              <Radio value="dog" disableRipple slotProps={{ input: { 'aria-label': 'Dog' } }} />
+              <Radio value="bird" disableRipple slotProps={{ input: { 'aria-label': 'Bird' } }} />
+            </RadioGroup>
+            <button type="button">after</button>
+          </React.Fragment>,
+        );
+        const after = screen.getByRole('button', { name: 'after' });
+        const [cat, dog, bird] = screen.getAllByRole('radio');
+
+        screen.getByRole('button', { name: 'before' }).focus();
+
+        // Tab enters the group on the checked radio (roving tab order).
+        await user.tab();
+        expect(cat).toHaveFocus();
+        expect(cat).to.have.property('checked', true);
+
+        // Arrow keys move focus to the next radio and check it, unchecking the previous.
+        await user.keyboard('[ArrowDown]');
+        expect(dog).toHaveFocus();
+        expect(dog).to.have.property('checked', true);
+        expect(cat).to.have.property('checked', false);
+
+        await user.keyboard('[ArrowDown]');
+        expect(bird).toHaveFocus();
+        expect(bird).to.have.property('checked', true);
+
+        // The group is a single tab stop: Tab leaves to the next control.
+        await user.tab();
+        expect(after).toHaveFocus();
+      },
+    );
   });
 });

--- a/packages/mui-material/src/RadioGroup/accessibility.md
+++ b/packages/mui-material/src/RadioGroup/accessibility.md
@@ -1,0 +1,177 @@
+# RadioGroup accessibility conformance
+
+Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility.md).
+
+RadioGroup coordinates a set of [Radio](../Radio/accessibility.md) children, so this report rates only the criteria that exist or change because of the grouping. Each radio's own conformance (contrast, target size, label in name, focus indicator, and the rest) is rated in the [Radio report](../Radio/accessibility.md) and listed under [Inherited from Radio](#inherited-from-radio).
+
+| Result                  | Count |
+| :---------------------- | :---- |
+| ✅ Supports             | 6     |
+| ⚠️ Partially Supports   | 1     |
+| ❌ Does Not Support     | 0     |
+| ➖ Not Applicable       | 30    |
+| ↗ Inherited (see Radio) | 18    |
+| 🚩 Unverified           | 3/7   |
+
+The first three rows and Not Applicable count the 7 group-level criteria plus the 30 that do not apply; Inherited adds the 18 item-level criteria rated in Radio (7 + 30 + 18 = 55). Unverified is the ratio of flagged to applicable group-level criteria; inherited criteria are excluded.
+
+## Known gaps
+
+- ⚠️ **3.3.2 Labels or Instructions.** The group ships no label of its own. `role="radiogroup"` requires an accessible name, but `UseRadioGroup` renders a group with no `FormLabel` and no `aria-labelledby`, so the question is unlabeled. Pair the group with a `FormLabel` referenced by `aria-labelledby`.
+
+## Success criteria
+
+### 🔍 Manual
+
+#### 1.4.1 Use of Color · A
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- Which option is selected is shown by the filled dot inside one circle, a shape difference, not color, so a color-blind user can tell the selected option from the rest.
+- A group error shown only through red `FormHelperText` is color-only. Pair it with text or an icon. That is author content.
+
+**Manual testing steps**
+
+1. Open `RadioButtonsGroup`, select an option, and view the group in grayscale (DevTools Rendering, Emulate vision deficiencies, Achromatopsia).
+2. Confirm the selected option is still identifiable by its dot.
+3. Render an error `FormHelperText` (as in `ErrorRadios`) in grayscale and confirm "error" is still perceivable.
+
+**Pass:** the selected option is distinguishable by the dot, and any error state is conveyed by more than color.
+
+### 🔁 Hybrid
+
+#### 1.3.1 Info and Relationships · A
+
+`✅ Supports` · `◐ Shared`
+
+- RadioGroup sets `role="radiogroup"` on its `FormGroup` root (`RadioGroup.js`) and shares one `name`, generated with `useId` when none is passed, through `RadioGroupContext`, so the native radios form one programmatically grouped set. Covered by axe-core and unit tests.
+- The group's accessible name and any description are the author's to set: `aria-labelledby` to a `FormLabel` for the name, and `aria-describedby` for `FormHelperText`. Without them the grouping is exposed but unnamed and undescribed.
+
+**Manual testing steps**
+
+1. Open `RadioButtonsGroup` and inspect the accessibility tree: confirm a `radiogroup` node named by the `FormLabel`, containing the `radio` options.
+2. Open `UseRadioGroup` and confirm the `radiogroup` is present but unnamed.
+
+**Pass:** the radios are exposed as one `radiogroup`, and the name and any description are set by the author.
+
+#### 2.4.6 Headings and Labels · AA
+
+`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+
+- The group's label comes from a `FormLabel` referenced by `aria-labelledby`, the documented pattern in `RadioButtonsGroup` and `RowRadioButtonsGroup`. axe-core covers that the reference resolves; whether the wording describes the question is a manual review.
+- A vague group label ("Choose one") would fail, and the component cannot enforce wording.
+
+**Manual testing steps**
+
+1. Read each group's `FormLabel` text.
+2. Confirm it describes the choice ("Gender", not "Choose one").
+
+**Pass:** every group label describes the question it asks.
+
+#### 3.3.2 Labels or Instructions · A
+
+`🚩 Unverified` · `⚠️ Partially Supports` · `◐ Shared`
+
+- A radio group is a data-entry question, so it needs a label or instructions presented to all users. The conforming pattern pairs `RadioGroup` with a `FormLabel` referenced by `aria-labelledby`, as `RadioButtonsGroup`, `ControlledRadioButtonsGroup`, and `RowRadioButtonsGroup` do.
+- The component supplies no group label itself, and `UseRadioGroup` ships a group with no `FormLabel` and no `aria-labelledby`, a reachable failure that nothing catches (no axe rule flags an unnamed `radiogroup`). Add a visible `FormLabel` for every group.
+
+**Manual testing steps**
+
+1. For each radio group, confirm a visible question or instruction is shown to all users.
+2. Flag any `RadioGroup` with no `FormLabel` (such as `UseRadioGroup`).
+
+**Pass:** every group has a visible label or instruction. A group with no visible label fails.
+
+#### 4.1.2 Name, Role, Value · A
+
+`✅ Supports` · `◐ Shared`
+
+- The group's role and value are met: `role="radiogroup"` names the relationship, and the selected value is exposed by the checked native radio with change notification, no ARIA needed. Covered by axe-core and unit tests.
+- The group's name is the shared part: it comes from the author's `FormLabel` via `aria-labelledby`. Each option's own name, role, and checked state are rated in the [Radio report](../Radio/accessibility.md).
+
+**Manual testing steps**
+
+1. Open `ControlledRadioButtonsGroup` and inspect the `radiogroup`: confirm its role, its name from the `FormLabel`, and that the selected `radio` reads as checked.
+2. Select a different option with a screen reader running and confirm the new value is announced.
+
+**Pass:** the group exposes its `radiogroup` role, an author-supplied name, and the current selected value with change notification.
+
+### ⚙️ Automated
+
+#### 2.1.1 Keyboard · A
+
+`✅ Supports` · `● Component`
+
+- Because RadioGroup renders real `<input type="radio">` options sharing one `name`, the browser provides the [APG radio pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio/) keyboard behavior with no custom script: <kbd>Space</kbd> selects the focused option, and <kbd>↓</kbd>/<kbd>→</kbd> and <kbd>↑</kbd>/<kbd>←</kbd> move to the next or previous option and select it, wrapping at the ends.
+- Covered by unit tests.
+
+#### 2.4.3 Focus Order · A
+
+`✅ Supports` · `● Component`
+
+- The group is one tab stop: <kbd>Tab</kbd> enters on the checked option, or the first enabled option when none is checked, and <kbd>Tab</kbd> again leaves the group (native roving tab order). RadioGroup's imperative `focus()` action (`RadioGroup.js`) sets the same entry point, focusing the checked input or the first enabled one.
+- Covered by unit tests.
+
+## Inherited from Radio
+
+These item-level criteria are rated once in the [Radio report](../Radio/accessibility.md); the grouping does not change them. They are not re-rated here and do not count toward the Unverified ratio.
+
+- [**1.1.1 Non-text Content (A)**](../Radio/accessibility.md). Each option's dot and circle, and its label-derived name.
+- [**1.3.2 Meaningful Sequence (A)**](../Radio/accessibility.md). Each option's input-then-label source order.
+- [**1.3.3 Sensory Characteristics (A)**](../Radio/accessibility.md). Each option's reliance on its label, not sensory cues.
+- [**1.4.3 Contrast (Minimum) (AA)**](../Radio/accessibility.md). Each option's label and helper text.
+- [**1.4.4 Resize Text (AA)**](../Radio/accessibility.md). Each option's rem-sized icon and text.
+- [**1.4.5 Images of Text (AA)**](../Radio/accessibility.md). Each option's text label.
+- [**1.4.10 Reflow (AA)**](../Radio/accessibility.md). Each option's inline-flex layout.
+- [**1.4.11 Non-text Contrast (AA)**](../Radio/accessibility.md). Each option's dot and circle at 3:1.
+- [**1.4.12 Text Spacing (AA)**](../Radio/accessibility.md). Each option's label under spacing overrides.
+- [**2.1.2 No Keyboard Trap (A)**](../Radio/accessibility.md). Each option as a native input.
+- [**2.4.7 Focus Visible (AA)**](../Radio/accessibility.md). Each option's focus ripple.
+- [**2.4.11 Focus Not Obscured (Minimum) (AA)**](../Radio/accessibility.md). Each option's focus visibility.
+- [**2.5.2 Pointer Cancellation (A)**](../Radio/accessibility.md). Each option activating on pointer-up.
+- [**2.5.3 Label in Name (A)**](../Radio/accessibility.md). Each option's accessible name containing its label.
+- [**2.5.8 Target Size (Minimum) (AA)**](../Radio/accessibility.md). Each option's padded 42px target.
+- [**3.2.1 On Focus (A)**](../Radio/accessibility.md). Each option changing nothing on focus.
+- [**3.2.2 On Input (A)**](../Radio/accessibility.md). Each option changing only its value on selection.
+- [**3.2.4 Consistent Identification (AA)**](../Radio/accessibility.md). Each option's stable label.
+
+## Not applicable
+
+- **1.3.5 Identify Input Purpose (AA).** Covers inputs that collect information about the user through `autocomplete`. A radio choice is not one of those input purposes.
+- **1.4.13 Content on Hover or Focus (AA).** The group shows no additional content on hover or focus; a `Tooltip` wrapper would own this.
+- **2.1.4 Character Key Shortcuts (A).** The only keys are <kbd>Space</kbd> and the arrow keys, and only while focused. There is no single-character shortcut.
+- **2.2.2 Pause, Stop, Hide (A).** No auto-starting moving, blinking, or auto-updating content.
+- **2.4.4 Link Purpose (In Context) (A).** The group renders no links.
+- **2.5.7 Dragging Movements (AA, new in 2.2).** Covers drag operations. Options select by tap, click, or key.
+- **3.1.1 Language of Page (A), 3.1.2 Language of Parts (AA).** The group emits no `<html lang>` and no text of its own. A foreign-language label is the author's phrase to mark.
+- **3.2.3 Consistent Navigation (AA).** Covers repeated navigation across a set of pages, not a single group.
+- **3.2.6 Consistent Help (A, new in 2.2).** Covers consistent placement of help across pages.
+- **3.3.7 Redundant Entry (A, new in 2.2).** Covers repopulating previously entered data. The group captures none.
+- **3.3.8 Accessible Authentication (Minimum) (AA, new in 2.2).** The paste, autofill, and cognitive-test duty falls on the credential fields, not a radio group.
+- **4.1.3 Status Messages (AA).** The group emits no status messages; the selected-value change is covered by 4.1.2.
+- **Time-based media (1.2.1 to 1.2.5).** No audio or video.
+- **Audio Control (1.4.2).** Emits no audio.
+- **Orientation (1.3.4).** Sets no orientation lock; the `row` prop is a layout choice, not a lock.
+- **Bypass Blocks (2.4.1), Page Titled (2.4.2), Multiple Ways (2.4.5).** Page or site structure, not a single group.
+- **Timing Adjustable (2.2.1).** Sets no time limit.
+- **Three Flashes or Below Threshold (2.3.1).** Nothing flashes.
+- **Pointer Gestures (2.5.1), Motion Actuation (2.5.4).** Selects on a simple click; reads no device motion.
+- **Error Identification (3.3.1), Error Suggestion (3.3.3), Error Prevention (3.3.4).** The group collects a choice and supports `required`, but in isolation it raises no error state or message of its own; error detection and messaging belong to the form or validation process. When an author shows an error (as `ErrorRadios` does), tie it to the group with `aria-describedby` (tracked under 1.3.1).
+
+## Level AAA
+
+The following SC are applicable but out of scope:
+
+- **2.3.3 Animation from Interactions.** Each option's ripple `scale()` animation honors `prefers-reduced-motion` when the theme sets `motion.reducedMotion` to `system` or `always`; `disableRipple` also removes it. The default is `never`. `🚩`
+- **2.4.13 Focus Appearance.** The option focus ripple is unlikely to meet the area and 3:1 thresholds, and `disableRipple` removes it. `🚩`
+- **2.5.5 Target Size (Enhanced), 44 px.** Default option sizes (42px medium, 38px small) are below 44px. `🚩`
+- **1.4.6 Contrast (Enhanced), 7:1.** Option labels (`text.primary`, about 16:1) clear 7:1, but helper text (about 5:1) and the dot and circle fall short where the 7:1 bar applies. `🚩`
+- Also touched, in the same shape as their A and AA siblings: **1.3.6 Identify Purpose, 1.4.9 Images of Text (No Exception), 2.1.3 Keyboard (No Exception), 2.4.12 Focus Not Obscured (Enhanced)**.
+
+## Scope and test environment
+
+- **Standard.** WCAG 2.2, Level A and AA.
+- **Component version.** `@mui/material` 9.1.2.
+- **Scope.** The RadioGroup component coordinating two or more `Radio` children, with `FormControl`/`FormLabel` for the group's name and `FormHelperText`, rendered through the documented API. Each radio's item-level conformance is inherited from the [Radio report](../Radio/accessibility.md).
+- **Automated.** axe-core via the Playwright visual-regression harness (results in [`radio-buttons.a11y.json`](../../../../docs/data/material/components/radio-buttons/radio-buttons.a11y.json)), plus interaction tests in [`RadioGroup.test.js`](./RadioGroup.test.js). The arrow-key navigation and roving tab-order test runs in the browser project only, since jsdom does not implement native radio-group navigation.
+- **Assistive-technology review.** Not yet performed. `🚩` criteria are assessed from source pending a review with NVDA, JAWS, and VoiceOver.

--- a/packages/mui-material/src/RadioGroup/accessibility.md
+++ b/packages/mui-material/src/RadioGroup/accessibility.md
@@ -6,18 +6,18 @@ RadioGroup coordinates a set of [Radio](../Radio/accessibility.md) children, so 
 
 | Result                  | Count |
 | :---------------------- | :---- |
-| ✅ Supports             | 6     |
-| ⚠️ Partially Supports   | 1     |
+| ✅ Supports             | 7     |
+| ⚠️ Partially Supports   | 0     |
 | ❌ Does Not Support     | 0     |
 | ➖ Not Applicable       | 30    |
 | ↗ Inherited (see Radio) | 18    |
-| 🚩 Unverified           | 3/7   |
+| 🚩 Flagged              | 3/7   |
 
-The first three rows and Not Applicable count the 7 group-level criteria plus the 30 that do not apply; Inherited adds the 18 item-level criteria rated in Radio (7 + 30 + 18 = 55). Unverified is the ratio of flagged to applicable group-level criteria; inherited criteria are excluded.
+The first three rows and Not Applicable count the 7 group-level criteria plus the 30 that do not apply; Inherited adds the 18 item-level criteria rated in Radio (7 + 30 + 18 = 55). Flagged is the ratio of source-assessed to applicable group-level criteria; inherited criteria are excluded.
 
 ## Known gaps
 
-- ⚠️ **3.3.2 Labels or Instructions.** The group ships no label of its own. `role="radiogroup"` requires an accessible name, but `UseRadioGroup` renders a group with no `FormLabel` and no `aria-labelledby`, so the question is unlabeled. Pair the group with a `FormLabel` referenced by `aria-labelledby`.
+No group-level gaps. The inherited item-level gaps (1.4.11 Non-text Contrast, 2.4.7 Focus Visible) are covered in the [Radio report](../Radio/accessibility.md).
 
 ## Success criteria
 
@@ -25,16 +25,16 @@ The first three rows and Not Applicable count the 7 group-level criteria plus th
 
 #### 1.4.1 Use of Color · A
 
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+`🚩` · `✅ Supports` · `◐ Shared`
 
-- Which option is selected is shown by the filled dot inside one circle, a shape difference, not color, so a color-blind user can tell the selected option from the rest.
-- A group error shown only through red `FormHelperText` is color-only. Pair it with text or an icon. That is author content.
+- State is conveyed by the dot's presence and not color - an empty circle (unchecked) and a circle with a filled dot (checked)
+- The group error state is color-only: `FormHelperText` conveys it through red text. The author is responsible for associating it with error text.
 
 **Manual testing steps**
 
-1. Open `RadioButtonsGroup`, select an option, and view the group in grayscale (DevTools Rendering, Emulate vision deficiencies, Achromatopsia).
+1. Render a `RadioGroup` with a `FormLabel` and several `Radio` options, select one, and view the group in grayscale (DevTools Rendering, Emulate vision deficiencies, Achromatopsia).
 2. Confirm the selected option is still identifiable by its dot.
-3. Render an error `FormHelperText` (as in `ErrorRadios`) in grayscale and confirm "error" is still perceivable.
+3. Render the group with an error `FormHelperText` in grayscale and confirm "error" is still perceivable.
 
 **Pass:** the selected option is distinguishable by the dot, and any error state is conveyed by more than color.
 
@@ -49,14 +49,14 @@ The first three rows and Not Applicable count the 7 group-level criteria plus th
 
 **Manual testing steps**
 
-1. Open `RadioButtonsGroup` and inspect the accessibility tree: confirm a `radiogroup` node named by the `FormLabel`, containing the `radio` options.
-2. Open `UseRadioGroup` and confirm the `radiogroup` is present but unnamed.
+1. Render a `RadioGroup` whose `aria-labelledby` points to a `FormLabel`, and inspect the accessibility tree: confirm a `radiogroup` node named by the `FormLabel`, containing the `radio` options.
+2. Render a `RadioGroup` with no `FormLabel` or `aria-labelledby` and confirm the `radiogroup` is present but unnamed.
 
 **Pass:** the radios are exposed as one `radiogroup`, and the name and any description are set by the author.
 
 #### 2.4.6 Headings and Labels · AA
 
-`🚩 Unverified` · `✅ Supports` · `◐ Shared`
+`🚩` · `✅ Supports` · `◐ Shared`
 
 - The group's label comes from a `FormLabel` referenced by `aria-labelledby`, the documented pattern in `RadioButtonsGroup` and `RowRadioButtonsGroup`. axe-core covers that the reference resolves; whether the wording describes the question is a manual review.
 - A vague group label ("Choose one") would fail, and the component cannot enforce wording.
@@ -70,15 +70,15 @@ The first three rows and Not Applicable count the 7 group-level criteria plus th
 
 #### 3.3.2 Labels or Instructions · A
 
-`🚩 Unverified` · `⚠️ Partially Supports` · `◐ Shared`
+`🚩` · `✅ Supports` · `◐ Shared`
 
-- A radio group is a data-entry question, so it needs a label or instructions presented to all users. The conforming pattern pairs `RadioGroup` with a `FormLabel` referenced by `aria-labelledby`, as `RadioButtonsGroup`, `ControlledRadioButtonsGroup`, and `RowRadioButtonsGroup` do.
-- The component supplies no group label itself, and `UseRadioGroup` ships a group with no `FormLabel` and no `aria-labelledby`, a reachable failure that nothing catches (no axe rule flags an unnamed `radiogroup`). Add a visible `FormLabel` for every group.
+- A radio group is a data-entry question, so it needs a label or instructions presented to all users. The component supports this through a `FormLabel` referenced by `aria-labelledby`, the documented pattern in `RadioButtonsGroup`, `ControlledRadioButtonsGroup`, and `RowRadioButtonsGroup`.
+- The label text itself is author content and should use`FormLabel`.
 
 **Manual testing steps**
 
 1. For each radio group, confirm a visible question or instruction is shown to all users.
-2. Flag any `RadioGroup` with no `FormLabel` (such as `UseRadioGroup`).
+2. Flag any `RadioGroup` with no `FormLabel`.
 
 **Pass:** every group has a visible label or instruction. A group with no visible label fails.
 
@@ -91,7 +91,7 @@ The first three rows and Not Applicable count the 7 group-level criteria plus th
 
 **Manual testing steps**
 
-1. Open `ControlledRadioButtonsGroup` and inspect the `radiogroup`: confirm its role, its name from the `FormLabel`, and that the selected `radio` reads as checked.
+1. Render a controlled `RadioGroup` with a `FormLabel` and inspect the `radiogroup`: confirm its role, its name from the `FormLabel`, and that the selected `radio` reads as checked.
 2. Select a different option with a screen reader running and confirm the new value is announced.
 
 **Pass:** the group exposes its `radiogroup` role, an author-supplied name, and the current selected value with change notification.
@@ -114,30 +114,30 @@ The first three rows and Not Applicable count the 7 group-level criteria plus th
 
 ## Inherited from Radio
 
-These item-level criteria are rated once in the [Radio report](../Radio/accessibility.md); the grouping does not change them. They are not re-rated here and do not count toward the Unverified ratio.
+These item-level criteria are rated once in the [Radio report](../Radio/accessibility.md); the grouping does not change them. They are not re-rated here and do not count toward the Flagged ratio.
 
-- [**1.1.1 Non-text Content (A)**](../Radio/accessibility.md). Each option's dot and circle, and its label-derived name.
-- [**1.3.2 Meaningful Sequence (A)**](../Radio/accessibility.md). Each option's input-then-label source order.
-- [**1.3.3 Sensory Characteristics (A)**](../Radio/accessibility.md). Each option's reliance on its label, not sensory cues.
-- [**1.4.3 Contrast (Minimum) (AA)**](../Radio/accessibility.md). Each option's label and helper text.
-- [**1.4.4 Resize Text (AA)**](../Radio/accessibility.md). Each option's rem-sized icon and text.
-- [**1.4.5 Images of Text (AA)**](../Radio/accessibility.md). Each option's text label.
-- [**1.4.10 Reflow (AA)**](../Radio/accessibility.md). Each option's inline-flex layout.
-- [**1.4.11 Non-text Contrast (AA)**](../Radio/accessibility.md). Each option's dot and circle at 3:1.
-- [**1.4.12 Text Spacing (AA)**](../Radio/accessibility.md). Each option's label under spacing overrides.
-- [**2.1.2 No Keyboard Trap (A)**](../Radio/accessibility.md). Each option as a native input.
-- [**2.4.7 Focus Visible (AA)**](../Radio/accessibility.md). Each option's focus ripple.
-- [**2.4.11 Focus Not Obscured (Minimum) (AA)**](../Radio/accessibility.md). Each option's focus visibility.
-- [**2.5.2 Pointer Cancellation (A)**](../Radio/accessibility.md). Each option activating on pointer-up.
-- [**2.5.3 Label in Name (A)**](../Radio/accessibility.md). Each option's accessible name containing its label.
-- [**2.5.8 Target Size (Minimum) (AA)**](../Radio/accessibility.md). Each option's padded 42px target.
-- [**3.2.1 On Focus (A)**](../Radio/accessibility.md). Each option changing nothing on focus.
-- [**3.2.2 On Input (A)**](../Radio/accessibility.md). Each option changing only its value on selection.
-- [**3.2.4 Consistent Identification (AA)**](../Radio/accessibility.md). Each option's stable label.
+- **1.1.1 Non-text Content (A).** Each option's dot and circle, and its label-derived name.
+- **1.3.2 Meaningful Sequence (A).** Each option's input-then-label source order.
+- **1.3.3 Sensory Characteristics (A).** Each option's reliance on its label, not sensory cues.
+- **1.4.3 Contrast (Minimum) (AA).** Each option's label and helper text.
+- **1.4.4 Resize Text (AA).** Each option's rem-sized icon and text.
+- **1.4.5 Images of Text (AA).** Each option's text label.
+- **1.4.10 Reflow (AA).** Each option's inline-flex layout.
+- **1.4.11 Non-text Contrast (AA).** Each option's dot and circle at 3:1.
+- **1.4.12 Text Spacing (AA).** Each option's label under spacing overrides.
+- **2.1.2 No Keyboard Trap (A).** Each option as a native input.
+- **2.4.7 Focus Visible (AA).** Each option's focus ripple.
+- **2.4.11 Focus Not Obscured (Minimum) (AA).** Each option's focus visibility.
+- **2.5.2 Pointer Cancellation (A).** Each option activating on pointer-up.
+- **2.5.3 Label in Name (A).** Each option's accessible name containing its label.
+- **2.5.8 Target Size (Minimum) (AA).** Each option's padded 42px target.
+- **3.2.1 On Focus (A).** Each option changing nothing on focus.
+- **3.2.2 On Input (A).** Each option changing only its value on selection.
+- **3.2.4 Consistent Identification (AA).** Each option's stable label.
 
 ## Not applicable
 
-- **1.3.5 Identify Input Purpose (AA).** Covers inputs that collect information about the user through `autocomplete`. A radio choice is not one of those input purposes.
+- **1.3.5 Identify Input Purpose (AA).** Covers fields that autofill the user's own data through `autocomplete`. Those purposes map to text-entry and `select` controls (`sex`, for example, is free-form text), not radio buttons, so even a "Gender" radio group is outside this criterion.
 - **1.4.13 Content on Hover or Focus (AA).** The group shows no additional content on hover or focus; a `Tooltip` wrapper would own this.
 - **2.1.4 Character Key Shortcuts (A).** The only keys are <kbd>Space</kbd> and the arrow keys, and only while focused. There is no single-character shortcut.
 - **2.2.2 Pause, Stop, Hide (A).** No auto-starting moving, blinking, or auto-updating content.
@@ -174,4 +174,4 @@ The following SC are applicable but out of scope:
 - **Component version.** `@mui/material` 9.1.2.
 - **Scope.** The RadioGroup component coordinating two or more `Radio` children, with `FormControl`/`FormLabel` for the group's name and `FormHelperText`, rendered through the documented API. Each radio's item-level conformance is inherited from the [Radio report](../Radio/accessibility.md).
 - **Automated.** axe-core via the Playwright visual-regression harness (results in [`radio-buttons.a11y.json`](../../../../docs/data/material/components/radio-buttons/radio-buttons.a11y.json)), plus interaction tests in [`RadioGroup.test.js`](./RadioGroup.test.js). The arrow-key navigation and roving tab-order test runs in the browser project only, since jsdom does not implement native radio-group navigation.
-- **Assistive-technology review.** Not yet performed. `🚩` criteria are assessed from source pending a review with NVDA, JAWS, and VoiceOver.
+- **Assistive-technology review.** Not yet performed. Flagged criteria are assessed from source pending a review with NVDA, JAWS, and VoiceOver.

--- a/test/regressions/a11y/axe.ts
+++ b/test/regressions/a11y/axe.ts
@@ -57,6 +57,11 @@ interface RecordA11yOptions {
   slug: string;
   demo: string;
   /**
+   * `visual` asserts only rules that need real rendered CSS. `all` asserts
+   * every axe violation/incomplete not listed in `skipAssertions`.
+   */
+  assertions?: 'visual' | 'all';
+  /**
    * Rule ids whose violations are recorded but not asserted on. The rule
    * still runs and still lands in the results JSON — only the test-failing
    * assertion is suppressed.
@@ -74,7 +79,7 @@ interface RecordA11yOptions {
 export function recordA11y(
   ctx: TestContext,
   results: AxeResults,
-  { slug, demo, skipAssertions = [] }: RecordA11yOptions,
+  { slug, demo, assertions = 'visual', skipAssertions = [] }: RecordA11yOptions,
 ): void {
   const rules: Record<string, RuleEntry> = {};
   const buckets: ReadonlyArray<[AxeResults['passes'], RuleStatus]> = [
@@ -100,22 +105,20 @@ export function recordA11y(
   (ctx.task.meta as { a11y?: A11yMeta }).a11y = meta;
 
   const skip = new Set(skipAssertions);
-  const visualViolations = results.violations.filter(
-    (v) => VISUAL_RULES.includes(v.id) && !skip.has(v.id),
-  );
-  const visualIncomplete = results.incomplete.filter(
-    (v) => VISUAL_RULES.includes(v.id) && !skip.has(v.id),
-  );
+  const shouldAssert = (ruleId: string) =>
+    !skip.has(ruleId) && (assertions === 'all' || VISUAL_RULES.includes(ruleId));
+  const assertedViolations = results.violations.filter((v) => shouldAssert(v.id));
+  const assertedIncomplete = results.incomplete.filter((v) => shouldAssert(v.id));
 
   const failures: string[] = [];
-  if (visualViolations.length > 0) {
+  if (assertedViolations.length > 0) {
     failures.push(
-      `${visualViolations.length} axe violation(s):\n\n${formatResults(visualViolations)}`,
+      `${assertedViolations.length} axe violation(s):\n\n${formatResults(assertedViolations)}`,
     );
   }
-  if (visualIncomplete.length > 0) {
+  if (assertedIncomplete.length > 0) {
     failures.push(
-      `${visualIncomplete.length} axe incomplete (needs review):\n\n${formatResults(visualIncomplete)}`,
+      `${assertedIncomplete.length} axe incomplete (needs review):\n\n${formatResults(assertedIncomplete)}`,
     );
   }
   if (failures.length > 0) {

--- a/test/regressions/demoMeta.test.ts
+++ b/test/regressions/demoMeta.test.ts
@@ -58,6 +58,25 @@ describe('getConfig', () => {
     );
   });
 
+  it('returns the radio a11y rule for a brace-glob enrolment', () => {
+    expect(
+      getConfig(A11Y_RULES, 'docs/data/material/components/radio-buttons/RadioButtonsGroup'),
+    ).to.deep.include({ enabled: true, assertions: 'all' });
+    expect(
+      getConfig(A11Y_RULES, 'docs/data/material/components/radio-buttons/UseRadioGroup'),
+    ).to.deep.include({ enabled: true, assertions: 'all' });
+  });
+
+  it('returns undefined for a radio demo outside the enrolment', () => {
+    // The radio-buttons enrolment omits FormControlLabelPlacement.
+    expect(
+      getConfig(
+        A11Y_RULES,
+        'docs/data/material/components/radio-buttons/FormControlLabelPlacement',
+      ),
+    ).to.equal(undefined);
+  });
+
   it('honours last-match-wins when multiple rules apply', () => {
     const rules = [
       { test: 'docs/data/material/components/foo/*', enabled: true },

--- a/test/regressions/demoMeta.ts
+++ b/test/regressions/demoMeta.ts
@@ -37,6 +37,11 @@ export interface A11yRule {
   /** Minimatch glob against `docs/data/material/components/{slug}/{Demo}`. */
   test: string;
   enabled?: boolean;
+  /**
+   * `visual` asserts rules that depend on rendered CSS. `all` asserts every
+   * axe violation/incomplete that is not listed in `skipAssertions`.
+   */
+  assertions?: 'visual' | 'all';
   /** Axe rule IDs recorded into results JSON but not asserted on. */
   skipAssertions?: string[];
 }
@@ -145,6 +150,20 @@ export const SCREENSHOT_RULES: ScreenshotRule[] = [
   },
 ];
 
+// Radio docs demos enrolled for axe assertions. FormControlLabelPlacement is left out: its axe
+// output duplicates RowRadioButtonsGroup (a row RadioGroup with a FormLabel), adding no new rules.
+const RADIO_A11Y_DEMOS = [
+  'RadioButtons',
+  'RadioButtonsGroup',
+  'ControlledRadioButtonsGroup',
+  'ColorRadioButtons',
+  'CustomizedRadios',
+  'SizeRadioButtons',
+  'RowRadioButtonsGroup',
+  'ErrorRadios',
+  'UseRadioGroup',
+];
+
 /**
  * A11y defaults to off — only matched-and-enabled rules produce results.
  * Slug-wide rules use `*`; brace-globs narrow enrolment to specific demos;
@@ -154,6 +173,11 @@ export const SCREENSHOT_RULES: ScreenshotRule[] = [
  */
 export const A11Y_RULES: A11yRule[] = [
   { test: 'docs/data/material/components/buttons/{BasicButtons,ColorButtons}', enabled: true },
+  {
+    test: `docs/data/material/components/radio-buttons/{${RADIO_A11Y_DEMOS.join(',')}}`,
+    enabled: true,
+    assertions: 'all',
+  },
 ];
 
 export interface ParsedRoute {

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -219,6 +219,7 @@ async function main() {
               recordA11y({ task }, results, {
                 slug: parsed.slug,
                 demo: parsed.demo,
+                assertions: a11yRule.assertions,
                 skipAssertions: a11yRule.skipAssertions,
               });
             }


### PR DESCRIPTION
Radio
| Result                | Count |
| :-------------------- | :---- |
| ✅ Supports           | 23    |
| ⚠️ Partially Supports | 2     |
| ❌ Does Not Support   | 0     |
| ➖ Not Applicable     | 30    |

RadioGroup
| Result                 | Count |
| :--------------------- | :---- |
| ✅ Supports            | 7     |
| ⚠️ Partially Supports  | 0     |
| ❌ Does Not Support    | 0     |
| ➖ Not Applicable      | 30    |
| ↗ Inherited from Radio | 18    |

Reports:
- [Radio](https://github.com/mj12albert/material-ui/blob/wcag-radiogroup/packages/mui-material/src/Radio/accessibility.md)
- [RadioGroup](https://github.com/mj12albert/material-ui/blob/wcag-radiogroup/packages/mui-material/src/RadioGroup/accessibility.md)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
