### PR TITLE
[test][accordion] Add axe tests and doc

### DIFF
--- a/docs/data/material/components/accordion/AccordionA11yNonNative.js
+++ b/docs/data/material/components/accordion/AccordionA11yNonNative.js
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Typography from '@mui/material/Typography';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+
+const CustomDivSummary = React.forwardRef(function CustomDivSummary(props, ref) {
+  return <div ref={ref} {...props} />;
+});
+
+export default function AccordionA11yNonNative() {
+  const id = React.useId();
+  return (
+    <div>
+      <Accordion defaultExpanded>
+        <AccordionSummary
+          component={CustomDivSummary}
+          nativeButton={false}
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls={`${id}-panel1-content`}
+          id={`${id}-panel1-header`}
+        >
+          <Typography component="span">Non-native summary</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+          malesuada lacus ex, sit amet blandit leo lobortis eget.
+        </AccordionDetails>
+      </Accordion>
+      <Accordion disabled>
+        <AccordionSummary
+          component={CustomDivSummary}
+          nativeButton={false}
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls={`${id}-panel2-content`}
+          id={`${id}-panel2-header`}
+        >
+          <Typography component="span">Disabled non-native summary</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+          malesuada lacus ex, sit amet blandit leo lobortis eget.
+        </AccordionDetails>
+      </Accordion>
+    </div>
+  );
+}

--- a/docs/data/material/components/accordion/AccordionA11yNonNative.tsx
+++ b/docs/data/material/components/accordion/AccordionA11yNonNative.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Typography from '@mui/material/Typography';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+
+const CustomDivSummary = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(function CustomDivSummary(props, ref) {
+  return <div ref={ref} {...props} />;
+});
+
+export default function AccordionA11yNonNative() {
+  const id = React.useId();
+  return (
+    <div>
+      <Accordion defaultExpanded>
+        <AccordionSummary
+          component={CustomDivSummary}
+          nativeButton={false}
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls={`${id}-panel1-content`}
+          id={`${id}-panel1-header`}
+        >
+          <Typography component="span">Non-native summary</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+          malesuada lacus ex, sit amet blandit leo lobortis eget.
+        </AccordionDetails>
+      </Accordion>
+      <Accordion disabled>
+        <AccordionSummary
+          component={CustomDivSummary}
+          nativeButton={false}
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls={`${id}-panel2-content`}
+          id={`${id}-panel2-header`}
+        >
+          <Typography component="span">Disabled non-native summary</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+          malesuada lacus ex, sit amet blandit leo lobortis eget.
+        </AccordionDetails>
+      </Accordion>
+    </div>
+  );
+}

