### PR TITLE
[docs] Move focus to the main content with the skip link

### DIFF
--- a/docs/pages/404.tsx
+++ b/docs/pages/404.tsx
@@ -12,7 +12,7 @@ export default function Custom404() {
       <Head title="404: This page could not be found - MUI" description="" />
       <AppHeaderBanner />
       <AppHeader />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <NotFoundHero />
         <Divider />
       </main>

--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -21,7 +21,7 @@ export default function About() {
       />
       <AppHeaderBanner />
       <AppHeader />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <AboutHero />
         <Divider />
         <OurValues />

--- a/docs/pages/blog.tsx
+++ b/docs/pages/blog.tsx
@@ -266,7 +266,7 @@ export default function Blog(props: InferGetStaticPropsType<typeof getStaticProp
         disableAlternateLocale
       />
       <AppHeader />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <Section cozy bg="gradient">
           <SectionHeadline
             alwaysCenter

--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -137,7 +137,7 @@ export default function Careers() {
       />
       <AppHeaderBanner />
       <AppHeader />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <Section cozy bg="gradient">
           <SectionHeadline
             alwaysCenter

--- a/docs/pages/components.tsx
+++ b/docs/pages/components.tsx
@@ -50,7 +50,7 @@ export default function Components() {
         description="MUI provides a simple, customizable, and accessible library of React components. Follow your own design system, or start with Material Design. You will develop React applications faster."
       />
       <AppHeader />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <Section bg="gradient" sx={{ py: { xs: 2, sm: 4 } }}>
           <Typography component="h1" variant="h2" sx={{ mb: 4, pl: 1 }}>
             All Components

--- a/docs/pages/core.tsx
+++ b/docs/pages/core.tsx
@@ -18,7 +18,7 @@ export default function Core() {
       />
       <AppHeaderBanner />
       <AppHeader gitHubRepository="https://github.com/mui/material-ui" />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <CoreHero />
         <CoreProducts />
         <Divider />

--- a/docs/pages/customers.tsx
+++ b/docs/pages/customers.tsx
@@ -30,7 +30,7 @@ export default function Customers(props: InferGetStaticPropsType<typeof getStati
       <AppHeaderBanner />
       <AppHeader />
       <Divider />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <CustomersHero />
         <CustomersLogoSlider />
         <Box

--- a/docs/pages/design-kits.tsx
+++ b/docs/pages/design-kits.tsx
@@ -21,7 +21,7 @@ export default function DesignKits() {
       />
       <AppHeaderBanner />
       <AppHeader gitHubRepository="https://github.com/mui/mui-design-kits" />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <DesignKitHero />
         <References companies={DESIGNKITS_CUSTOMERS} />
         <Divider />

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -49,7 +49,7 @@ export default function Home() {
       </NoSsr>
       <AppHeaderBanner />
       <AppHeader />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <Hero />
         <References companies={CORE_CUSTOMERS} />
         <Divider />

--- a/docs/pages/material-ui.tsx
+++ b/docs/pages/material-ui.tsx
@@ -23,7 +23,7 @@ export default function MaterialUI() {
       />
       <AppHeaderBanner />
       <AppHeader gitHubRepository="https://github.com/mui/material-ui" />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <MaterialHero />
         <References companies={CORE_CUSTOMERS} />
         <Divider />

--- a/docs/pages/pricing.tsx
+++ b/docs/pages/pricing.tsx
@@ -26,7 +26,7 @@ export default function Pricing() {
       />
       <AppHeaderBanner />
       <AppHeader />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <HeroPricing />
         <LicenseModelProvider>
           <MultiAppProvider>

--- a/docs/pages/templates.tsx
+++ b/docs/pages/templates.tsx
@@ -21,7 +21,7 @@ export default function Templates() {
       />
       <AppHeaderBanner />
       <AppHeader />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <TemplateHero />
         <References companies={TEMPLATES_CUSTOMERS} />
         <Divider />

--- a/docs/pages/x.tsx
+++ b/docs/pages/x.tsx
@@ -23,7 +23,7 @@ export default function X() {
       />
       <AppHeaderBanner />
       <AppHeader gitHubRepository="https://github.com/mui/mui-x" />
-      <main id="main-content">
+      <main id="main-content" tabIndex={-1}>
         <XHero />
         <References companies={ADVANCED_CUSTOMERS} />
         <Divider />

--- a/packages-internal/core-docs/src/AppLayout/layout/AppContainer.tsx
+++ b/packages-internal/core-docs/src/AppLayout/layout/AppContainer.tsx
@@ -16,5 +16,5 @@ const StyledAppContainer = styled(Container)(({ theme }) => {
 });
 
 export function AppContainer(props: React.ComponentProps<typeof Container>) {
-  return <StyledAppContainer id="main-content" maxWidth={false} {...props} />;
+  return <StyledAppContainer id="main-content" tabIndex={-1} maxWidth={false} {...props} />;
 }

--- a/packages-internal/core-docs/src/Link/SkipLink.tsx
+++ b/packages-internal/core-docs/src/Link/SkipLink.tsx
@@ -57,5 +57,9 @@ const StyledLink = styled(MuiLink)(({ theme }) => ({
 export function SkipLink() {
   const t = useTranslate();
 
-  return <StyledLink href="#main-content">{t('appFrame.skipToContent')}</StyledLink>;
+  return (
+    <StyledLink href="#main-content" data-no-markdown-link="true">
+      {t('appFrame.skipToContent')}
+    </StyledLink>
+  );
 }

--- a/test/e2e-website/material-docs.spec.ts
+++ b/test/e2e-website/material-docs.spec.ts
@@ -23,6 +23,9 @@ test.describe('Material docs', () => {
     await page.goto('/material-ui/getting-started/installation/');
 
     await page.keyboard.press('Tab');
+
+    await expect(page.locator('a[href="#main-content"]')).toBeFocused();
+
     await page.keyboard.press('Enter');
 
     await expect(page.locator('#main-content')).toBeFocused();

--- a/test/e2e-website/material-docs.spec.ts
+++ b/test/e2e-website/material-docs.spec.ts
@@ -19,6 +19,15 @@ test.describe('Material docs', () => {
     );
   });
 
+  test('should move the focus to the main content with the skip link', async ({ page }) => {
+    await page.goto('/material-ui/getting-started/installation/');
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Enter');
+
+    await expect(page.locator('#main-content')).toBeFocused();
+  });
+
   test('[zh] should have correct link with hash in the TOC', async ({ page }) => {
     test.skip(
       (process.env.CIRCLE_BRANCH || '').startsWith('pull'),


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #48943

Activating "Skip to content" scrolled the page but left DOM focus where it was, so the next Tab went back through the announcement bar and the header. `MarkdownLinks` registers a document-level click handler that calls `preventDefault()` on every internal anchor and hands the URL to `Router.push`, and the skip link goes through it as well, so the browser never runs its own fragment navigation.

Opting the link out with `data-no-markdown-link` brings that back, and `#main-content` now carries `tabIndex={-1}` so it can receive focus.

Validation:

- `pnpm test:e2e-website:dev -g "skip link"`, which fails on master and passes here
- `pnpm eslint`, `pnpm typescript` and `pnpm prettier --check` on the touched files
