### PR TITLE
[release] v9.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # [Versions](https://mui.com/material-ui/getting-started/versions/)
 
+## 9.3.1
+
+<!-- generated comparing v9.3.0..master -->
+
+_Aug 6, 2026_
+
+A big thanks to the 3 contributors who made this release possible. Here are some highlights ✨:
+
+- 🐛 Fixed a regression where exit transitions could get stuck.
+
+### `@mui/material@9.3.1`
+
+- [transitions] Prevent exit transitions from getting stuck (#48881) @ZeeshanTamboli
+
+### Core
+
+- [blog] Clarify early bird renewal discount scope (#48906) @DanailH
+- [test][pagination] Add more unit tests (#48927) @silviuaavram
+
+All contributors of this release in alphabetical order: @DanailH, @silviuaavram, @ZeeshanTamboli
+
 ## 9.3.0
 
 <!-- generated comparing v9.2.0..master -->

--- a/docs/pages/blog/mui-x-sep-2024-price-update.md
+++ b/docs/pages/blog/mui-x-sep-2024-price-update.md
@@ -70,6 +70,12 @@ Current customers will still benefit from a 20% renewal discount (vs. 25% early 
 This means you will be able to renew your licenses or purchase additional licenses at a 7% price increase while gaining access to new features.
 You'll receive the discount via email, or you can also request it by contacting our [sales team](mailto:sales@mui.com).
 
+:::warning
+**Clarification (added August 2026):** This renewal discount applies to Premium licenses purchased through the early bird program before September 1st, 2024.
+It can be used when renewing existing licenses only, meaning it is not valid for other MUI X purchases, including but not limited to the new v9 software, which are billed under current pricing.
+If you're unsure whether a specific purchase qualifies for discount, please check with our [sales team](mailto:sales@mui.com) before renewing.
+:::
+
 ## Effective date
 
 The new pricing updates will take effect on September 1st, 2024.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/monorepo",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/packages/mui-core-downloads-tracker/package.json
+++ b/packages/mui-core-downloads-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/core-downloads-tracker",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "author": "MUI Team",
   "description": "Internal package to track number of downloads of our design system libraries.",
   "license": "MIT",

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/material",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "author": "MUI Team",
   "description": "Material UI is an open-source React component library that implements Google's Material Design. It's comprehensive and can be used in production out of the box.",
   "license": "MIT",

--- a/packages/mui-material/src/Modal/Modal.js
+++ b/packages/mui-material/src/Modal/Modal.js
@@ -117,6 +117,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
     getBackdropProps,
     getTransitionProps,
     portalRef,
+    portalContainer,
     isTopModal,
     exited,
     hasTransition,
@@ -186,7 +187,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
   }
 
   return (
-    <Portal ref={portalRef} container={container} disablePortal={disablePortal}>
+    <Portal ref={portalRef} container={portalContainer} disablePortal={disablePortal}>
       <RootSlot {...rootProps}>
         {!hideBackdrop ? <BackdropSlot {...backdropProps} /> : null}
         <FocusTrap

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -779,6 +779,8 @@ describe('<Modal />', () => {
   });
 
   describe('prop: container', () => {
+    clock.withFakeTimers();
+
     it('should be able to change the container', () => {
       function TestCase(props) {
         const { anchorEl } = props;
@@ -795,6 +797,99 @@ describe('<Modal />', () => {
       setProps({ anchorEl: document.body });
       setProps({ anchorEl: null });
       setProps({ anchorEl: document.body });
+    });
+
+    it('should finish closing when the container changes during the exit transition', () => {
+      function TestCase(props) {
+        const firstContainerRef = React.useRef(null);
+        const secondContainerRef = React.useRef(null);
+        const getContainer = React.useCallback(
+          () =>
+            props.containerIndex === 0 ? firstContainerRef.current : secondContainerRef.current,
+          [props.containerIndex],
+        );
+
+        return (
+          <React.Fragment>
+            <div data-testid="first-container" ref={firstContainerRef} />
+            <div data-testid="second-container" ref={secondContainerRef} />
+            <Modal
+              data-testid="modal"
+              open={props.open}
+              container={getContainer}
+              closeAfterTransition
+              onTransitionExited={props.onTransitionExited}
+            >
+              <Fade
+                in={props.open}
+                timeout={100}
+                onExit={props.onExit}
+                onExiting={props.onExiting}
+                onExited={props.onExited}
+              >
+                <div>Content</div>
+              </Fade>
+            </Modal>
+          </React.Fragment>
+        );
+      }
+
+      const handleExit = spy();
+      const handleExiting = spy();
+      const handleExited = spy();
+      const handleTransitionExited = spy();
+      const { setProps } = render(
+        <TestCase
+          open
+          containerIndex={0}
+          onExit={handleExit}
+          onExiting={handleExiting}
+          onExited={handleExited}
+          onTransitionExited={handleTransitionExited}
+        />,
+      );
+
+      act(() => {
+        clock.runToLast();
+      });
+      const firstContainer = screen.getByTestId('first-container');
+      const secondContainer = screen.getByTestId('second-container');
+      expect(within(firstContainer).getByTestId('modal')).not.to.equal(null);
+
+      setProps({ open: false, containerIndex: 0 });
+      expect(handleExit.callCount).to.equal(1);
+      expect(handleExiting.callCount).to.equal(1);
+      expect(handleExited.callCount).to.equal(0);
+      expect(handleTransitionExited.callCount).to.equal(0);
+
+      act(() => {
+        clock.tick(50);
+      });
+      setProps({ open: false, containerIndex: 1 });
+
+      expect(within(firstContainer).getByTestId('modal')).not.to.equal(null);
+      expect(within(secondContainer).queryByTestId('modal')).to.equal(null);
+      expect(handleExit.callCount).to.equal(1);
+      expect(handleExiting.callCount).to.equal(1);
+      expect(handleExited.callCount).to.equal(0);
+      expect(handleTransitionExited.callCount).to.equal(0);
+
+      act(() => {
+        clock.tick(50);
+      });
+      expect(screen.queryByTestId('modal')).to.equal(null);
+      expect(handleExit.callCount).to.equal(1);
+      expect(handleExiting.callCount).to.equal(1);
+      expect(handleExited.callCount).to.equal(1);
+      expect(handleTransitionExited.callCount).to.equal(1);
+      expect(firstContainer.style).to.have.property('overflow', '');
+
+      setProps({ open: true, containerIndex: 1 });
+      act(() => {
+        clock.runToLast();
+      });
+      expect(within(firstContainer).queryByTestId('modal')).to.equal(null);
+      expect(within(secondContainer).getByTestId('modal')).not.to.equal(null);
     });
   });
 

--- a/packages/mui-material/src/Modal/useModal.ts
+++ b/packages/mui-material/src/Modal/useModal.ts
@@ -44,6 +44,7 @@ function useModal(parameters: UseModalParameters): UseModalReturnValue {
   // @ts-ignore internal logic
   const modal = React.useRef<{ modalRef: HTMLDivElement; mount: HTMLElement }>({});
   const mountNodeRef = React.useRef<HTMLElement>(null);
+  const lastMountNodeRef = React.useRef<HTMLElement>(null);
   const modalRef = React.useRef<HTMLDivElement>(null);
   const handleRef = useForkRef(modalRef, rootRef);
   const [exited, setExited] = React.useState(!open);
@@ -83,12 +84,14 @@ function useModal(parameters: UseModalParameters): UseModalReturnValue {
 
   const isTopModal = () => manager.isTopModal(getModal());
 
-  const handlePortalRef = useEventCallback((node: HTMLElement) => {
+  const handlePortalRef = useEventCallback((node: HTMLElement | null) => {
     mountNodeRef.current = node;
 
     if (!node) {
       return;
     }
+
+    lastMountNodeRef.current = node;
 
     if (open && isTopModal()) {
       handleMounted();
@@ -220,12 +223,18 @@ function useModal(parameters: UseModalParameters): UseModalReturnValue {
     };
   };
 
+  // Changing a portal's container remounts its children. Keep an exiting transition in its
+  // current container so it can finish and notify the modal that it is safe to unmount.
+  const portalContainer =
+    !open && hasTransition && !exited ? (lastMountNodeRef.current ?? container) : container;
+
   return {
     getRootProps,
     getBackdropProps,
     getTransitionProps,
     rootRef: handleRef,
     portalRef: handlePortalRef,
+    portalContainer,
     isTopModal,
     exited,
     hasTransition,

--- a/packages/mui-material/src/Modal/useModal.types.ts
+++ b/packages/mui-material/src/Modal/useModal.types.ts
@@ -113,6 +113,11 @@ export interface UseModalReturnValue {
    */
   portalRef: React.RefCallback<Element> | null;
   /**
+   * The container used by the portal. While a transition is exiting, this remains the last
+   * resolved mount node so changing containers does not remount the transition.
+   */
+  portalContainer: PortalProps['container'];
+  /**
    * If `true`, the modal is the top most one.
    */
   isTopModal: () => boolean;

--- a/packages/mui-material/src/Pagination/Pagination.test.js
+++ b/packages/mui-material/src/Pagination/Pagination.test.js
@@ -25,6 +25,7 @@ describe('<Pagination />', () => {
     const { container } = render(<Pagination />);
 
     expect(container.firstChild).to.have.class(classes.root);
+    expect(screen.getByRole('navigation')).to.have.attribute('aria-label', 'pagination navigation');
   });
 
   it('moves aria-current to the specified page', () => {
@@ -96,5 +97,29 @@ describe('<Pagination />', () => {
     expect(buttons[2].textContent).to.equal('6');
     expect(buttons[3].textContent).to.equal('7');
     expect(buttons[0].querySelector('svg')).to.have.attribute('data-testid', 'NavigateNextIcon');
+  });
+
+  it('hides the next button when hideNextButton is true', () => {
+    render(<Pagination count={3} hideNextButton />);
+
+    expect(screen.queryByRole('button', { name: /go to next page/i })).to.equal(null);
+  });
+
+  it('hides the previous button when hidePrevButton is true', () => {
+    render(<Pagination count={3} hidePrevButton />);
+
+    expect(screen.queryByRole('button', { name: /go to previous page/i })).to.equal(null);
+  });
+
+  it('hides the first button when showFirstButton is false', () => {
+    render(<Pagination count={3} showFirstButton={false} />);
+
+    expect(screen.queryByRole('button', { name: /go to first page/i })).to.equal(null);
+  });
+
+  it('hides the last button when showLastButton is false', () => {
+    render(<Pagination count={3} showLastButton={false} />);
+
+    expect(screen.queryByRole('button', { name: /go to last page/i })).to.equal(null);
   });
 });

--- a/packages/mui-material/src/internal/Transition.test.tsx
+++ b/packages/mui-material/src/internal/Transition.test.tsx
@@ -571,6 +571,91 @@ describe('<Transition />', () => {
   describe('interrupted transitions', () => {
     clock.withFakeTimers();
 
+    it.skipIf(!('Activity' in React))(
+      'restarts completion when effects reconnect while exiting',
+      () => {
+        const handlers = {
+          onExit: spy(),
+          onExiting: spy(),
+          onExited: spy(),
+        };
+
+        function ActivityHarness(props: { in: boolean; mode: 'hidden' | 'visible' }) {
+          return (
+            <React.Activity mode={props.mode}>
+              <TestHarness
+                in={props.in}
+                appear={false}
+                unmountOnExit
+                timeout={100}
+                handlers={handlers}
+              />
+            </React.Activity>
+          );
+        }
+
+        const { setProps } = render(<ActivityHarness in mode="visible" />);
+        setProps({ in: false, mode: 'visible' });
+        expect(screen.getByTestId('target')).to.have.attribute('data-status', 'exiting');
+        expect(handlers.onExit.callCount).to.equal(1);
+        expect(handlers.onExiting.callCount).to.equal(1);
+
+        // Activity disconnects effects while preserving state. This cancels the pending completion
+        setProps({ in: false, mode: 'hidden' });
+        clock.tick(100);
+        expect(screen.getByTestId('target')).to.have.attribute('data-status', 'exiting');
+        expect(handlers.onExited.callCount).to.equal(0);
+
+        setProps({ in: false, mode: 'visible' });
+        expect(handlers.onExit.callCount).to.equal(1);
+        expect(handlers.onExiting.callCount).to.equal(1);
+        clock.tick(100);
+
+        expect(screen.queryByTestId('target')).to.equal(null);
+        expect(handlers.onExited.callCount).to.equal(1);
+      },
+    );
+
+    it.skipIf(!('Activity' in React))(
+      'does not complete the superseded phase when in flips on reconnect',
+      () => {
+        const handlers = {
+          onEnter: spy(),
+          onEntering: spy(),
+          onEntered: spy(),
+          onExit: spy(),
+          onExiting: spy(),
+          onExited: spy(),
+        };
+
+        function ActivityHarness(props: { in: boolean; mode: 'hidden' | 'visible' }) {
+          return (
+            <React.Activity mode={props.mode}>
+              <TestHarness in={props.in} appear={false} timeout={100} handlers={handlers} />
+            </React.Activity>
+          );
+        }
+
+        const { setProps } = render(<ActivityHarness in mode="visible" />);
+        setProps({ in: false, mode: 'visible' });
+        expect(screen.getByTestId('target')).to.have.attribute('data-status', 'exiting');
+
+        // Effects disconnect mid-exit, then reconnect in the same commit that `in` flips back.
+        // The reconciliation effect starts entering before the lifecycle effect runs, so the
+        // lifecycle effect must not schedule completion for the superseded exit.
+        setProps({ in: false, mode: 'hidden' });
+        clock.tick(50);
+        setProps({ in: true, mode: 'visible' });
+        clock.tick(100);
+
+        expect(screen.getByTestId('target')).to.have.attribute('data-status', 'entered');
+        expect(handlers.onEnter.callCount).to.equal(1);
+        expect(handlers.onEntering.callCount).to.equal(1);
+        expect(handlers.onEntered.callCount).to.equal(1);
+        expect(handlers.onExited.callCount).to.equal(0);
+      },
+    );
+
     it('cancels entering when in flips to false mid-transition', () => {
       const handlers = {
         onEntered: spy(),

--- a/packages/mui-material/src/internal/Transition.tsx
+++ b/packages/mui-material/src/internal/Transition.tsx
@@ -350,7 +350,7 @@ function Transition(props: InternalTransitionProps): React.ReactNode {
   // Runs on mount. useEnhancedEffect is needed because the initial appear
   // transition may read layout before paint. In StrictMode development builds,
   // React mounts, cleans up, and mounts again; cleanup cancels pending work and
-  // the second mount restarts the same transition.
+  // the status effect below restarts an active transition when effects reconnect.
   useEnhancedEffect(() => {
     mountedRef.current = true;
     if (shouldAppearOnMountRef.current) {
@@ -389,6 +389,8 @@ function Transition(props: InternalTransitionProps): React.ReactNode {
 
   // Fire lifecycle callbacks for committed status changes. The guard prevents
   // duplicate callbacks in StrictMode; propsRef keeps delayed callbacks fresh.
+  // Completion is scheduled outside the guard so an active transition is
+  // restarted when React reconnects effects while preserving state.
   useEnhancedEffect(() => {
     // `unmounted` is bookkeeping, not a real transition state. Do not fire
     // callbacks when moving into or out of it; otherwise the first open with
@@ -398,21 +400,29 @@ function Transition(props: InternalTransitionProps): React.ReactNode {
       return;
     }
     const prev = lastFiredStatusRef.current;
-    if (prev === status) {
-      return;
+    const statusChanged = prev !== status;
+    if (statusChanged) {
+      lastFiredStatusRef.current = status;
     }
-    lastFiredStatusRef.current = status;
 
     const current = propsRef.current;
     if (status === 'entering') {
-      current.onEntering?.(isAppearingRef.current);
-      scheduleTransitionEnd('entered', 'entering');
+      if (statusChanged) {
+        current.onEntering?.(isAppearingRef.current);
+      }
+      if (nextCallbackRef.current === null && statusRef.current === status) {
+        scheduleTransitionEnd('entered', 'entering');
+      }
     } else if (status === 'exiting') {
-      current.onExiting?.();
-      scheduleTransitionEnd('exited', 'exiting');
-    } else if (status === 'entered') {
+      if (statusChanged) {
+        current.onExiting?.();
+      }
+      if (nextCallbackRef.current === null && statusRef.current === status) {
+        scheduleTransitionEnd('exited', 'exiting');
+      }
+    } else if (status === 'entered' && statusChanged) {
       current.onEntered?.(isAppearingRef.current);
-    } else if (status === 'exited') {
+    } else if (status === 'exited' && statusChanged) {
       current.onExited?.();
     }
   }, [propsRef, scheduleTransitionEnd, status]);


### PR DESCRIPTION
Hotfix release for the exit-transitions regression.

Cherry-picked from master onto `release/9.3.1` (cut at v9.3.0):

- [transitions] Prevent exit transitions from getting stuck (#48881)
- [test][pagination] Add more unit tests (#48927)
- [blog] Clarify early bird renewal discount scope (#48906)

Plus version bumps (`@mui/material`, `@mui/core-downloads-tracker` → 9.3.1) and the changelog.