--- a/docs/data/material/components/accordion/AccordionA11yTextSpacing.js
+++ b/docs/data/material/components/accordion/AccordionA11yTextSpacing.js
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Typography from '@mui/material/Typography';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+
+export default function AccordionA11yTextSpacing() {
+  const id = React.useId();
+  return (
+    <Accordion defaultExpanded sx={{ maxWidth: 320 }}>
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls={`${id}-panel1-content`}
+        id={`${id}-panel1-header`}
+      >
+        <Typography component="span">
+          Review your accessibility settings before continuing to the next step
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Typography>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+          malesuada lacus ex, sit amet blandit leo lobortis eget. Vivamus auctor
+          neque a sapien fringilla, in dictum massa pretium.
+        </Typography>
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/docs/data/material/components/accordion/AccordionA11yTextSpacing.tsx
+++ b/docs/data/material/components/accordion/AccordionA11yTextSpacing.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Typography from '@mui/material/Typography';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+
+export default function AccordionA11yTextSpacing() {
+  const id = React.useId();
+  return (
+    <Accordion defaultExpanded sx={{ maxWidth: 320 }}>
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls={`${id}-panel1-content`}
+        id={`${id}-panel1-header`}
+      >
+        <Typography component="span">
+          Review your accessibility settings before continuing to the next step
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Typography>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+          malesuada lacus ex, sit amet blandit leo lobortis eget. Vivamus auctor
+          neque a sapien fringilla, in dictum massa pretium.
+        </Typography>
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/docs/data/material/components/accordion/accordion.a11y.json
+++ b/docs/data/material/components/accordion/accordion.a11y.json
@@ -1,0 +1,530 @@
+{
+  "AccordionA11yNonNative": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-command-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "avoid-inline-spacing": {
+        "status": "pass",
+        "tags": ["wcag21aa"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "AccordionA11yTextSpacing": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "avoid-inline-spacing": {
+        "status": "pass",
+        "tags": ["wcag21aa"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "AccordionExpandDefault": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "avoid-inline-spacing": {
+        "status": "pass",
+        "tags": ["wcag21aa"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "incomplete",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "AccordionExpandIcon": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "avoid-inline-spacing": {
+        "status": "pass",
+        "tags": ["wcag21aa"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "incomplete",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "AccordionTransition": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "avoid-inline-spacing": {
+        "status": "pass",
+        "tags": ["wcag21aa"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "AccordionUsage": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "avoid-inline-spacing": {
+        "status": "pass",
+        "tags": ["wcag21aa"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "incomplete",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "ControlledAccordions": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "avoid-inline-spacing": {
+        "status": "pass",
+        "tags": ["wcag21aa"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "CustomizedAccordions": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-deprecated-role": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-required-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-roles": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "avoid-inline-spacing": {
+        "status": "pass",
+        "tags": ["wcag21aa"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "pass",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  },
+  "DisabledAccordion": {
+    "rules": {
+      "aria-allowed-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-conditional-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-hidden-focus": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-prohibited-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "aria-valid-attr-value": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "avoid-inline-spacing": {
+        "status": "pass",
+        "tags": ["wcag21aa"]
+      },
+      "button-name": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "color-contrast": {
+        "status": "incomplete",
+        "tags": ["wcag2aa"]
+      },
+      "duplicate-id-aria": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "nested-interactive": {
+        "status": "pass",
+        "tags": ["wcag2a"]
+      },
+      "target-size": {
+        "status": "pass",
+        "tags": ["wcag22aa"]
+      }
+    }
+  }
+}

--- a/packages/mui-material/src/Accordion/Accordion.test.js
+++ b/packages/mui-material/src/Accordion/Accordion.test.js
@@ -5,7 +5,7 @@ import { spy } from 'sinon';
 import { createRenderer, fireEvent, isJsdom, reactMajor, screen } from '@mui/internal-test-utils';
 import Accordion, { accordionClasses as classes } from '@mui/material/Accordion';
 import Paper from '@mui/material/Paper';
-import Collapse from '@mui/material/Collapse';
+import Collapse, { collapseClasses } from '@mui/material/Collapse';
 import Fade from '@mui/material/Fade';
 import Slide from '@mui/material/Slide';
 import Grow from '@mui/material/Grow';
@@ -450,5 +450,21 @@ describe('<Accordion />', () => {
     );
 
     expect(screen.getByTestId('region-slot')).to.have.attribute('role', 'list');
+  });
+
+  describe('WCAG 2.2 conformance', () => {
+    it('2.4.3 Focus Order: a collapsed panel is hidden, removing its content from the tab order', () => {
+      const { container } = render(
+        <Accordion>
+          <AccordionSummary>Summary</AccordionSummary>
+          Details
+        </Accordion>,
+      );
+
+      // Collapse applies its `hidden` class (visibility: hidden) when fully
+      // collapsed, so the panel and any focusable content it holds leave the
+      // tab order until the accordion is expanded.
+      expect(container.querySelector(`.${collapseClasses.hidden}`)).not.to.equal(null);
+    });
   });
 });

--- a/packages/mui-material/src/Accordion/accessibility.md
+++ b/packages/mui-material/src/Accordion/accessibility.md
@@ -1,0 +1,283 @@
+# Accordion accessibility conformance
+
+Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility.md).
+
+This doc covers the root `<Accordion>` together with `AccordionDetails` and `AccordionActions`, which are passive content containers. It inherits the header's item-level criteria from [AccordionSummary](../AccordionSummary/accessibility.md).
+
+| Result                             | Count |
+| :--------------------------------- | :---- |
+| ✅ Supports                        | 19    |
+| ⚠️ Partially Supports              | 0     |
+| ❌ Does Not Support                | 0     |
+| ➖ Not Applicable                  | 31    |
+| ↗ Inherited (see AccordionSummary) | 5     |
+| 🚩 Flagged                         | 6/19  |
+
+## Known gaps
+
+- Inherits: ⚠️ **1.4.11 Non-text Contrast** (the summary focus indicator) from [AccordionSummary](../AccordionSummary/accessibility.md).
+
+## Success criteria
+
+### 🔍 Manual
+
+#### 1.3.2 Meaningful Sequence · A
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- The header renders before its panel in DOM order, so the reading sequence matches the visual one; the panel content is author-supplied.
+
+**Manual testing steps**
+
+1. With a screen reader running, expand an accordion and read it top to bottom.
+
+**Pass:** the header is announced before its panel content.
+
+#### 1.3.3 Sensory Characteristics · A
+
+`✅ Supports` · `○ Author`
+
+- The accordion is operated by its header label, not by a sensory cue; surrounding instructions must not rely on the chevron's shape or position alone.
+
+**Manual testing steps**
+
+1. Find product copy that tells users to expand a section and check it names the section by its heading.
+
+**Pass:** no instruction depends on shape, color, or position alone.
+
+#### 1.4.1 Use of Color · A
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- The open and closed states are shown by `aria-expanded` and the rotated chevron, not by color alone.
+
+**Manual testing steps**
+
+1. In a UI with accordions, turn on a grayscale view and expand or collapse a panel.
+
+**Pass:** the state stays distinguishable without color.
+
+#### 1.4.4 Resize Text · AA
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- Header and panel text use rem and theme spacing, so the accordion scales with browser zoom; a fixed-pixel wrapper in the surrounding layout could clip at 200%.
+
+**Manual testing steps**
+
+1. In a UI with accordions, set browser zoom to 200%.
+2. Confirm header and panel text are fully visible and the control still toggles.
+
+**Pass:** nothing is clipped at 200%.
+
+#### 1.4.5 Images of Text · AA
+
+`✅ Supports` · `○ Author`
+
+- The header and panel render real text.
+
+**Manual testing steps**
+
+1. Confirm the header or panel text is real text and not an image.
+
+**Pass:** no header or panel renders its text as an image.
+
+#### 1.4.10 Reflow · AA
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- The accordion is full width and its text wraps, so it reflows on its own; horizontal overflow at 320 CSS pixels comes from the surrounding layout.
+
+**Manual testing steps**
+
+1. In a UI with accordions, set the viewport to 320 CSS pixels wide.
+2. Confirm there is no sideways scrolling and all text is reachable.
+
+**Pass:** content reflows with no horizontal scroll.
+
+#### 2.4.11 Focus Not Obscured (Minimum) · AA
+
+`✅ Supports` · `○ Author`
+
+- The accordion never hides its own focused header; full obscuring comes from sticky headers or overlays in the surrounding layout.
+
+**Manual testing steps**
+
+1. In a page with a sticky header, <kbd>Tab</kbd> to a header near it, scroll it under the sticky element, and <kbd>Tab</kbd> back.
+
+**Pass:** at least part of the focused header stays visible.
+
+#### 3.2.4 Consistent Identification · AA
+
+`✅ Supports` · `○ Author`
+
+- The component produces one stable name and structure per set of props; using the same header for the same purpose across pages is an authoring concern.
+
+**Manual testing steps**
+
+1. Compare accordions with same purpose across the product.
+
+**Pass:** consistently uses the same text and icon.
+
+### 🔁 Hybrid
+
+#### 1.3.1 Info and Relationships · A
+
+`✅ Supports` · `◐ Shared`
+
+- The summary button is wrapped in an `<h3>` heading (the `heading` slot, overridable), and the panel takes `role="region"` named by `aria-labelledby` from the summary's `id`, so the header-to-panel relationship is programmatic.
+- axe-core `aria-valid-attr-value`, `duplicate-id-aria`, and `aria-allowed-attr` pass across the demos; whether `<h3>` is the right level in the page outline is the author's responsibility.
+
+**Manual testing steps**
+
+1. In a page with an expanded accordion, inspect the accessibility tree.
+2. Confirm the header is a heading and the expanded panel is a region named by that header.
+
+**Pass:** the header is exposed as a heading and the panel as a region named by it.
+
+#### 1.4.3 Contrast (Minimum) · AA
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- The summary label (`text.primary` or `text.secondary`) and the default panel content (`Typography`) sit on `paper` above 4.5:1; custom content colors and action-button themes are the author's.
+- axe-core `color-contrast` passes where it can resolve the background and returns incomplete on some demos, where axe cannot read the summary background behind the divider `::before` pseudo-element; no demo records a failure.
+
+**Manual testing steps**
+
+1. With a contrast checker, measure the summary label and the expanded panel text against their backgrounds.
+2. Check any custom theme colors the product uses.
+
+**Pass:** at least 4.5:1 for the summary label and panel text. Disabled summaries are exempt.
+
+#### 2.4.6 Headings and Labels · AA
+
+`✅ Supports` · `◐ Shared`
+
+- Each accordion provides an `<h3>` heading whose text is the summary label; axe-core `button-name` confirms that label is present.
+- Whether the heading describes its section is an authoring concern.
+
+**Manual testing steps**
+
+1. Read each accordion heading out of context and ask whether it names its section.
+
+**Pass:** every heading describes its section.
+
+#### 1.4.12 Text Spacing · AA
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- Header and panel heights come from padding, not fixed heights, so the WCAG text-spacing values grow the accordion without clipping.
+- axe-core `avoid-inline-spacing` passes, and a visual-regression screenshot guards the layout.
+
+**Manual testing steps**
+
+1. On an accordion with a long summary label and multi-paragraph panel content, apply the four WCAG text-spacing values in the DevTools console: `document.head.insertAdjacentHTML('beforeend','<style>*{line-height:1.5!important;letter-spacing:.12em!important;word-spacing:.16em!important}p{margin-bottom:2em!important}</style>')`.
+2. Look for clipped or overlapping text.
+
+**Pass:** all header and panel text stays visible.
+
+#### 4.1.2 Name, Role, Value · A
+
+`✅ Supports` · `◐ Shared`
+
+- The summary's `aria-expanded` (set by the component) exposes the required open or closed state; the panel takes `role="region"` named by `aria-labelledby`, and `aria-controls` links the header to it.
+- The region name depends on the author setting `id` and `aria-controls` on the summary, as every demo does; omitting them leaves the region unnamed. axe-core `aria-valid-attr-value` and `duplicate-id-aria` pass.
+
+**Manual testing steps**
+
+1. With a screen reader running, move to an accordion header and expand it.
+2. Confirm the collapsed or expanded state is announced, and the expanded panel is reached as a named region.
+
+**Pass:** state, role, and the header-to-region name are all exposed.
+
+### ⚙️ Automated
+
+#### 2.1.1 Keyboard · A
+
+`✅ Supports` · `● Component`
+
+- The accordion expands and collapses through the summary's native activation (<kbd>Enter</kbd> and <kbd>Space</kbd>); the WAI-ARIA accordion pattern requires only that plus <kbd>Tab</kbd>, and does not define arrow-key navigation between headers.
+- Confirmed by interaction tests in [`../ButtonBase/ButtonBase.test.js`](../ButtonBase/ButtonBase.test.js) and an `onChange`-on-click test in [`Accordion.test.js`](./Accordion.test.js).
+
+#### 2.1.2 No Keyboard Trap · A
+
+`✅ Supports` · `● Component`
+
+- Each header is a single focusable stop and the collapsed panel is removed from the tab order, so <kbd>Tab</kbd> moves through the cluster and out without a trap.
+- Confirmed by a unit test in [`../AccordionSummary/AccordionSummary.test.js`](../AccordionSummary/AccordionSummary.test.js) (<kbd>Tab</kbd> enters and leaves the header freely).
+
+#### 2.4.3 Focus Order · A
+
+`✅ Supports` · `◐ Shared`
+
+- The collapsed panel is set to `visibility: hidden` by `Collapse`, so its content and any AccordionActions buttons leave the tab order; an expanded panel sits in DOM order right after its header.
+- Confirmed by unit tests in [`./Accordion.test.js`](./Accordion.test.js) (a collapsed panel gets the `Collapse` hidden state) and [`../AccordionSummary/AccordionSummary.test.js`](../AccordionSummary/AccordionSummary.test.js) (the header is a single tab stop; a disabled header leaves the order).
+
+#### 2.5.2 Pointer Cancellation · A
+
+`✅ Supports` · `● Component`
+
+- The accordion toggles on `click`, fired on pointer-up; `mousedown` alone does not toggle.
+- Confirmed by a unit test in [`../AccordionSummary/AccordionSummary.test.js`](../AccordionSummary/AccordionSummary.test.js) (releasing off the target does not toggle; a full click does).
+
+#### 3.2.1 On Focus · A
+
+`✅ Supports` · `● Component`
+
+- Focusing a header applies the focus-visible tint only; it triggers no expand, navigation, or focus move, so focus alone changes no context.
+- Confirmed by a unit test in [`../AccordionSummary/AccordionSummary.test.js`](../AccordionSummary/AccordionSummary.test.js) (focusing the header does not toggle it).
+
+#### 3.2.2 On Input · A
+
+`✅ Supports` · `◐ Shared`
+
+- Expanding or collapsing a panel changes content within the same page, which is not a change of context; coupling activation to navigation would be an author decision.
+- Confirmed by a unit test in [`../AccordionSummary/AccordionSummary.test.js`](../AccordionSummary/AccordionSummary.test.js) (the panel toggles only on explicit activation, never on its own).
+
+## Not applicable
+
+- **1.3.5 Identify Input Purpose (AA).** Collects no user data.
+- **1.4.13 Content on Hover or Focus (AA).** The panel opens on activation, not on hover or focus.
+- **2.1.4 Character Key Shortcuts (A).** Implements no shortcut bound to a letter, punctuation, number, or symbol key; <kbd>Enter</kbd> and <kbd>Space</kbd> are standard activation, not character shortcuts.
+- **2.4.4 Link Purpose (In Context) (A).** The header is a button, not a link.
+- **2.5.7 Dragging Movements (AA, new in 2.2).** No drag interactions.
+- **3.1.1 Language of Page (A), 3.1.2 Language of Parts (AA).** Authoring concern.
+- **3.2.3 Consistent Navigation (AA).** Inapplicable in isolation.
+- **3.2.6 Consistent Help (A, new in 2.2).** Provides no help mechanism.
+- **3.3.7 Redundant Entry (A, new in 2.2).** Re-enters no data.
+- **3.3.8 Accessible Authentication (Minimum) (AA, new in 2.2).** No authentication step.
+- **4.1.3 Status Messages (AA).** Adds no status region; the state is carried by `aria-expanded` on the focused header.
+- **Time-based media (1.2.1 to 1.2.5).** No audio or video.
+- **Audio Control (1.4.2).** Emits no audio.
+- **Orientation (1.3.4).** Sets no orientation lock; a layout concern.
+- **Bypass Blocks (2.4.1), Page Titled (2.4.2), Multiple Ways (2.4.5).** Page or site structure concerns.
+- **Timing Adjustable (2.2.1), Pause, Stop, Hide (2.2.2).** Sets no time limit; the expand transition is user-triggered.
+- **Three Flashes or Below Threshold (2.3.1).** Nothing flashes.
+- **Pointer Gestures (2.5.1), Motion Actuation (2.5.4).** Activates on a simple click; reads no device motion.
+- **Error Identification (3.3.1), Labels or Instructions (3.3.2), Error Suggestion (3.3.3), Error Prevention (3.3.4).** The accordion collects and validates no input; these belong to the form or process.
+
+## Inherited from AccordionSummary
+
+These item-level criteria are rated on the header button. See [AccordionSummary](../AccordionSummary/accessibility.md).
+
+- [1.1.1 Non-text Content](../AccordionSummary/accessibility.md)
+- [1.4.11 Non-text Contrast](../AccordionSummary/accessibility.md)
+- [2.4.7 Focus Visible](../AccordionSummary/accessibility.md)
+- [2.5.3 Label in Name](../AccordionSummary/accessibility.md)
+- [2.5.8 Target Size (Minimum)](../AccordionSummary/accessibility.md)
+
+## Level AAA
+
+- **2.3.3 Animation from Interactions.** The `Collapse` transition and chevron rotation honor `prefers-reduced-motion` only when the theme sets `motion.reducedMotion` to `system` or `always`; the default is `never`. `🚩`
+- **2.4.13 Focus Appearance.** The header focus tint is unlikely to meet the area and contrast thresholds. `🚩`
+- **2.5.5 Target Size (Enhanced), 44px.** The header (48px tall) meets it; nested action buttons may not. `🚩`
+- **1.4.6 Contrast (Enhanced), 7:1.** `text.primary` clears 7:1, but `text.secondary` (about 5.7:1) does not. `🚩`
+- Also touched, in the same shape as their A and AA siblings: **1.3.6 Identify Purpose, 1.4.9 Images of Text (No Exception), 2.1.3 Keyboard (No Exception), 2.4.12 Focus Not Obscured (Enhanced)**.
+
+## Scope and test environment
+
+- **Standard.** WCAG 2.2, Level A and AA.
+- **Component version.** `@mui/material` 9.1.2.
+- **Scope.** The Accordion cluster rendered through its documented API: the root `<Accordion>`, plus the passive `AccordionDetails` (the panel's padding container) and `AccordionActions` (the optional action bar), both `<div>`s with no role or ARIA of their own. The interactive header `AccordionSummary` has its own [report](../AccordionSummary/accessibility.md) and is inherited here; author-supplied panel content and action buttons are the author's responsibility.
+- **Automated.** axe-core via Playwright test harness (results in [`accordion.a11y.json`](../../../../docs/data/material/components/accordion/accordion.a11y.json)), plus interaction tests in `Accordion.test.js`, `AccordionSummary.test.js`, and `ButtonBase.test.js`.
+- **Assistive-technology review.** Not yet performed. Flagged criteria are assessed from source pending a review with NVDA, JAWS, and VoiceOver.

--- a/packages/mui-material/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/mui-material/src/AccordionSummary/AccordionSummary.test.js
@@ -114,22 +114,6 @@ describe('<AccordionSummary />', () => {
     expect(handleChange.callCount).to.equal(1);
   });
 
-  // JSDOM doesn't support :focus-visible
-  it.skipIf(isJsdom())('calls onFocusVisible if focused visibly', function test() {
-    const handleFocusVisible = spy();
-    render(<AccordionSummary onFocusVisible={handleFocusVisible} />);
-    // simulate pointer device
-    fireEvent.mouseDown(document.body);
-
-    // this doesn't actually apply focus like in the browser. we need to move focus manually
-    fireEvent.keyDown(document.body, { key: 'Tab' });
-    act(() => {
-      screen.getByRole('button').focus();
-    });
-
-    expect(handleFocusVisible.callCount).to.equal(1);
-  });
-
   describe('prop: nativeButton', () => {
     it('forwards nativeButton={false} through useSlot to ButtonBase', () => {
       const CustomSpan = React.forwardRef((props, ref) => <span ref={ref} {...props} />);
@@ -150,6 +134,146 @@ describe('<AccordionSummary />', () => {
       // would warn about a non-button host with nativeButton omitted.
       expect(errorSpy.mock.calls.length).to.equal(0);
       errorSpy.mockRestore();
+    });
+  });
+
+  describe('WCAG 2.2 conformance', () => {
+    it('2.1.2 No Keyboard Trap: keyboard focus can enter and leave the summary', async () => {
+      const { user } = render(
+        <React.Fragment>
+          <button type="button">Before</button>
+          <Accordion>
+            <AccordionSummary>Summary</AccordionSummary>
+          </Accordion>
+          <button type="button">After</button>
+        </React.Fragment>,
+      );
+
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'Before' })).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'Summary' })).toHaveFocus();
+
+      // Tab moves focus back out of the summary — it is never captured.
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+
+      // Shift+Tab moves back onto it.
+      await user.tab({ shift: true });
+      expect(screen.getByRole('button', { name: 'Summary' })).toHaveFocus();
+    });
+
+    describe('2.4.3 Focus Order', () => {
+      it('is a single tab stop in natural DOM order with no positive tabIndex', async () => {
+        const { user } = render(
+          <React.Fragment>
+            <button type="button">Before</button>
+            <Accordion>
+              <AccordionSummary>Summary</AccordionSummary>
+            </Accordion>
+            <button type="button">After</button>
+          </React.Fragment>,
+        );
+        expect(screen.getByRole('button', { name: 'Summary' })).to.have.property('tabIndex', 0);
+
+        await user.tab();
+        expect(screen.getByRole('button', { name: 'Before' })).toHaveFocus();
+        await user.tab();
+        expect(screen.getByRole('button', { name: 'Summary' })).toHaveFocus();
+        await user.tab();
+        expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+      });
+
+      it('removes a disabled summary from the tab order', async () => {
+        const { user } = render(
+          <React.Fragment>
+            <Accordion disabled>
+              <AccordionSummary>Disabled</AccordionSummary>
+            </Accordion>
+            <button type="button">After</button>
+          </React.Fragment>,
+        );
+
+        // Tab skips the disabled summary and lands on the next control.
+        await user.tab();
+        expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+      });
+    });
+
+    // JSDOM doesn't support :focus-visible
+    it.skipIf(isJsdom())(
+      '2.4.7 Focus Visible: applies the focus-visible state on keyboard focus',
+      function test() {
+        const handleFocusVisible = spy();
+        render(<AccordionSummary onFocusVisible={handleFocusVisible} />);
+        // simulate pointer device
+        fireEvent.mouseDown(document.body);
+
+        // this doesn't actually apply focus like in the browser. we need to move focus manually
+        fireEvent.keyDown(document.body, { key: 'Tab' });
+        act(() => {
+          screen.getByRole('button').focus();
+        });
+
+        expect(handleFocusVisible.callCount).to.equal(1);
+      },
+    );
+
+    it('2.5.2 Pointer Cancellation: activates on click, but not when released off the target', async () => {
+      const handleChange = spy();
+      const { user } = render(
+        <React.Fragment>
+          <Accordion onChange={handleChange} expanded={false}>
+            <AccordionSummary>Summary</AccordionSummary>
+          </Accordion>
+          <div data-testid="outside" />
+        </React.Fragment>,
+      );
+      const button = screen.getByRole('button');
+
+      // Press on the summary, move away, then release: nothing runs on the down
+      // event, and releasing off the target cancels the activation.
+      await user.pointer([
+        { keys: '[MouseLeft>]', target: button },
+        { target: screen.getByTestId('outside') },
+        { keys: '[/MouseLeft]' },
+      ]);
+      expect(handleChange.callCount).to.equal(0);
+
+      // A full click — press and release over the target — toggles the accordion.
+      await user.click(button);
+      expect(handleChange.callCount).to.equal(1);
+    });
+
+    it('3.2.1 On Focus: moving keyboard focus to the summary does not toggle it', async () => {
+      const handleChange = spy();
+      const { user } = render(
+        <Accordion onChange={handleChange} expanded={false}>
+          <AccordionSummary>Summary</AccordionSummary>
+        </Accordion>,
+      );
+
+      await user.tab();
+      expect(screen.getByRole('button')).toHaveFocus();
+      // Focus alone changes no context.
+      expect(handleChange.callCount).to.equal(0);
+    });
+
+    it('3.2.2 On Input: the panel toggles only from explicit activation, never on its own', async () => {
+      const handleChange = spy();
+      const { user } = render(
+        <Accordion onChange={handleChange} expanded={false}>
+          <AccordionSummary>Summary</AccordionSummary>
+        </Accordion>,
+      );
+
+      // Rendering the summary and its aria-expanded state toggles nothing on its own.
+      expect(handleChange.callCount).to.equal(0);
+
+      // The panel toggles only when the user explicitly activates the summary.
+      await user.click(screen.getByRole('button'));
+      expect(handleChange.callCount).to.equal(1);
     });
   });
 });

--- a/packages/mui-material/src/AccordionSummary/accessibility.md
+++ b/packages/mui-material/src/AccordionSummary/accessibility.md
@@ -1,0 +1,345 @@
+# AccordionSummary accessibility conformance
+
+Rated against WCAG 2.2 Level A and AA. See the [reports legend](../accessibility.md).
+
+This is the item-level report for the accordion header button. The root `<Accordion>` inherits these criteria; see [Accordion](../Accordion/accessibility.md).
+
+| Result                | Count |
+| :-------------------- | :---- |
+| ✅ Supports           | 23    |
+| ⚠️ Partially Supports | 1     |
+| ❌ Does Not Support   | 0     |
+| ➖ Not Applicable     | 31    |
+| 🚩 Flagged            | 8/24  |
+
+## Known gaps
+
+- ⚠️ **1.4.11 Non-text Contrast.** The keyboard-focus indicator is only a background tint (`action.focus`), about 1.3:1 against the adjacent `paper` surface, below the 3:1 minimum.
+
+## Success criteria
+
+### 🔍 Manual
+
+#### 1.3.2 Meaningful Sequence · A
+
+`✅ Supports` · `○ Author`
+
+- The summary is one control whose slots render in DOM order: the content `span`, then the `expandIcon` wrapper; the decorative icon is `aria-hidden`, leaving the label as the exposed content.
+- Order carries meaning only across the surrounding controls, which the page layout sets.
+
+**Manual testing steps**
+
+1. In an accordion, read the summary content from left to right.
+2. Compare it to the order announced by a screen reader.
+
+**Pass:** the announced order matches the visual order.
+
+#### 1.3.3 Sensory Characteristics · A
+
+`✅ Supports` · `○ Author`
+
+- The summary is identified by its text label, not only by the position or shape of the `expandIcon`.
+- Surrounding instructions must not rely on the icon's direction alone (for example, "open the section with the down arrow").
+
+**Manual testing steps**
+
+1. Find any product copy that tells users to expand a section.
+2. Check that it names the section by its heading, not only by the chevron's shape or position.
+
+**Pass:** no instruction depends on the icon alone.
+
+#### 1.4.1 Use of Color · A
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- The expanded state is conveyed by `aria-expanded` and the rotated `expandIcon`, not by color, and the label carries the meaning.
+
+**Manual testing steps**
+
+1. In a UI with accordions, turn on a grayscale view (Chrome DevTools: Rendering, Emulate vision deficiencies, Achromatopsia).
+2. Expand and collapse a panel.
+
+**Pass:** the open and closed states stay distinguishable without color.
+
+#### 1.4.4 Resize Text · AA
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- The label text is rem-based (`Typography`), and the 48px `min-height` is a floor that content grows past, not a fixed size, so the summary scales with browser zoom rather than clipping.
+- A fixed-pixel container in the surrounding layout could clip at 200%.
+
+**Manual testing steps**
+
+1. In a UI with accordions, set browser zoom to 200% (<kbd>Ctrl</kbd> or <kbd>Cmd</kbd> and <kbd>+</kbd>).
+2. Confirm the summary label is fully visible and the control still toggles.
+
+**Pass:** nothing is clipped at 200%.
+
+#### 1.4.5 Images of Text · AA
+
+`✅ Supports` · `○ Author`
+
+- The label is real text passed as children.
+
+**Manual testing steps**
+
+1. Verify that the summary label is real text.
+
+**Pass:** no summary renders its label as an image of text.
+
+#### 1.4.10 Reflow · AA
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- The summary is full width and its label wraps, so it reflows on its own; horizontal overflow at 320 CSS pixels comes from the surrounding layout.
+
+**Manual testing steps**
+
+1. In a UI with accordions, set the window (or the DevTools device toolbar) to 320 CSS pixels wide.
+2. Confirm there is no sideways scrolling and the summary text is reachable.
+
+**Pass:** content reflows with no horizontal scroll, and long labels wrap.
+
+#### 1.4.11 Non-text Contrast · AA
+
+`🚩` · `⚠️ Partially Supports` · `● Component`
+
+- The keyboard-focus indicator is a background change to `action.focus` (`rgba(0, 0, 0, 0.12)`), about 1.3:1 against the adjacent `paper` surface, below the 3:1 minimum; `ButtonBase` sets `outline: 0`, so no outline backs it up.
+- The `expandIcon` uses `action.active` (`rgba(0, 0, 0, 0.54)`), about 4.6:1 on `paper`, which clears 3:1.
+
+**Manual testing steps**
+
+1. Press <kbd>Tab</kbd> to focus an accordion summary.
+2. With a contrast checker, measure the focused background against the resting background, and the chevron against the surface behind it.
+
+**Pass:** the focus indicator and the icon are each at least 3:1. The focus indicator is the known shortfall.
+
+#### 2.4.11 Focus Not Obscured (Minimum) · AA
+
+`✅ Supports` · `○ Author`
+
+- The summary never hides itself; obscuring typically comes from sticky headers or overlays in the surrounding layout.
+
+**Manual testing steps**
+
+1. In a page with a sticky header, press <kbd>Tab</kbd> to a summary near it.
+2. Scroll so the summary sits under the sticky element, then <kbd>Tab</kbd> to it again.
+
+**Pass:** at least part of the focused summary stays visible, never entirely covered.
+
+#### 2.5.3 Label in Name · A
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- The accessible name is the visible label: the children become the name, and an `SvgIcon` `expandIcon` defaults to `aria-hidden`; a custom icon node adds to the name unless the author hides it.
+- An `aria-label` that omits or reorders the visible words breaks this; compare the visible text to the computed name.
+
+**Manual testing steps**
+
+1. With a screen reader verify that the summary announces the same as the visible text
+
+**Pass:** the visible label appears in the accessible name.
+
+#### 3.2.4 Consistent Identification · AA
+
+`✅ Supports` · `○ Author`
+
+- The component produces one stable accessible name per set of props.
+
+**Manual testing steps**
+
+1. Compare accordions with same purpose across the product.
+
+**Pass:** consistently uses the same text and icon.
+
+### 🔁 Hybrid
+
+#### 1.1.1 Non-text Content · A
+
+`✅ Supports` · `◐ Shared`
+
+- The `expandIcon` (an `SvgIcon`) defaults to `aria-hidden` and `focusable="false"`, so it is decorative and the name comes from the summary children.
+- axe-core `button-name` and `aria-command-name` confirm a name is present across the demos; whether the name conveys the section's purpose needs an assistive-technology review.
+
+**Manual testing steps**
+
+1. With a screen reader running (NVDA with Chrome, or VoiceOver with Safari), <kbd>Tab</kbd> to accordion summaries that carry an `expandIcon` and confirm each announces the label, not the chevron.
+
+**Pass:** every summary's announced name matches its section, and the chevron is silent.
+
+#### 1.3.1 Info and Relationships · A
+
+`✅ Supports` · `◐ Shared`
+
+- The summary exposes its `button` role and its `aria-expanded` state programmatically; the disclosure relationship to the panel is wired by the root `<Accordion>` (see [Accordion](../Accordion/accessibility.md)).
+- axe-core `aria-allowed-attr`, `aria-valid-attr`, and `aria-valid-attr-value` pass across the demos.
+
+**Manual testing steps**
+
+1. With a screen reader running, move to an accordion summary.
+2. Confirm it announces a collapsed or expanded button.
+
+**Pass:** role and state match the visual presentation.
+
+#### 1.4.3 Contrast (Minimum) · AA
+
+`🚩` · `✅ Supports` · `● Component`
+
+- The label uses `text.primary` (about 16:1) or `text.secondary` (about 5.7:1) on `paper`, both above 4.5:1; disabled summaries drop to `0.38` opacity and are exempt.
+- axe-core `color-contrast` passes where it can resolve the background and returns incomplete on some demos, where axe cannot read the summary background behind the divider `::before` pseudo-element; no demo records a failure, so a visual check is the remaining step.
+
+**Manual testing steps**
+
+1. With a contrast checker, measure each summary label, including any secondary `text.secondary` line, against its background.
+2. Check any custom theme colors the product uses.
+
+**Pass:** at least 4.5:1 for the label text. Disabled summaries are exempt.
+
+#### 1.4.12 Text Spacing · AA
+
+`🚩` · `✅ Supports` · `◐ Shared`
+
+- The label wraps and the summary height comes from `min-height` and padding, not a fixed height, so the WCAG text-spacing values grow the control without clipping.
+- axe-core `avoid-inline-spacing` passes, and a visual-regression screenshot guards the layout.
+
+**Manual testing steps**
+
+1. On an accordion with a long summary label, apply the four WCAG text-spacing values in the DevTools console: `document.head.insertAdjacentHTML('beforeend','<style>*{line-height:1.5!important;letter-spacing:.12em!important;word-spacing:.16em!important}p{margin-bottom:2em!important}</style>')`.
+2. Look for clipped or overlapping label text.
+
+**Pass:** all label text stays visible and the summary still toggles.
+
+#### 2.4.6 Headings and Labels · AA
+
+`✅ Supports` · `◐ Shared`
+
+- The accessible name serves as the summary's label; axe-core `button-name` confirms it is present.
+- Whether the label describes the section is an authoring concern.
+
+**Manual testing steps**
+
+1. Read each summary label out of context.
+2. Ask whether it says what the section contains.
+
+**Pass:** every label describes its section, not a vague "Details".
+
+#### 2.4.7 Focus Visible · AA
+
+`🚩` · `✅ Supports` · `● Component`
+
+- Keyboard focus applies the `.Mui-focusVisible` background (`action.focus`); mouse focus is suppressed, and `ButtonBase` removes the native outline, so this tint is the only indicator.
+- Covered by a unit test in [`AccordionSummary.test.js`](./AccordionSummary.test.js) that confirms the focus-visible state fires; whether the tint is perceptible enough is the visual step (its contrast is the 1.4.11 shortfall).
+
+**Manual testing steps**
+
+1. Press <kbd>Tab</kbd> to move focus across accordion summaries.
+2. Confirm a focus indicator appears and differs from the resting style.
+3. Click a summary with the mouse and confirm the indicator does not appear.
+
+**Pass:** every keyboard-focused summary shows a visible indicator.
+
+#### 4.1.2 Name, Role, Value · A
+
+`✅ Supports` · `◐ Shared`
+
+- The native summary is a `button`; with `nativeButton={false}` and a custom `component`, `ButtonBase` applies `role="button"`. The name comes from the children and the state from `aria-expanded`.
+- axe-core `button-name`, `aria-command-name`, `aria-allowed-attr`, `aria-roles`, `nested-interactive`, and `duplicate-id-aria` pass; a unit test in [`AccordionSummary.test.js`](./AccordionSummary.test.js) confirms `aria-expanded` tracks the state. Whether the name is meaningful needs an assistive-technology review.
+
+**Manual testing steps**
+
+1. With a screen reader running, <kbd>Tab</kbd> to a native summary and a non-native (`nativeButton={false}`) summary.
+2. Confirm each announces the name, the button role, and the collapsed or expanded state.
+
+**Pass:** name, role, and state are correct for the native and non-native summaries.
+
+### ⚙️ Automated
+
+#### 2.1.1 Keyboard · A
+
+`✅ Supports` · `● Component`
+
+- The native summary activates with <kbd>Enter</kbd> and <kbd>Space</kbd>; the non-native `role="button"` gets the same handling from `ButtonBase`, and a disabled summary leaves the tab order.
+- Confirmed by interaction tests in [`../ButtonBase/ButtonBase.test.js`](../ButtonBase/ButtonBase.test.js).
+
+#### 2.1.2 No Keyboard Trap · A
+
+`✅ Supports` · `● Component`
+
+- The summary is a single focusable control that installs no focus-capturing loop; <kbd>Tab</kbd> moves in and out, and a disabled summary leaves the order.
+- Confirmed by a unit test in [`./AccordionSummary.test.js`](./AccordionSummary.test.js) (<kbd>Tab</kbd> is not intercepted, and focus moves away freely).
+
+#### 2.4.3 Focus Order · A
+
+`✅ Supports` · `◐ Shared`
+
+- The summary sits in natural DOM order with no positive `tabIndex`, so it is one correct focus stop; order across the cluster is covered in [Accordion](../Accordion/accessibility.md).
+- Confirmed by a unit test in [`./AccordionSummary.test.js`](./AccordionSummary.test.js) (default `tabIndex` is `0`; a disabled summary leaves the order).
+
+#### 2.5.2 Pointer Cancellation · A
+
+`✅ Supports` · `● Component`
+
+- Activation runs on `click`, fired on pointer-up over the target; `mousedown` alone does not toggle, so releasing off the target cancels.
+- Confirmed by a unit test in [`./AccordionSummary.test.js`](./AccordionSummary.test.js) (releasing off the target does not toggle; a full click does).
+
+#### 2.5.8 Target Size (Minimum) · AA
+
+`✅ Supports` · `● Component`
+
+- The summary is full width with a 48px `min-height` (64px when expanded), well above the 24 by 24 CSS pixel minimum. axe-core `target-size` confirms this across the demos in [`accordion.a11y.json`](../../../../docs/data/material/components/accordion/accordion.a11y.json).
+- Not covered: `sx` overrides that shrink a custom summary.
+
+#### 3.2.1 On Focus · A
+
+`✅ Supports` · `● Component`
+
+- Focusing the summary applies the focus-visible tint and runs `onFocus` callbacks only; there is no navigation or focus move, so focus alone changes no context.
+- Confirmed by a unit test in [`./AccordionSummary.test.js`](./AccordionSummary.test.js) (focusing the summary does not toggle it).
+
+#### 3.2.2 On Input · A
+
+`✅ Supports` · `◐ Shared`
+
+- Activating the summary toggles the panel within the same page, which is not a change of context.
+- Whether an author's `onClick` couples activation to navigation is an author decision.
+- Confirmed by a unit test in [`./AccordionSummary.test.js`](./AccordionSummary.test.js) (the panel toggles only on explicit activation, never on its own).
+
+## Not applicable
+
+- **1.3.5 Identify Input Purpose (AA).** Collects no user data.
+- **1.4.13 Content on Hover or Focus (AA).** The panel opens on activation, not on hover or focus.
+- **2.1.4 Character Key Shortcuts (A).** Implements no shortcut bound to a letter, punctuation, number, or symbol key; <kbd>Enter</kbd> and <kbd>Space</kbd> are standard activation, not character shortcuts.
+- **2.4.4 Link Purpose (In Context) (A).** The summary is a button, not a link.
+- **2.5.7 Dragging Movements (AA, new in 2.2).** No drag interactions.
+- **3.1.1 Language of Page (A), 3.1.2 Language of Parts (AA).** Authoring concern.
+- **3.2.3 Consistent Navigation (AA).** Inapplicable in isolation.
+- **3.2.6 Consistent Help (A, new in 2.2).** Provides no help mechanism.
+- **3.3.7 Redundant Entry (A, new in 2.2).** Re-enters no data.
+- **3.3.8 Accessible Authentication (Minimum) (AA, new in 2.2).** No authentication step.
+- **4.1.3 Status Messages (AA).** Adds no status region; the state is carried by `aria-expanded` on the focused summary.
+- **Time-based media (1.2.1 to 1.2.5).** No audio or video.
+- **Audio Control (1.4.2).** Emits no audio.
+- **Orientation (1.3.4).** Sets no orientation lock; a layout concern.
+- **Bypass Blocks (2.4.1), Page Titled (2.4.2), Multiple Ways (2.4.5).** Page or site structure concerns.
+- **Timing Adjustable (2.2.1), Pause, Stop, Hide (2.2.2).** Sets no time limit and nothing moves on its own.
+- **Three Flashes or Below Threshold (2.3.1).** Nothing flashes.
+- **Pointer Gestures (2.5.1), Motion Actuation (2.5.4).** Activates on a simple click; reads no device motion.
+- **Error Identification (3.3.1), Labels or Instructions (3.3.2), Error Suggestion (3.3.3), Error Prevention (3.3.4).** The summary collects and validates no input; these belong to the form or process.
+
+## Level AAA
+
+The following SC are applicable but out of scope:
+
+- **2.3.3 Animation from Interactions.** The `expandIcon` rotation honors `prefers-reduced-motion` only when the theme sets `motion.reducedMotion` to `system` or `always`; the default is `never`. `🚩`
+- **2.4.13 Focus Appearance.** The focus tint is unlikely to meet the area and contrast thresholds. `🚩`
+- **2.5.5 Target Size (Enhanced), 44px.** The summary (48px tall) meets it; nested action buttons may not. `🚩`
+- **1.4.6 Contrast (Enhanced), 7:1.** `text.primary` clears 7:1, but `text.secondary` (about 5.7:1) does not. `🚩`
+- Also touched, in the same shape as their A and AA siblings: **1.3.6 Identify Purpose, 1.4.9 Images of Text (No Exception), 2.1.3 Keyboard (No Exception), 2.4.12 Focus Not Obscured (Enhanced)**.
+
+## Scope and test environment
+
+- **Standard.** WCAG 2.2, Level A and AA.
+- **Component version.** `@mui/material` 9.1.2.
+- **Scope.** The AccordionSummary header button, rendered through its documented API inside an Accordion.
+- **Automated.** axe-core via Playwright test harness (results in [`accordion.a11y.json`](../../../../docs/data/material/components/accordion/accordion.a11y.json)), plus interaction tests in `AccordionSummary.test.js` and `ButtonBase.test.js`.
+- **Assistive-technology review.** Not yet performed. Flagged criteria are assessed from source pending a review with NVDA, JAWS, and VoiceOver.

--- a/test/regressions/a11y/axe.ts
+++ b/test/regressions/a11y/axe.ts
@@ -57,6 +57,11 @@ interface RecordA11yOptions {
   slug: string;
   demo: string;
   /**
+   * `visual` asserts only rules that need real rendered CSS. `all` asserts
+   * every axe violation/incomplete not listed in `skipAssertions`.
+   */
+  assertions?: 'visual' | 'all';
+  /**
    * Rule ids whose violations are recorded but not asserted on. The rule
    * still runs and still lands in the results JSON — only the test-failing
    * assertion is suppressed.
@@ -74,7 +79,7 @@ interface RecordA11yOptions {
 export function recordA11y(
   ctx: TestContext,
   results: AxeResults,
-  { slug, demo, skipAssertions = [] }: RecordA11yOptions,
+  { slug, demo, assertions = 'visual', skipAssertions = [] }: RecordA11yOptions,
 ): void {
   const rules: Record<string, RuleEntry> = {};
   const buckets: ReadonlyArray<[AxeResults['passes'], RuleStatus]> = [
@@ -100,22 +105,20 @@ export function recordA11y(
   (ctx.task.meta as { a11y?: A11yMeta }).a11y = meta;
 
   const skip = new Set(skipAssertions);
-  const visualViolations = results.violations.filter(
-    (v) => VISUAL_RULES.includes(v.id) && !skip.has(v.id),
-  );
-  const visualIncomplete = results.incomplete.filter(
-    (v) => VISUAL_RULES.includes(v.id) && !skip.has(v.id),
-  );
+  const shouldAssert = (ruleId: string) =>
+    !skip.has(ruleId) && (assertions === 'all' || VISUAL_RULES.includes(ruleId));
+  const assertedViolations = results.violations.filter((v) => shouldAssert(v.id));
+  const assertedIncomplete = results.incomplete.filter((v) => shouldAssert(v.id));
 
   const failures: string[] = [];
-  if (visualViolations.length > 0) {
+  if (assertedViolations.length > 0) {
     failures.push(
-      `${visualViolations.length} axe violation(s):\n\n${formatResults(visualViolations)}`,
+      `${assertedViolations.length} axe violation(s):\n\n${formatResults(assertedViolations)}`,
     );
   }
-  if (visualIncomplete.length > 0) {
+  if (assertedIncomplete.length > 0) {
     failures.push(
-      `${visualIncomplete.length} axe incomplete (needs review):\n\n${formatResults(visualIncomplete)}`,
+      `${assertedIncomplete.length} axe incomplete (needs review):\n\n${formatResults(assertedIncomplete)}`,
     );
   }
   if (failures.length > 0) {

--- a/test/regressions/demoMeta.test.ts
+++ b/test/regressions/demoMeta.test.ts
@@ -74,6 +74,35 @@ describe('getConfig', () => {
   });
 });
 
+describe('getConfig (accordion a11y)', () => {
+  it('enrols the accordion demos and fixtures for all-rule assertions', () => {
+    expect(
+      getConfig(A11Y_RULES, 'docs/data/material/components/accordion/AccordionUsage'),
+    ).to.deep.include({ enabled: true, assertions: 'all' });
+    expect(
+      getConfig(A11Y_RULES, 'docs/data/material/components/accordion/AccordionA11yNonNative'),
+    ).to.deep.include({ enabled: true, assertions: 'all' });
+  });
+
+  it('records but does not assert color-contrast on the accordion cluster', () => {
+    // The divider `::before` makes axe unable to resolve the summary background.
+    expect(
+      getConfig(A11Y_RULES, 'docs/data/material/components/accordion/CustomizedAccordions'),
+    ).to.deep.include({
+      enabled: true,
+      assertions: 'all',
+      skipAssertions: ['color-contrast'],
+    });
+  });
+
+  it('returns undefined for an accordion demo outside the brace-glob enrolment', () => {
+    // The accordion enrolment lists specific demos; it is not slug-wide.
+    expect(
+      getConfig(A11Y_RULES, 'docs/data/material/components/accordion/SomeUnenrolledDemo'),
+    ).to.equal(undefined);
+  });
+});
+
 describe('rule data sanity', () => {
   it('rule arrays are non-empty (catches accidental import regression)', () => {
     expect(SCREENSHOT_RULES.length).to.be.greaterThan(0);

--- a/test/regressions/demoMeta.ts
+++ b/test/regressions/demoMeta.ts
@@ -37,6 +37,11 @@ export interface A11yRule {
   /** Minimatch glob against `docs/data/material/components/{slug}/{Demo}`. */
   test: string;
   enabled?: boolean;
+  /**
+   * `visual` asserts rules that depend on rendered CSS. `all` asserts every
+   * axe violation/incomplete that is not listed in `skipAssertions`.
+   */
+  assertions?: 'visual' | 'all';
   /** Axe rule IDs recorded into results JSON but not asserted on. */
   skipAssertions?: string[];
 }
@@ -143,6 +148,22 @@ export const SCREENSHOT_RULES: ScreenshotRule[] = [
     viewportWidth: 1440,
     waitForSelector: '.MuiDataGrid-row:not(.MuiDataGrid-rowSkeleton) .MuiDataGrid-cell',
   },
+  { test: 'docs/data/material/components/accordion/AccordionA11y*', enabled: false }, // A11y-only coverage fixtures
+  { test: 'docs/data/material/components/accordion/AccordionA11yTextSpacing', enabled: true }, // Visual regression for text spacing (1.4.12); adds no unique axe coverage
+];
+
+// Accordion docs demos + a11y fixtures enrolled for axe assertions (the cluster:
+// root Accordion + AccordionSummary header + AccordionDetails/Actions).
+const ACCORDION_A11Y_DEMOS = [
+  'AccordionUsage',
+  'AccordionExpandDefault',
+  'AccordionExpandIcon',
+  'ControlledAccordions',
+  'CustomizedAccordions',
+  'DisabledAccordion',
+  'AccordionTransition',
+  'AccordionA11yNonNative',
+  'AccordionA11yTextSpacing',
 ];
 
 /**
@@ -154,6 +175,16 @@ export const SCREENSHOT_RULES: ScreenshotRule[] = [
  */
 export const A11Y_RULES: A11yRule[] = [
   { test: 'docs/data/material/components/buttons/{BasicButtons,ColorButtons}', enabled: true },
+  {
+    // `color-contrast` is recorded but not asserted: the Accordion root's
+    // divider `::before` pseudo-element blocks axe's background resolution for
+    // the summary label, so the rule returns `incomplete` on some demos.
+    // No demo records a contrast failure; the label clears 4.5:1 on `paper`.
+    test: `docs/data/material/components/accordion/{${ACCORDION_A11Y_DEMOS.join(',')}}`,
+    enabled: true,
+    assertions: 'all',
+    skipAssertions: ['color-contrast'],
+  },
 ];
 
 export interface ParsedRoute {

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -219,6 +219,7 @@ async function main() {
               recordA11y({ task }, results, {
                 slug: parsed.slug,
                 demo: parsed.demo,
+                assertions: a11yRule.assertions,
                 skipAssertions: a11yRule.skipAssertions,
               });
             }


### PR DESCRIPTION
Accordion
| Result                             | Count |
| :--------------------------------- | :---- |
| ✅ Supports                        | 19    |
| ⚠️ Partially Supports              | 0     |
| ❌ Does Not Support                | 0     |
| ➖ Not Applicable                  | 31    |
| ↗ Inherited (see AccordionSummary) | 5     |

AccordionSummary
| Result                | Count |
| :-------------------- | :---- |
| ✅ Supports           | 23    |
| ⚠️ Partially Supports | 1     |
| ❌ Does Not Support   | 0     |
| ➖ Not Applicable     | 31    |

Doc:
- [Accordion](https://github.com/mj12albert/material-ui/blob/wcag-accordion/packages/mui-material/src/Accordion/accessibility.md)
- [AccordionSummary](https://github.com/mj12albert/material-ui/blob/wcag-accordion/packages/mui-material/src/AccordionSummary/accessibility.md)

AccordionDetails/AccordionActions are dumb content containers that doesn't warrant their own reviews

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
