### PR TITLE
[tablepagination] Add focus style to default InputBase used in Select

### DIFF
--- a/packages/mui-material/src/NativeSelect/NativeSelectInput.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelectInput.js
@@ -36,6 +36,7 @@ export const StyledSelectSelect = styled('select', {
   borderRadius: 0,
   cursor: 'pointer',
   '&:focus': {
+    backgroundColor: theme.alpha((theme.vars || theme).palette.text.primary, 0.05),
     // Reset Chrome style
     borderRadius: 0,
   },

--- a/packages/mui-material/src/NativeSelect/NativeSelectInput.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelectInput.js
@@ -36,7 +36,7 @@ export const StyledSelectSelect = styled('select', {
   borderRadius: 0,
   cursor: 'pointer',
   '&:focus': {
-    backgroundColor: theme.alpha((theme.vars || theme).palette.text.primary, 0.05),
+    backgroundColor: (theme.vars || theme).palette.action.focus,
     // Reset Chrome style
     borderRadius: 0,
   },

--- a/packages/mui-material/src/NativeSelect/NativeSelectInput.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelectInput.js
@@ -36,7 +36,6 @@ export const StyledSelectSelect = styled('select', {
   borderRadius: 0,
   cursor: 'pointer',
   '&:focus': {
-    backgroundColor: (theme.vars || theme).palette.action.focus,
     // Reset Chrome style
     borderRadius: 0,
   },

--- a/packages/mui-material/src/TablePagination/TablePagination.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.js
@@ -101,11 +101,13 @@ const TablePaginationSelect = styled(Select, {
   },
 });
 
-const TablePaginationInputBase = styled(InputBase)(({ theme }) => ({
-  [`& .${tablePaginationClasses.select}:focus`]: {
-    backgroundColor: (theme.vars || theme).palette.action.focus,
-  },
-}));
+const TablePaginationInputBase = styled(InputBase)(
+  memoTheme(({ theme }) => ({
+    [`& .${tablePaginationClasses.select}:focus`]: {
+      backgroundColor: (theme.vars || theme).palette.action.focus,
+    },
+  })),
+);
 
 const TablePaginationMenuItem = styled(MenuItem, {
   name: 'MuiTablePagination',

--- a/packages/mui-material/src/TablePagination/TablePagination.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.js
@@ -101,6 +101,12 @@ const TablePaginationSelect = styled(Select, {
   },
 });
 
+const TablePaginationInputBase = styled(InputBase)(({ theme }) => ({
+  [`& .${tablePaginationClasses.select}:focus`]: {
+    backgroundColor: (theme.vars || theme).palette.action.focus,
+  },
+}));
+
 const TablePaginationMenuItem = styled(MenuItem, {
   name: 'MuiTablePagination',
   slot: 'MenuItem',
@@ -266,7 +272,7 @@ const TablePagination = React.forwardRef(function TablePagination(inProps, ref) 
         {rowsPerPageOptions.length > 1 && (
           <SelectSlot
             variant="standard"
-            {...(!selectProps.variant && { input: <InputBase /> })}
+            {...(!selectProps.variant && { input: <TablePaginationInputBase /> })}
             value={rowsPerPage}
             onChange={onRowsPerPageChange}
             id={selectId}

--- a/packages/mui-material/src/TablePagination/TablePagination.test.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
-import { fireEvent, createRenderer, screen } from '@mui/internal-test-utils';
+import { fireEvent, createRenderer, isJsdom, screen } from '@mui/internal-test-utils';
 import TableFooter from '@mui/material/TableFooter';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
@@ -10,6 +10,7 @@ import TablePagination, { tablePaginationClasses as classes } from '@mui/materia
 import { inputClasses } from '@mui/material/Input';
 import { outlinedInputClasses } from '@mui/material/OutlinedInput';
 import { filledInputClasses } from '@mui/material/FilledInput';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import IconButton, { iconButtonClasses } from '@mui/material/IconButton';
 import { svgIconClasses } from '@mui/material/SvgIcon';
 import { createSvgIcon } from '@mui/material/utils';
@@ -709,6 +710,47 @@ describe('<TablePagination />', () => {
         const combobox = screen.getByRole('combobox');
         expect(combobox.parentElement).to.have.class(inputClasses.disabled);
       });
+
+      it.skipIf(isJsdom())(
+        'should apply a focus background only to the default InputBase-backed select',
+        async () => {
+          const theme = createTheme({
+            palette: {
+              action: {
+                focus: 'rgb(1, 2, 3)',
+              },
+            },
+          });
+
+          const { user } = render(
+            <ThemeProvider theme={theme}>
+              <TablePagination
+                count={1}
+                page={0}
+                onPageChange={noop}
+                onRowsPerPageChange={noop}
+                rowsPerPage={10}
+              />
+              <TablePagination
+                count={1}
+                page={0}
+                onPageChange={noop}
+                onRowsPerPageChange={noop}
+                rowsPerPage={10}
+                slotProps={{ select: { variant: 'outlined' } }}
+              />
+            </ThemeProvider>,
+          );
+
+          const [defaultSelect, outlinedSelect] = screen.getAllByRole('combobox');
+
+          await user.tab();
+          expect(defaultSelect).toHaveComputedStyle({ backgroundColor: 'rgb(1, 2, 3)' });
+
+          await user.tab();
+          expect(outlinedSelect).not.toHaveComputedStyle({ backgroundColor: 'rgb(1, 2, 3)' });
+        },
+      );
     });
   });
 

--- a/packages/mui-material/src/TablePagination/TablePagination.test.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.test.js
@@ -724,21 +724,27 @@ describe('<TablePagination />', () => {
 
           const { user } = render(
             <ThemeProvider theme={theme}>
-              <TablePagination
-                count={1}
-                page={0}
-                onPageChange={noop}
-                onRowsPerPageChange={noop}
-                rowsPerPage={10}
-              />
-              <TablePagination
-                count={1}
-                page={0}
-                onPageChange={noop}
-                onRowsPerPageChange={noop}
-                rowsPerPage={10}
-                slotProps={{ select: { variant: 'outlined' } }}
-              />
+              <table>
+                <TableFooter>
+                  <TableRow>
+                    <TablePagination
+                      count={1}
+                      page={0}
+                      onPageChange={noop}
+                      onRowsPerPageChange={noop}
+                      rowsPerPage={10}
+                    />
+                    <TablePagination
+                      count={1}
+                      page={0}
+                      onPageChange={noop}
+                      onRowsPerPageChange={noop}
+                      rowsPerPage={10}
+                      slotProps={{ select: { variant: 'outlined' } }}
+                    />
+                  </TableRow>
+                </TableFooter>
+              </table>
             </ThemeProvider>,
           );
 

--- a/packages/mui-material/src/TablePagination/TablePagination.test.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.test.js
@@ -754,6 +754,7 @@ describe('<TablePagination />', () => {
           expect(defaultSelect).toHaveComputedStyle({ backgroundColor: 'rgb(1, 2, 3)' });
 
           await user.tab();
+          expect(outlinedSelect).toHaveFocus();
           expect(outlinedSelect).not.toHaveComputedStyle({ backgroundColor: 'rgb(1, 2, 3)' });
         },
       );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The control is focusable, so the focus style should be clearly visible. Since it's used in DataTable / TablePagination, it's high impact. Not changing anything related to InputBase or Select, since their focus style is expected.

|Before|After|
|--|--|
|<img width="711" height="111" alt="Screenshot 2026-07-28 at 11 23 24" src="https://github.com/user-attachments/assets/62979c4e-1f1f-4ea4-a0fb-80b0245bb8ab" />|<img width="719" height="115" alt="Screenshot 2026-07-28 at 11 23 11" src="https://github.com/user-attachments/assets/c646f7a8-b74e-4360-95e9-75e02ae82f5d" />|