### PR TITLE
[docs] Manage focus on Open in Chat button click

### DIFF
--- a/packages-internal/core-docs/src/Demo/OpenInMUIChatButton.test.tsx
+++ b/packages-internal/core-docs/src/Demo/OpenInMUIChatButton.test.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { act, createRenderer, isJsdom, screen } from '@mui/internal-test-utils';
+import { ThemeProvider } from '@mui/material/styles';
+import { brandingLightTheme } from '../branding';
+import DemoContext, { type DemoContextValue } from '../DemoContext';
+import PageContext from '../PageContext';
+import { OpenInMUIChatButton } from './OpenInMUIChatButton';
+import type { DemoData } from './sandbox/types';
+
+const mocks = vi.hoisted(() => ({
+  openSandbox: vi.fn(async () => {}),
+}));
+
+vi.mock('./sandbox/MuiChat', () => ({
+  createMuiChat: () => ({ openSandbox: mocks.openSandbox }),
+}));
+
+const pageContext = {
+  activePage: null,
+  pages: [],
+  productId: 'material-ui',
+  productCategoryId: 'core',
+  productIdentifier: { metadata: '', name: 'Material UI', versions: [] },
+  activePageParents: [],
+} satisfies React.ContextType<typeof PageContext>;
+
+const demoContext = {
+  productDisplayName: 'Material UI',
+  csb: { primaryPackage: '@mui/material' },
+} satisfies DemoContextValue;
+
+const demoData: DemoData = {
+  title: 'BasicTabs',
+  language: 'tsx',
+  raw: '',
+  codeVariant: 'TS',
+  githubLocation: 'docs/data/material/components/tabs/BasicTabs.tsx',
+  productId: 'material-ui',
+};
+
+function createDeferredPromise() {
+  let resolve!: () => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe.skipIf(!isJsdom())('OpenInMUIChatButton', () => {
+  const { render } = createRenderer();
+
+  function renderButton(children?: React.ReactNode) {
+    return render(
+      <PageContext.Provider value={pageContext}>
+        <DemoContext.Provider value={demoContext}>
+          <ThemeProvider theme={brandingLightTheme}>
+            <OpenInMUIChatButton demoData={demoData} />
+            {children}
+          </ThemeProvider>
+        </DemoContext.Provider>
+      </PageContext.Provider>,
+    );
+  }
+
+  beforeEach(() => {
+    mocks.openSandbox.mockReset();
+    vi.stubEnv('MUI_CHAT_API_BASE_URL', 'https://chat.example.com');
+    vi.stubEnv('MUI_CHAT_SCOPES', 'material-ui');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('restores focus after opening MUI Chat', async () => {
+    const deferred = createDeferredPromise();
+    mocks.openSandbox.mockImplementation(() => deferred.promise);
+    const { user } = renderButton();
+    const chatButton = screen.getByRole('button', { name: 'Edit in Chat' });
+
+    await user.click(chatButton);
+    expect(chatButton).to.have.property('disabled', true);
+
+    act(() => chatButton.blur());
+    expect(document.activeElement).not.to.equal(chatButton);
+
+    await act(async () => deferred.resolve());
+
+    expect(chatButton).to.have.property('disabled', false);
+    expect(document.activeElement).to.equal(chatButton);
+  });
+
+  it('restores focus when opening MUI Chat fails', async () => {
+    const deferred = createDeferredPromise();
+    mocks.openSandbox.mockImplementation(() => deferred.promise);
+    const { user } = renderButton();
+    const chatButton = screen.getByRole('button', { name: 'Edit in Chat' });
+
+    await user.click(chatButton);
+    expect(chatButton).to.have.property('disabled', true);
+
+    act(() => chatButton.blur());
+    await act(async () => deferred.reject(new Error('Unable to open MUI Chat')));
+
+    expect(chatButton).to.have.property('disabled', false);
+    expect(document.activeElement).to.equal(chatButton);
+    expect(screen.getByRole('alert')).to.have.text('Unable to open MUI Chat');
+  });
+
+  it('does not restore focus if the user moves it while loading', async () => {
+    const deferred = createDeferredPromise();
+    mocks.openSandbox.mockImplementation(() => deferred.promise);
+    const { user } = renderButton(<button type="button">Other action</button>);
+    const chatButton = screen.getByRole('button', { name: 'Edit in Chat' });
+    const otherButton = screen.getByRole('button', { name: 'Other action' });
+
+    await user.click(chatButton);
+    await user.click(otherButton);
+    expect(document.activeElement).to.equal(otherButton);
+
+    await act(async () => deferred.resolve());
+
+    expect(chatButton).to.have.property('disabled', false);
+    expect(document.activeElement).to.equal(otherButton);
+  });
+});

--- a/packages-internal/core-docs/src/Demo/OpenInMUIChatButton.tsx
+++ b/packages-internal/core-docs/src/Demo/OpenInMUIChatButton.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import useForkRef from '@mui/utils/useForkRef';
+import { getActiveElement, ownerDocument } from '@mui/material/utils';
 import { styled, keyframes, alpha } from '@mui/material/styles';
 import Button, { type ButtonProps } from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -98,6 +100,27 @@ export const OpenInMUIChatButton = React.forwardRef<HTMLButtonElement, OpenInMUI
     const baseUrl = process.env.MUI_CHAT_API_BASE_URL;
     const scopes = process.env.MUI_CHAT_SCOPES;
 
+    const rainbowButtonRef = React.useRef<HTMLButtonElement | null>(null);
+    const handleRef = useForkRef<HTMLButtonElement>(ref, rainbowButtonRef);
+    const wasLoadingRef = React.useRef(false);
+
+    React.useEffect(() => {
+      if (wasLoadingRef.current && !loading) {
+        const rainbowButton = rainbowButtonRef.current;
+        const document = ownerDocument(rainbowButton);
+        const activeElement = getActiveElement(document);
+
+        if (
+          activeElement === document.body ||
+          activeElement === null ||
+          activeElement === document.documentElement
+        ) {
+          rainbowButtonRef.current?.focus();
+        }
+      }
+      wasLoadingRef.current = loading;
+    }, [loading]);
+
     const handleClick = async () => {
       setLoading(true);
       setError(null);
@@ -120,9 +143,8 @@ export const OpenInMUIChatButton = React.forwardRef<HTMLButtonElement, OpenInMUI
       <React.Fragment>
         <RainbowButton
           data-mui-color-scheme="dark"
-          ref={ref}
+          ref={handleRef}
           loading={loading}
-          disabled={!!error}
           loadingIndicator={<CircularProgress color="inherit" size={12} />}
           onClick={handleClick}
           {...props}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

When clicking Open in Chat button in the docs, the focus is lost to the body. Restore the focus to the button once the button is not loading anymore, and if the user did not move focus elsewhere.

Also, there is no reason to disable the button while showing the error toast. Button should be enabled as soon as possible, when the request returns.