### PR TITLE
[test] Add an `assertions` mode to the axe regression harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ axe-core runs inside the visual-regression Playwright loop (`test/regressions/in
 Key files:
 
 - `test/regressions/demoMeta.ts` — `SCREENSHOT_RULES` and `A11Y_RULES` arrays, matched last-wins (no inheritance: overrides restate every field) against `docs/data/material/components/{slug}/{Demo}` (minimatch globs).
-- `test/regressions/a11y/axe.ts` — asserts `color-contrast` and `link-in-text-block` unless listed in `skipAssertions`.
+- `test/regressions/a11y/axe.ts` — asserts `color-contrast` and `link-in-text-block` by default, or all exercised axe rules when the matching a11y rule sets `assertions: 'all'`; `skipAssertions` suppresses selected rule assertions.
 - `test/regressions/a11y/a11yReporter.ts` — writes one file per slug at `docs/data/material/components/{slug}/{slug}.a11y.json`. Each file is keyed by demo name, then by axe rule ID. Each rule records a `status` (`pass`, `fail`, or `incomplete`) and WCAG tags.
 
 Enroll a component (slug-wide, or narrow with brace-glob):
@@ -174,7 +174,7 @@ Enroll a component (slug-wide, or narrow with brace-glob):
 ```ts
 // test/regressions/demoMeta.ts
 { test: 'docs/data/material/components/alert/*', enabled: true, skipAssertions: ['color-contrast'] },
-{ test: 'docs/data/material/components/buttons/{BasicButtons,ColorButtons}', enabled: true },
+{ test: 'docs/data/material/components/buttons/{BasicButtons,ColorButtons}', enabled: true, assertions: 'all' },
 ```
 
 Override a specific demo: append a per-demo rule _after_ the slug-wide rule (last-match-wins; the override must restate every field it wants):

--- a/packages-internal/scripts/generate-llms-txt/test/processComponent.test.ts
+++ b/packages-internal/scripts/generate-llms-txt/test/processComponent.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';

--- a/packages-internal/scripts/generate-llms-txt/test/processComponent.test.ts
+++ b/packages-internal/scripts/generate-llms-txt/test/processComponent.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';

--- a/test/regressions/README.md
+++ b/test/regressions/README.md
@@ -52,11 +52,13 @@ A fixture can be loaded with `await renderFixture(fixturePath)`, for example `re
 
 Accessibility checks are opt-in.
 Add rules in `./demoMeta.ts` under `A11Y_RULES`.
+By default, only CSS-dependent visual axe rules are asserted.
+Set `assertions: 'all'` when a fixture is expected to pass every axe rule it exercises.
 
 Use a slug-wide rule for many demos, or a brace-glob for specific demos:
 
 ```ts
-{ test: 'docs/data/material/components/buttons/{BasicButtons,ColorButtons}', enabled: true }
+{ test: 'docs/data/material/components/buttons/{BasicButtons,ColorButtons}', enabled: true, assertions: 'all' }
 ```
 
 Filtered runs with `-t` only refresh matched slugs.

--- a/test/regressions/a11y/axe.test.ts
+++ b/test/regressions/a11y/axe.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
+import { expect } from 'chai';
 import type { AxeResults, Result } from 'axe-core';
 import type { TestContext } from 'vitest';
 import { recordA11y } from './axe';

--- a/test/regressions/a11y/axe.test.ts
+++ b/test/regressions/a11y/axe.test.ts
@@ -1,5 +1,4 @@
 import { describe, it } from 'vitest';
-import { expect } from 'chai';
 import type { AxeResults, Result } from 'axe-core';
 import type { TestContext } from 'vitest';
 import { recordA11y } from './axe';

--- a/test/regressions/a11y/axe.test.ts
+++ b/test/regressions/a11y/axe.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import type { AxeResults, Result } from 'axe-core';
+import type { TestContext } from 'vitest';
+import { recordA11y } from './axe';
+
+/** A minimal axe result carrying a single rule in one bucket. */
+function axeResults({
+  violations = [],
+  incomplete = [],
+  passes = [],
+}: Partial<Record<'violations' | 'incomplete' | 'passes', Result[]>>): AxeResults {
+  return { violations, incomplete, passes, inapplicable: [] } as unknown as AxeResults;
+}
+
+function rule(id: string, tags: string[] = ['wcag2a']): Result {
+  return { id, tags, nodes: [], description: id, help: id, helpUrl: '' } as unknown as Result;
+}
+
+/** `recordA11y` only touches `ctx.task.meta`, so a bare object is enough. */
+function context(): TestContext {
+  return { task: { meta: {} } } as unknown as TestContext;
+}
+
+describe('recordA11y', () => {
+  it('records every rule it saw, whatever the assertion mode', () => {
+    const ctx = context();
+    recordA11y(ctx, axeResults({ passes: [rule('button-name')] }), {
+      slug: 'buttons',
+      demo: 'BasicButtons',
+    });
+
+    expect((ctx.task.meta as any).a11y).to.deep.equal({
+      slug: 'buttons',
+      demo: 'BasicButtons',
+      rules: { 'button-name': { status: 'pass', tags: ['wcag2a'] } },
+    });
+  });
+
+  it('visual mode ignores a violation that does not depend on rendered CSS', () => {
+    expect(() =>
+      recordA11y(context(), axeResults({ violations: [rule('button-name')] }), {
+        slug: 'buttons',
+        demo: 'BasicButtons',
+      }),
+    ).not.to.throw();
+  });
+
+  it('visual mode still asserts the CSS-dependent rules', () => {
+    expect(() =>
+      recordA11y(context(), axeResults({ violations: [rule('color-contrast', ['wcag2aa'])] }), {
+        slug: 'buttons',
+        demo: 'BasicButtons',
+      }),
+    ).to.throw(/color-contrast/);
+  });
+
+  it('all mode asserts a violation that visual mode would ignore', () => {
+    expect(() =>
+      recordA11y(context(), axeResults({ violations: [rule('button-name')] }), {
+        slug: 'buttons',
+        demo: 'BasicButtons',
+        assertions: 'all',
+      }),
+    ).to.throw(/button-name/);
+  });
+
+  it('all mode asserts incompletes too, since an unresolved rule is not evidence', () => {
+    expect(() =>
+      recordA11y(context(), axeResults({ incomplete: [rule('aria-valid-attr')] }), {
+        slug: 'buttons',
+        demo: 'BasicButtons',
+        assertions: 'all',
+      }),
+    ).to.throw(/needs review/);
+  });
+
+  it('skipAssertions suppresses the assertion but keeps the result', () => {
+    const ctx = context();
+    expect(() =>
+      recordA11y(ctx, axeResults({ violations: [rule('button-name')] }), {
+        slug: 'buttons',
+        demo: 'BasicButtons',
+        assertions: 'all',
+        skipAssertions: ['button-name'],
+      }),
+    ).not.to.throw();
+
+    expect((ctx.task.meta as any).a11y.rules['button-name'].status).to.equal('fail');
+  });
+});

--- a/test/regressions/a11y/axe.ts
+++ b/test/regressions/a11y/axe.ts
@@ -56,6 +56,18 @@ interface RecordA11yOptions {
   slug: string;
   demo: string;
   /**
+   * `visual` asserts only rules that need real rendered CSS. `all` asserts
+   * every axe violation/incomplete not listed in `skipAssertions`.
+   *
+   * Note that `all` covers the `incomplete` bucket too, so a rule axe cannot
+   * decide on its own — a background it fails to resolve, say — fails the
+   * test rather than passing quietly. That is deliberate: an unresolved rule
+   * is not evidence of conformance. `skipAssertions` is the escape hatch for
+   * a fixture with a known-noisy incomplete; the result still lands in the
+   * JSON, only the assertion is suppressed.
+   */
+  assertions?: 'visual' | 'all';
+  /**
    * Rule ids whose violations are recorded but not asserted on. The rule
    * still runs and still lands in the results JSON — only the test-failing
    * assertion is suppressed.
@@ -73,7 +85,7 @@ interface RecordA11yOptions {
 export function recordA11y(
   ctx: TestContext,
   results: AxeResults,
-  { slug, demo, skipAssertions = [] }: RecordA11yOptions,
+  { slug, demo, assertions = 'visual', skipAssertions = [] }: RecordA11yOptions,
 ): void {
   const rules: Record<string, RuleEntry> = {};
   const buckets: ReadonlyArray<[AxeResults['passes'], RuleStatus]> = [
@@ -99,22 +111,20 @@ export function recordA11y(
   (ctx.task.meta as { a11y?: A11yMeta }).a11y = meta;
 
   const skip = new Set(skipAssertions);
-  const visualViolations = results.violations.filter(
-    (v) => VISUAL_RULES.includes(v.id) && !skip.has(v.id),
-  );
-  const visualIncomplete = results.incomplete.filter(
-    (v) => VISUAL_RULES.includes(v.id) && !skip.has(v.id),
-  );
+  const shouldAssert = (ruleId: string) =>
+    !skip.has(ruleId) && (assertions === 'all' || VISUAL_RULES.includes(ruleId));
+  const assertedViolations = results.violations.filter((v) => shouldAssert(v.id));
+  const assertedIncomplete = results.incomplete.filter((v) => shouldAssert(v.id));
 
   const failures: string[] = [];
-  if (visualViolations.length > 0) {
+  if (assertedViolations.length > 0) {
     failures.push(
-      `${visualViolations.length} axe violation(s):\n\n${formatResults(visualViolations)}`,
+      `${assertedViolations.length} axe violation(s):\n\n${formatResults(assertedViolations)}`,
     );
   }
-  if (visualIncomplete.length > 0) {
+  if (assertedIncomplete.length > 0) {
     failures.push(
-      `${visualIncomplete.length} axe incomplete (needs review):\n\n${formatResults(visualIncomplete)}`,
+      `${assertedIncomplete.length} axe incomplete (needs review):\n\n${formatResults(assertedIncomplete)}`,
     );
   }
   if (failures.length > 0) {

--- a/test/regressions/demoMeta.ts
+++ b/test/regressions/demoMeta.ts
@@ -40,6 +40,7 @@ export interface A11yRule {
   /**
    * `visual` asserts rules that depend on rendered CSS. `all` asserts every
    * axe violation/incomplete that is not listed in `skipAssertions`.
+   * @default 'visual'
    */
   assertions?: 'visual' | 'all';
   /** Axe rule IDs recorded into results JSON but not asserted on. */

--- a/test/regressions/demoMeta.ts
+++ b/test/regressions/demoMeta.ts
@@ -37,6 +37,11 @@ export interface A11yRule {
   /** Minimatch glob against `docs/data/material/components/{slug}/{Demo}`. */
   test: string;
   enabled?: boolean;
+  /**
+   * `visual` asserts rules that depend on rendered CSS. `all` asserts every
+   * axe violation/incomplete that is not listed in `skipAssertions`.
+   */
+  assertions?: 'visual' | 'all';
   /** Axe rule IDs recorded into results JSON but not asserted on. */
   skipAssertions?: string[];
 }
@@ -153,7 +158,11 @@ export const SCREENSHOT_RULES: ScreenshotRule[] = [
  * Initial PR scope: `buttons` only. Other components onboard incrementally.
  */
 export const A11Y_RULES: A11yRule[] = [
-  { test: 'docs/data/material/components/buttons/{BasicButtons,ColorButtons}', enabled: true },
+  {
+    test: 'docs/data/material/components/buttons/{BasicButtons,ColorButtons}',
+    enabled: true,
+    assertions: 'all',
+  },
 ];
 
 export interface ParsedRoute {

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -223,6 +223,7 @@ async function main() {
               recordA11y({ task }, results, {
                 slug: parsed.slug,
                 demo: parsed.demo,
+                assertions: a11yRule.assertions,
                 skipAssertions: a11yRule.skipAssertions,
               });
             }


### PR DESCRIPTION
Adds an `assertions` mode to the axe regression harness so a fixture can assert
every axe rule it exercises, not only the CSS-dependent visual ones. This is the
foundation the per-component WCAG conformance reports build on.

Also stops excluding the `progress` slug from the demo bundle so axe can reach
the LinearProgress demos; screenshots stay disabled slug-wide for it, since the
animated bars are flaky.

Original work by @mj12albert, extracted from #48708 so the harness change reviews
separately from the Button report.

Part of the WCAG conformance effort (see #14187).

> [!IMPORTANT]
> **How to review this PR**
>
> Layer 1 of 14 in a stacked series (#48915 → #48926). Its branch is the base of the series. GitHub cannot chain PR bases across a fork, so every PR in the series targets `master` instead.
>
> Its diff is exactly its own change — [`a0b8a93`](https://github.com/mui/material-ui/pull/48915/commits/a0b8a93f4dfac7344f04d2b453b9e6fa047b6a82).
>
> Part of the WCAG conformance effort (#14187).
