### PR TITLE
[input] Add missing InputBase class keys

### DIFF
--- a/docs/pages/material-ui/api/input.json
+++ b/docs/pages/material-ui/api/input.json
@@ -58,6 +58,18 @@
   "imports": ["import Input from '@mui/material/Input';", "import { Input } from '@mui/material';"],
   "classes": [
     {
+      "key": "adornedEnd",
+      "className": "MuiInput-adornedEnd",
+      "description": "Styles applied to the root element if `endAdornment` is provided.",
+      "isGlobal": false
+    },
+    {
+      "key": "adornedStart",
+      "className": "MuiInput-adornedStart",
+      "description": "Styles applied to the root element if `startAdornment` is provided.",
+      "isGlobal": false
+    },
+    {
       "key": "colorSecondary",
       "className": "MuiInput-colorSecondary",
       "description": "Styles applied to the root element if color secondary.",
@@ -94,6 +106,12 @@
       "isGlobal": false
     },
     {
+      "key": "hiddenLabel",
+      "className": "MuiInput-hiddenLabel",
+      "description": "Styles applied to the root element if `hiddenLabel={true}`.",
+      "isGlobal": false
+    },
+    {
       "key": "input",
       "className": "MuiInput-input",
       "description": "Styles applied to the input element.",
@@ -110,6 +128,12 @@
       "className": "MuiInput-multiline",
       "description": "Styles applied to the root element if `multiline={true}`.",
       "isGlobal": false
+    },
+    {
+      "key": "readOnly",
+      "className": "Mui-readOnly",
+      "description": "State class applied to the root element if `readOnly={true}`.",
+      "isGlobal": true
     },
     {
       "key": "root",

--- a/docs/translations/api-docs/input/input.json
+++ b/docs/translations/api-docs/input/input.json
@@ -83,6 +83,16 @@
     }
   },
   "classDescriptions": {
+    "adornedEnd": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>endAdornment</code> is provided"
+    },
+    "adornedStart": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>startAdornment</code> is provided"
+    },
     "colorSecondary": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
@@ -113,6 +123,11 @@
       "nodeName": "the root element",
       "conditions": "<code>fullWidth={true}</code>"
     },
+    "hiddenLabel": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>hiddenLabel={true}</code>"
+    },
     "input": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the input element" },
     "inputTypeSearch": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
