### PR TITLE
[transitions] Prevent exit transitions from getting stuck

### DIFF
--- a/packages/mui-material/src/Modal/Modal.js
+++ b/packages/mui-material/src/Modal/Modal.js
@@ -117,6 +117,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
     getBackdropProps,
     getTransitionProps,
     portalRef,
+    portalContainer,
     isTopModal,
     exited,
     hasTransition,
@@ -186,7 +187,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
   }
 
   return (
-    <Portal ref={portalRef} container={container} disablePortal={disablePortal}>
+    <Portal ref={portalRef} container={portalContainer} disablePortal={disablePortal}>
       <RootSlot {...rootProps}>
         {!hideBackdrop ? <BackdropSlot {...backdropProps} /> : null}
         <FocusTrap

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -779,6 +779,8 @@ describe('<Modal />', () => {
   });
 
   describe('prop: container', () => {
+    clock.withFakeTimers();
+
     it('should be able to change the container', () => {
       function TestCase(props) {
         const { anchorEl } = props;
@@ -795,6 +797,99 @@ describe('<Modal />', () => {
       setProps({ anchorEl: document.body });
       setProps({ anchorEl: null });
       setProps({ anchorEl: document.body });
+    });
+
+    it('should finish closing when the container changes during the exit transition', () => {
+      function TestCase(props) {
+        const firstContainerRef = React.useRef(null);
+        const secondContainerRef = React.useRef(null);
+        const getContainer = React.useCallback(
+          () =>
+            props.containerIndex === 0 ? firstContainerRef.current : secondContainerRef.current,
+          [props.containerIndex],
+        );
+
+        return (
+          <React.Fragment>
+            <div data-testid="first-container" ref={firstContainerRef} />
+            <div data-testid="second-container" ref={secondContainerRef} />
+            <Modal
+              data-testid="modal"
+              open={props.open}
+              container={getContainer}
+              closeAfterTransition
+              onTransitionExited={props.onTransitionExited}
+            >
+              <Fade
+                in={props.open}
+                timeout={100}
+                onExit={props.onExit}
+                onExiting={props.onExiting}
+                onExited={props.onExited}
+              >
+                <div>Content</div>
+              </Fade>
+            </Modal>
+          </React.Fragment>
+        );
+      }
+
+      const handleExit = spy();
+      const handleExiting = spy();
+      const handleExited = spy();
+      const handleTransitionExited = spy();
+      const { setProps } = render(
+        <TestCase
+          open
+          containerIndex={0}
+          onExit={handleExit}
+          onExiting={handleExiting}
+          onExited={handleExited}
+          onTransitionExited={handleTransitionExited}
+        />,
+      );
+
+      act(() => {
+        clock.runToLast();
+      });
+      const firstContainer = screen.getByTestId('first-container');
+      const secondContainer = screen.getByTestId('second-container');
+      expect(within(firstContainer).getByTestId('modal')).not.to.equal(null);
+
+      setProps({ open: false, containerIndex: 0 });
+      expect(handleExit.callCount).to.equal(1);
+      expect(handleExiting.callCount).to.equal(1);
+      expect(handleExited.callCount).to.equal(0);
+      expect(handleTransitionExited.callCount).to.equal(0);
+
+      act(() => {
+        clock.tick(50);
+      });
+      setProps({ open: false, containerIndex: 1 });
+
+      expect(within(firstContainer).getByTestId('modal')).not.to.equal(null);
+      expect(within(secondContainer).queryByTestId('modal')).to.equal(null);
+      expect(handleExit.callCount).to.equal(1);
+      expect(handleExiting.callCount).to.equal(1);
+      expect(handleExited.callCount).to.equal(0);
+      expect(handleTransitionExited.callCount).to.equal(0);
+
+      act(() => {
+        clock.tick(50);
+      });
+      expect(screen.queryByTestId('modal')).to.equal(null);
+      expect(handleExit.callCount).to.equal(1);
+      expect(handleExiting.callCount).to.equal(1);
+      expect(handleExited.callCount).to.equal(1);
+      expect(handleTransitionExited.callCount).to.equal(1);
+      expect(firstContainer.style).to.have.property('overflow', '');
+
+      setProps({ open: true, containerIndex: 1 });
+      act(() => {
+        clock.runToLast();
+      });
+      expect(within(firstContainer).queryByTestId('modal')).to.equal(null);
+      expect(within(secondContainer).getByTestId('modal')).not.to.equal(null);
     });
   });
 

--- a/packages/mui-material/src/Modal/useModal.ts
+++ b/packages/mui-material/src/Modal/useModal.ts
@@ -44,6 +44,7 @@ function useModal(parameters: UseModalParameters): UseModalReturnValue {
   // @ts-ignore internal logic
   const modal = React.useRef<{ modalRef: HTMLDivElement; mount: HTMLElement }>({});
   const mountNodeRef = React.useRef<HTMLElement>(null);
+  const lastMountNodeRef = React.useRef<HTMLElement>(null);
   const modalRef = React.useRef<HTMLDivElement>(null);
   const handleRef = useForkRef(modalRef, rootRef);
   const [exited, setExited] = React.useState(!open);
@@ -83,12 +84,14 @@ function useModal(parameters: UseModalParameters): UseModalReturnValue {
 
   const isTopModal = () => manager.isTopModal(getModal());
 
-  const handlePortalRef = useEventCallback((node: HTMLElement) => {
+  const handlePortalRef = useEventCallback((node: HTMLElement | null) => {
     mountNodeRef.current = node;
 
     if (!node) {
       return;
     }
+
+    lastMountNodeRef.current = node;
 
     if (open && isTopModal()) {
       handleMounted();
@@ -220,12 +223,18 @@ function useModal(parameters: UseModalParameters): UseModalReturnValue {
     };
   };
 
+  // Changing a portal's container remounts its children. Keep an exiting transition in its
+  // current container so it can finish and notify the modal that it is safe to unmount.
+  const portalContainer =
+    !open && hasTransition && !exited ? (lastMountNodeRef.current ?? container) : container;
+
   return {
     getRootProps,
     getBackdropProps,
     getTransitionProps,
     rootRef: handleRef,
     portalRef: handlePortalRef,
+    portalContainer,
     isTopModal,
     exited,
     hasTransition,

--- a/packages/mui-material/src/Modal/useModal.types.ts
+++ b/packages/mui-material/src/Modal/useModal.types.ts
@@ -113,6 +113,11 @@ export interface UseModalReturnValue {
    */
   portalRef: React.RefCallback<Element> | null;
   /**
+   * The container used by the portal. While a transition is exiting, this remains the last
+   * resolved mount node so changing containers does not remount the transition.
+   */
+  portalContainer: PortalProps['container'];
+  /**
    * If `true`, the modal is the top most one.
    */
   isTopModal: () => boolean;

--- a/packages/mui-material/src/internal/Transition.test.tsx
+++ b/packages/mui-material/src/internal/Transition.test.tsx
@@ -616,6 +616,46 @@ describe('<Transition />', () => {
       },
     );
 
+    it.skipIf(!('Activity' in React))(
+      'does not complete the superseded phase when in flips on reconnect',
+      () => {
+        const handlers = {
+          onEnter: spy(),
+          onEntering: spy(),
+          onEntered: spy(),
+          onExit: spy(),
+          onExiting: spy(),
+          onExited: spy(),
+        };
+
+        function ActivityHarness(props: { in: boolean; mode: 'hidden' | 'visible' }) {
+          return (
+            <React.Activity mode={props.mode}>
+              <TestHarness in={props.in} appear={false} timeout={100} handlers={handlers} />
+            </React.Activity>
+          );
+        }
+
+        const { setProps } = render(<ActivityHarness in mode="visible" />);
+        setProps({ in: false, mode: 'visible' });
+        expect(screen.getByTestId('target')).to.have.attribute('data-status', 'exiting');
+
+        // Effects disconnect mid-exit, then reconnect in the same commit that `in` flips back.
+        // The reconciliation effect starts entering before the lifecycle effect runs, so the
+        // lifecycle effect must not schedule completion for the superseded exit.
+        setProps({ in: false, mode: 'hidden' });
+        clock.tick(50);
+        setProps({ in: true, mode: 'visible' });
+        clock.tick(100);
+
+        expect(screen.getByTestId('target')).to.have.attribute('data-status', 'entered');
+        expect(handlers.onEnter.callCount).to.equal(1);
+        expect(handlers.onEntering.callCount).to.equal(1);
+        expect(handlers.onEntered.callCount).to.equal(1);
+        expect(handlers.onExited.callCount).to.equal(0);
+      },
+    );
+
     it('cancels entering when in flips to false mid-transition', () => {
       const handlers = {
         onEntered: spy(),

--- a/packages/mui-material/src/internal/Transition.test.tsx
+++ b/packages/mui-material/src/internal/Transition.test.tsx
@@ -571,6 +571,51 @@ describe('<Transition />', () => {
   describe('interrupted transitions', () => {
     clock.withFakeTimers();
 
+    it.skipIf(!('Activity' in React))(
+      'restarts completion when effects reconnect while exiting',
+      () => {
+        const handlers = {
+          onExit: spy(),
+          onExiting: spy(),
+          onExited: spy(),
+        };
+
+        function ActivityHarness(props: { in: boolean; mode: 'hidden' | 'visible' }) {
+          return (
+            <React.Activity mode={props.mode}>
+              <TestHarness
+                in={props.in}
+                appear={false}
+                unmountOnExit
+                timeout={100}
+                handlers={handlers}
+              />
+            </React.Activity>
+          );
+        }
+
+        const { setProps } = render(<ActivityHarness in mode="visible" />);
+        setProps({ in: false, mode: 'visible' });
+        expect(screen.getByTestId('target')).to.have.attribute('data-status', 'exiting');
+        expect(handlers.onExit.callCount).to.equal(1);
+        expect(handlers.onExiting.callCount).to.equal(1);
+
+        // Activity disconnects effects while preserving state. This cancels the pending completion
+        setProps({ in: false, mode: 'hidden' });
+        clock.tick(100);
+        expect(screen.getByTestId('target')).to.have.attribute('data-status', 'exiting');
+        expect(handlers.onExited.callCount).to.equal(0);
+
+        setProps({ in: false, mode: 'visible' });
+        expect(handlers.onExit.callCount).to.equal(1);
+        expect(handlers.onExiting.callCount).to.equal(1);
+        clock.tick(100);
+
+        expect(screen.queryByTestId('target')).to.equal(null);
+        expect(handlers.onExited.callCount).to.equal(1);
+      },
+    );
+
     it('cancels entering when in flips to false mid-transition', () => {
       const handlers = {
         onEntered: spy(),

--- a/packages/mui-material/src/internal/Transition.tsx
+++ b/packages/mui-material/src/internal/Transition.tsx
@@ -410,14 +410,14 @@ function Transition(props: InternalTransitionProps): React.ReactNode {
       if (statusChanged) {
         current.onEntering?.(isAppearingRef.current);
       }
-      if (nextCallbackRef.current === null && statusRef.current === status) {
+      if (nextCallbackRef.current === null) {
         scheduleTransitionEnd('entered', 'entering');
       }
     } else if (status === 'exiting') {
       if (statusChanged) {
         current.onExiting?.();
       }
-      if (nextCallbackRef.current === null && statusRef.current === status) {
+      if (nextCallbackRef.current === null) {
         scheduleTransitionEnd('exited', 'exiting');
       }
     } else if (status === 'entered' && statusChanged) {

--- a/packages/mui-material/src/internal/Transition.tsx
+++ b/packages/mui-material/src/internal/Transition.tsx
@@ -350,7 +350,7 @@ function Transition(props: InternalTransitionProps): React.ReactNode {
   // Runs on mount. useEnhancedEffect is needed because the initial appear
   // transition may read layout before paint. In StrictMode development builds,
   // React mounts, cleans up, and mounts again; cleanup cancels pending work and
-  // the second mount restarts the same transition.
+  // the status effect below restarts an active transition when effects reconnect.
   useEnhancedEffect(() => {
     mountedRef.current = true;
     if (shouldAppearOnMountRef.current) {
@@ -389,6 +389,8 @@ function Transition(props: InternalTransitionProps): React.ReactNode {
 
   // Fire lifecycle callbacks for committed status changes. The guard prevents
   // duplicate callbacks in StrictMode; propsRef keeps delayed callbacks fresh.
+  // Completion is scheduled outside the guard so an active transition is
+  // restarted when React reconnects effects while preserving state.
   useEnhancedEffect(() => {
     // `unmounted` is bookkeeping, not a real transition state. Do not fire
     // callbacks when moving into or out of it; otherwise the first open with
@@ -398,21 +400,29 @@ function Transition(props: InternalTransitionProps): React.ReactNode {
       return;
     }
     const prev = lastFiredStatusRef.current;
-    if (prev === status) {
-      return;
+    const statusChanged = prev !== status;
+    if (statusChanged) {
+      lastFiredStatusRef.current = status;
     }
-    lastFiredStatusRef.current = status;
 
     const current = propsRef.current;
     if (status === 'entering') {
-      current.onEntering?.(isAppearingRef.current);
-      scheduleTransitionEnd('entered', 'entering');
+      if (statusChanged) {
+        current.onEntering?.(isAppearingRef.current);
+      }
+      if (nextCallbackRef.current === null) {
+        scheduleTransitionEnd('entered', 'entering');
+      }
     } else if (status === 'exiting') {
-      current.onExiting?.();
-      scheduleTransitionEnd('exited', 'exiting');
-    } else if (status === 'entered') {
+      if (statusChanged) {
+        current.onExiting?.();
+      }
+      if (nextCallbackRef.current === null) {
+        scheduleTransitionEnd('exited', 'exiting');
+      }
+    } else if (status === 'entered' && statusChanged) {
       current.onEntered?.(isAppearingRef.current);
-    } else if (status === 'exited') {
+    } else if (status === 'exited' && statusChanged) {
       current.onExited?.();
     }
   }, [propsRef, scheduleTransitionEnd, status]);

--- a/packages/mui-material/src/internal/Transition.tsx
+++ b/packages/mui-material/src/internal/Transition.tsx
@@ -410,14 +410,14 @@ function Transition(props: InternalTransitionProps): React.ReactNode {
       if (statusChanged) {
         current.onEntering?.(isAppearingRef.current);
       }
-      if (nextCallbackRef.current === null) {
+      if (nextCallbackRef.current === null && statusRef.current === status) {
         scheduleTransitionEnd('entered', 'entering');
       }
     } else if (status === 'exiting') {
       if (statusChanged) {
         current.onExiting?.();
       }
-      if (nextCallbackRef.current === null) {
+      if (nextCallbackRef.current === null && statusRef.current === status) {
         scheduleTransitionEnd('exited', 'exiting');
       }
     } else if (status === 'entered' && statusChanged) {


### PR DESCRIPTION
Fix transitions that can get stuck in `exiting` when React reconnects effects or when a Modal’s portal container changes during an exit.

The transition completion timer/listener is rearmed after effects reconnect without repeating lifecycle callbacks such as `onExit` or `onExiting`.

Modal now retains its last resolved portal container while exiting. This prevents React from remounting the transition subtree before `onExited` fires, ensuring the Modal unmounts and releases its scroll lock. Subsequent opens use the latest container.

Added regression tests covering:

- Transition completion after effects reconnect.
- Portal container changes during an active exit.
- Lifecycle callbacks firing exactly once.
- Modal cleanup, unmounting, and reopening in the new container.

Fixes #32286.