### PR TITLE
[pagination] Manage focus whenever first / last / next / previous buttons become disabled

### DIFF
--- a/docs/data/material/components/pagination/UsePagination.js
+++ b/docs/data/material/components/pagination/UsePagination.js
@@ -1,5 +1,8 @@
+import * as React from 'react';
 import usePagination from '@mui/material/usePagination';
 import { styled } from '@mui/material/styles';
+
+const count = 10;
 
 const List = styled('ul')({
   listStyle: 'none',
@@ -9,33 +12,68 @@ const List = styled('ul')({
 });
 
 export default function UsePagination() {
+  const firstPageRef = React.useRef(null);
+  const lastPageRef = React.useRef(null);
+
   const { items } = usePagination({
-    count: 10,
+    count,
   });
 
   return (
     <nav>
       <List>
-        {items.map(({ page, type, selected, ...item }, index) => {
+        {items.map(({ page, type, selected, onClick, ...item }, index) => {
           let children = null;
 
           if (type === 'start-ellipsis' || type === 'end-ellipsis') {
             children = '…';
           } else if (type === 'page') {
+            let pageRef;
+
+            if (page === 1) {
+              pageRef = firstPageRef;
+            } else if (page === count) {
+              pageRef = lastPageRef;
+            }
+
             children = (
               <button
                 type="button"
+                ref={pageRef}
                 style={{
                   fontWeight: selected ? 'bold' : undefined,
                 }}
                 {...item}
+                onClick={onClick}
               >
                 {page}
               </button>
             );
           } else {
             children = (
-              <button type="button" {...item}>
+              <button
+                type="button"
+                {...item}
+                onClick={(event) => {
+                  let focusTarget;
+
+                  if (type === 'previous' && page === 1) {
+                    focusTarget = firstPageRef;
+                  } else if (type === 'next' && page === count) {
+                    focusTarget = lastPageRef;
+                  }
+
+                  const shouldMoveFocus =
+                    event.currentTarget.ownerDocument.activeElement ===
+                    event.currentTarget;
+
+                  onClick(event);
+
+                  if (shouldMoveFocus) {
+                    focusTarget?.current?.focus();
+                  }
+                }}
+              >
                 {type}
               </button>
             );

--- a/docs/data/material/components/pagination/UsePagination.tsx
+++ b/docs/data/material/components/pagination/UsePagination.tsx
@@ -1,5 +1,8 @@
+import * as React from 'react';
 import usePagination from '@mui/material/usePagination';
 import { styled } from '@mui/material/styles';
+
+const count = 10;
 
 const List = styled('ul')({
   listStyle: 'none',
@@ -9,33 +12,68 @@ const List = styled('ul')({
 });
 
 export default function UsePagination() {
+  const firstPageRef = React.useRef<HTMLButtonElement>(null);
+  const lastPageRef = React.useRef<HTMLButtonElement>(null);
+
   const { items } = usePagination({
-    count: 10,
+    count,
   });
 
   return (
     <nav>
       <List>
-        {items.map(({ page, type, selected, ...item }, index) => {
+        {items.map(({ page, type, selected, onClick, ...item }, index) => {
           let children = null;
 
           if (type === 'start-ellipsis' || type === 'end-ellipsis') {
             children = '…';
           } else if (type === 'page') {
+            let pageRef;
+
+            if (page === 1) {
+              pageRef = firstPageRef;
+            } else if (page === count) {
+              pageRef = lastPageRef;
+            }
+
             children = (
               <button
                 type="button"
+                ref={pageRef}
                 style={{
                   fontWeight: selected ? 'bold' : undefined,
                 }}
                 {...item}
+                onClick={onClick}
               >
                 {page}
               </button>
             );
           } else {
             children = (
-              <button type="button" {...item}>
+              <button
+                type="button"
+                {...item}
+                onClick={(event) => {
+                  let focusTarget: typeof firstPageRef | undefined;
+
+                  if (type === 'previous' && page === 1) {
+                    focusTarget = firstPageRef;
+                  } else if (type === 'next' && page === count) {
+                    focusTarget = lastPageRef;
+                  }
+
+                  const shouldMoveFocus =
+                    event.currentTarget.ownerDocument.activeElement ===
+                    event.currentTarget;
+
+                  onClick(event);
+
+                  if (shouldMoveFocus) {
+                    focusTarget?.current?.focus();
+                  }
+                }}
+              >
                 {type}
               </button>
             );

--- a/packages/mui-material/src/Pagination/Pagination.js
+++ b/packages/mui-material/src/Pagination/Pagination.js
@@ -9,6 +9,10 @@ import usePagination from '../usePagination';
 import PaginationItem from '../PaginationItem';
 import { styled } from '../zero-styled';
 import { useDefaultProps } from '../DefaultPropsProvider';
+import { useForkRef } from '../utils';
+import getActiveElement from '../utils/getActiveElement';
+import ownerDocument from '../utils/ownerDocument';
+import useEnhancedEffect from '../utils/useEnhancedEffect';
 
 const useUtilityClasses = (ownerState) => {
   const { classes, variant } = ownerState;
@@ -97,12 +101,64 @@ const Pagination = React.forwardRef(function Pagination(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
+  const paginationRef = React.useRef(null);
+  const pendingFocusRef = React.useRef(null);
+  const handleRef = useForkRef(ref, paginationRef);
+
+  const selectedPage = items.find((item) => item.selected)?.page;
+
+  const handleItemClick = React.useCallback(
+    (item, event) => {
+      pendingFocusRef.current = null;
+
+      const willBecomeDisabled =
+        ((item.type === 'first' || item.type === 'previous') && item.page === 1) ||
+        ((item.type === 'next' || item.type === 'last') && item.page === count);
+
+      if (
+        willBecomeDisabled &&
+        getActiveElement(ownerDocument(event.currentTarget)) === event.currentTarget
+      ) {
+        pendingFocusRef.current = {
+          page: item.page,
+          trigger: event.currentTarget,
+        };
+      }
+
+      item.onClick(event);
+    },
+    [count],
+  );
+
+  useEnhancedEffect(() => {
+    const pending = pendingFocusRef.current;
+
+    if (!pending || pending.page !== selectedPage) {
+      return;
+    }
+
+    const document = ownerDocument(paginationRef.current);
+    const activeElement = getActiveElement(document);
+
+    // if focus was lost to the body or to the disabled button, restore it to the selected page
+    if (
+      activeElement === document.body ||
+      activeElement === document.documentElement ||
+      activeElement === pending.trigger ||
+      activeElement == null
+    ) {
+      paginationRef.current.querySelector('[aria-current="page"]')?.focus();
+    }
+
+    pendingFocusRef.current = null;
+  }, [selectedPage]);
+
   return (
     <PaginationRoot
       aria-label="pagination navigation"
       className={clsx(classes.root, className)}
       ownerState={ownerState}
-      ref={ref}
+      ref={handleRef}
       {...other}
     >
       <PaginationUl className={classes.ul} ownerState={ownerState}>
@@ -115,6 +171,7 @@ const Pagination = React.forwardRef(function Pagination(inProps, ref) {
               shape,
               size,
               variant,
+              onClick: (event) => handleItemClick(item, event),
             })}
           </li>
         ))}

--- a/packages/mui-material/src/Pagination/Pagination.test.js
+++ b/packages/mui-material/src/Pagination/Pagination.test.js
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, screen } from '@mui/internal-test-utils';
@@ -121,5 +122,160 @@ describe('<Pagination />', () => {
     render(<Pagination count={3} showLastButton={false} />);
 
     expect(screen.queryByRole('button', { name: /go to last page/i })).to.equal(null);
+  });
+
+  it('manages focus when buttons become disabled', async () => {
+    const { user } = render(
+      <Pagination count={3} defaultPage={2} showFirstButton showLastButton />,
+    );
+
+    const goToPreviousButton = screen.getByRole('button', { name: /go to previous page/i });
+    const goToFirstButton = screen.getByRole('button', { name: /go to first page/i });
+
+    await user.click(goToPreviousButton);
+
+    expect(goToPreviousButton).to.have.attribute('disabled', '');
+    expect(goToFirstButton).to.have.attribute('disabled', '');
+    expect(screen.getByRole('button', { name: /page 1/i })).toHaveFocus();
+
+    const goToNextButton = screen.getByRole('button', { name: /go to next page/i });
+    const goToLastButton = screen.getByRole('button', { name: /go to last page/i });
+
+    await user.click(goToNextButton);
+    await user.click(goToNextButton);
+
+    expect(goToNextButton).to.have.attribute('disabled', '');
+    expect(goToLastButton).to.have.attribute('disabled', '');
+    expect(screen.getByRole('button', { name: /page 3/i })).toHaveFocus();
+
+    await user.click(goToFirstButton);
+
+    expect(goToPreviousButton).to.have.attribute('disabled', '');
+    expect(goToFirstButton).to.have.attribute('disabled', '');
+    expect(screen.getByRole('button', { name: /page 1/i })).toHaveFocus();
+
+    await user.click(goToLastButton);
+
+    expect(goToNextButton).to.have.attribute('disabled', '');
+    expect(goToLastButton).to.have.attribute('disabled', '');
+    expect(screen.getByRole('button', { name: /page 3/i })).toHaveFocus();
+  });
+
+  [
+    {
+      type: 'previous',
+      props: { count: 3, defaultPage: 2 },
+      targetPage: 1,
+    },
+    {
+      type: 'first',
+      props: { count: 3, defaultPage: 2, showFirstButton: true },
+      targetPage: 1,
+    },
+    {
+      type: 'next',
+      props: { count: 3, defaultPage: 2 },
+      targetPage: 3,
+    },
+    {
+      type: 'last',
+      props: { count: 3, defaultPage: 2, showLastButton: true },
+      targetPage: 3,
+    },
+  ].forEach(({ type, props, targetPage }) => {
+    it(`moves focus to page ${targetPage} when the ${type} button becomes disabled`, async () => {
+      const { user } = render(<Pagination {...props} />);
+
+      const navigationButton = screen.getByRole('button', {
+        name: `Go to ${type} page`,
+      });
+
+      React.act(() => {
+        navigationButton.focus();
+      });
+
+      await user.keyboard('{Enter}');
+
+      expect(navigationButton).to.have.attribute('disabled', '');
+      expect(screen.getByRole('button', { name: `page ${targetPage}` })).toHaveFocus();
+    });
+  });
+
+  it('moves focus after a controlled page update commits', async () => {
+    function TestCase() {
+      const [page, setPage] = React.useState(2);
+
+      return <Pagination count={3} page={page} onChange={(_, newPage) => setPage(newPage)} />;
+    }
+
+    const { user } = render(<TestCase />);
+
+    const previousButton = screen.getByRole('button', {
+      name: 'Go to previous page',
+    });
+
+    React.act(() => {
+      previousButton.focus();
+    });
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByRole('button', { name: 'page 1' })).toHaveFocus();
+  });
+
+  it('moves focus when the boundary page is rendered after navigation', async () => {
+    const { user } = render(
+      <Pagination count={10} defaultPage={5} boundaryCount={0} showFirstButton />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Go to page 1' })).to.equal(null);
+
+    const firstButton = screen.getByRole('button', {
+      name: 'Go to first page',
+    });
+
+    React.act(() => {
+      firstButton.focus();
+    });
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByRole('button', { name: 'page 1' })).toHaveFocus();
+  });
+
+  it('does not override focus moved by onChange', async () => {
+    const resultsRef = React.createRef();
+
+    function TestCase() {
+      const [page, setPage] = React.useState(2);
+
+      return (
+        <React.Fragment>
+          <h2 ref={resultsRef} tabIndex={-1}>
+            Results
+          </h2>
+
+          <Pagination
+            count={3}
+            page={page}
+            onChange={(_, newPage) => {
+              setPage(newPage);
+              resultsRef.current.focus();
+            }}
+          />
+        </React.Fragment>
+      );
+    }
+
+    const { user } = render(<TestCase />);
+
+    const previousButton = screen.getByRole('button', {
+      name: 'Go to previous page',
+    });
+
+    React.act(() => {
+      previousButton.focus();
+    });
+    await user.keyboard('{Enter}');
+
+    expect(resultsRef.current).toHaveFocus();
   });
 });

--- a/packages/mui-material/src/Pagination/Pagination.test.js
+++ b/packages/mui-material/src/Pagination/Pagination.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, screen } from '@mui/internal-test-utils';
+import { act, createRenderer, screen } from '@mui/internal-test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Pagination, { paginationClasses as classes } from '@mui/material/Pagination';
 import { paginationItemClasses } from '@mui/material/PaginationItem';
@@ -190,7 +190,7 @@ describe('<Pagination />', () => {
         name: `Go to ${type} page`,
       });
 
-      React.act(() => {
+      act(() => {
         navigationButton.focus();
       });
 
@@ -214,7 +214,7 @@ describe('<Pagination />', () => {
       name: 'Go to previous page',
     });
 
-    React.act(() => {
+    act(() => {
       previousButton.focus();
     });
     await user.keyboard('{Enter}');
@@ -233,7 +233,7 @@ describe('<Pagination />', () => {
       name: 'Go to first page',
     });
 
-    React.act(() => {
+    act(() => {
       firstButton.focus();
     });
     await user.keyboard('{Enter}');
@@ -271,7 +271,7 @@ describe('<Pagination />', () => {
       name: 'Go to previous page',
     });
 
-    React.act(() => {
+    act(() => {
       previousButton.focus();
     });
     await user.keyboard('{Enter}');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

`Pagination` needs to have focus managed whenever the first / next / last / previous buttons are focused, pressed, and they become disabled. Currently, the focus is lost to the `<body>` so we manage it to the active item whenever that happens.

On click event, we store the button pressed, then on the subsequent render, in effect, we check if we need to manage focus (focused element is either body or disabled button), and we focus the button that has `aria-current="page"`. 

Also update the `usePagination` docs example since that needs its focus to be managed.

Repro:
- go to pagination [example with back / next buttons](http://localhost:3000/material-ui/react-pagination/#basic-pagination)
- set active page to be equal or greater than 2
- focus back button
- hit enter until the back button becomes disabled

Expected: focus should be managed to an active element
Actual: focus is lost to the body.

Fix: focus is managed to 

the first page button (when back becomes disabled) or the last page button (when next page becomes disabled).

Before:

https://github.com/user-attachments/assets/afb6ba03-a469-4302-a273-5fa34ceaa0c3

After:

https://github.com/user-attachments/assets/c7bd9086-7c13-4f75-9f01-ed2b65f42075