@@ -123,6 +138,11 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>multiline={true}</code>"
+    },
+    "readOnly": {
+      "description": "State class applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>readOnly={true}</code>"
     },
     "root": { "description": "Styles applied to the root element." },
     "sizeSmall": {

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -10,6 +10,7 @@ import { styled } from '../zero-styled';
 import memoTheme from '../utils/memoTheme';
 import createSimplePaletteValueFilter from '../utils/createSimplePaletteValueFilter';
 import { useDefaultProps } from '../DefaultPropsProvider';
+import { useFormControlState } from '../FormControl/useFormControl';
 import inputLabelClasses from '../InputLabel/inputLabelClasses';
 import inputClasses, { getInputUtilityClass } from './inputClasses';
 import { getTransitionStyles } from '../transitions/utils';
@@ -21,10 +22,16 @@ import {
 } from '../InputBase/InputBase';
 
 const useUtilityClasses = (ownerState) => {
-  const { classes, disableUnderline } = ownerState;
+  const { classes, disableUnderline, startAdornment, endAdornment, hiddenLabel } = ownerState;
 
   const slots = {
-    root: ['root', !disableUnderline && 'underline'],
+    root: [
+      'root',
+      !disableUnderline && 'underline',
+      startAdornment && 'adornedStart',
+      endAdornment && 'adornedEnd',
+      hiddenLabel && 'hiddenLabel',
+    ],
     input: ['input'],
   };
 
@@ -154,7 +161,8 @@ const Input = React.forwardRef(function Input(inProps, ref) {
     ...other
   } = props;
 
-  const classes = useUtilityClasses(props);
+  const [fcs] = useFormControlState({ props, states: ['hiddenLabel'] });
+  const classes = useUtilityClasses({ ...props, hiddenLabel: fcs.hiddenLabel });
 
   const ownerState = { disableUnderline };
   const inputComponentsProps = { root: { ownerState } };

--- a/packages/mui-material/src/Input/Input.spec.tsx
+++ b/packages/mui-material/src/Input/Input.spec.tsx
@@ -1,0 +1,6 @@
+import Input from '@mui/material/Input';
+
+<Input classes={{ adornedStart: 'adorned-start' }} />;
+<Input classes={{ adornedEnd: 'adorned-end' }} />;
+<Input classes={{ hiddenLabel: 'hidden-label' }} />;
+<Input classes={{ readOnly: 'read-only' }} />;

--- a/packages/mui-material/src/Input/Input.test.js
+++ b/packages/mui-material/src/Input/Input.test.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
+import FormControl from '@mui/material/FormControl';
 import InputBase from '@mui/material/InputBase';
-import Input, { inputClasses as classes } from '@mui/material/Input';
+import Input, { getInputUtilityClass, inputClasses as classes } from '@mui/material/Input';
 import describeConformance from '../../test/describeConformance';
 
 describe('<Input />', () => {
@@ -43,6 +44,20 @@ describe('<Input />', () => {
       <Input data-test="test" multiline sx={{ [`&.${classes.multiline}`]: { mt: '10px' } }} />,
     );
     expect(document.querySelector('[data-test=test]')).toHaveComputedStyle({ marginTop: '10px' });
+  });
+
+  it('should have the documented state classes', () => {
+    render(
+      <FormControl hiddenLabel>
+        <Input data-testid="root" readOnly startAdornment="start" endAdornment="end" />
+      </FormControl>,
+    );
+    const root = screen.getByTestId('root');
+
+    expect(root).to.have.class(getInputUtilityClass('adornedStart'));
+    expect(root).to.have.class(getInputUtilityClass('adornedEnd'));
+    expect(root).to.have.class(getInputUtilityClass('hiddenLabel'));
+    expect(root).to.have.class(getInputUtilityClass('readOnly'));
   });
 
   it('should not forward the notched prop to the DOM', () => {

--- a/packages/mui-material/src/Input/inputClasses.ts
+++ b/packages/mui-material/src/Input/inputClasses.ts
@@ -11,6 +11,10 @@ export interface InputClasses {
   focused: string;
   /** Styles applied to the root element if `disabled={true}`. */
   disabled: string;
+  /** Styles applied to the root element if `startAdornment` is provided. */
+  adornedStart: string;
+  /** Styles applied to the root element if `endAdornment` is provided. */
+  adornedEnd: string;
   /** Styles applied to the root element if color secondary. */
   colorSecondary: string;
   /** Styles applied to the root element unless `disableUnderline={true}`. */
@@ -23,6 +27,10 @@ export interface InputClasses {
   multiline: string;
   /** Styles applied to the root element if `fullWidth={true}`. */
   fullWidth: string;
+  /** Styles applied to the root element if `hiddenLabel={true}`. */
+  hiddenLabel: string;
+  /** State class applied to the root element if `readOnly={true}`. */
+  readOnly: string;
   /** Styles applied to the input element. */
   input: string;
   /** Styles applied to the input element if `type="search"`. */

--- a/packages/mui-material/src/Input/inputClasses.ts
+++ b/packages/mui-material/src/Input/inputClasses.ts
@@ -45,7 +45,14 @@ export function getInputUtilityClass(slot: string): string {
 
 const inputClasses: InputClasses = {
   ...inputBaseClasses,
-  ...generateUtilityClasses('MuiInput', ['root', 'underline', 'input']),
+  ...generateUtilityClasses('MuiInput', [
+    'root',
+    'underline',
+    'input',
+    'adornedStart',
+    'adornedEnd',
+    'hiddenLabel',
+  ]),
 };
 
 export default inputClasses;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #20706.

`inputClasses` already exposes the class keys inherited from `InputBase` at runtime, but `InputClasses` omitted `adornedStart`, `adornedEnd`, `hiddenLabel`, and `readOnly`. As a result, TypeScript rejected these valid keys when they were passed to the `Input` component's `classes` prop.

This change aligns the public type and generated API documentation with the existing runtime class map, and adds focused compile-time coverage for all four keys.

Tests:
- `pnpm -F @mui/material typescript`
- `pnpm test:node Input` (214 passed, 39 skipped)
- `pnpm prettier`
- `pnpm eslint`
- `pnpm proptypes`
- `pnpm docs:api`