### PR TITLE
[test] Fail the regression run when a webfont does not load

### DIFF
--- a/test/regressions/index.jsx
+++ b/test/regressions/index.jsx
@@ -89,8 +89,13 @@ function App(props) {
   const isDev = computeIsDev(hash);
 
   // Using <link rel="stylesheet" /> does not apply the google Roboto font in chromium headless/headfull.
-  const [fontState, setFontState] = React.useState('pending');
+  const [fontState, setFontState] = React.useState({ status: 'pending', missing: [] });
   React.useEffect(() => {
+    // `active` fires when at least one family loads, so a partial failure would
+    // still render the missing families with fallback faces. Collect them and
+    // report the load as inactive instead.
+    const missing = [];
+
     webfontloader.load({
       google: {
         families: ['Roboto:300,400,500,700', 'Inter:300,400,500,600,700,800,900', 'Material+Icons'],
@@ -100,11 +105,14 @@ function App(props) {
         urls: ['https://use.fontawesome.com/releases/v5.14.0/css/all.css'],
       },
       timeout: 20000,
+      fontinactive: (family, fvd) => {
+        missing.push(`${family}:${fvd}`);
+      },
       active: () => {
-        setFontState('active');
+        setFontState({ status: missing.length === 0 ? 'active' : 'inactive', missing });
       },
       inactive: () => {
-        setFontState('inactive');
+        setFontState({ status: 'inactive', missing });
       },
     });
   }, []);
@@ -120,7 +128,7 @@ function App(props) {
 
   return (
     <React.Fragment>
-      {fontState === 'active' ? (
+      {fontState.status === 'active' ? (
         <Routes>
           {fixtures.map((fixture) => {
             const path = computePath(fixture);
@@ -155,7 +163,12 @@ function App(props) {
 
       {isDev ? (
         <div>
-          <div data-webfontloader={fontState}>webfontloader: {fontState}</div>
+          <div
+            data-webfontloader={fontState.status}
+            data-webfont-missing={fontState.missing.join(', ')}
+          >
+            webfontloader: {fontState.status}
+          </div>
           <p>
             Devtools can be enabled by appending <code>#dev</code> in the addressbar or disabled by
             appending <code>#no-dev</code>.

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -54,7 +54,19 @@ async function main() {
     // This should load shared resources such as fonts.
     await page.goto(`${baseUrl}#dev`, { waitUntil: 'networkidle0' });
     // If we still get flaky fonts after awaiting this try `document.fonts.ready`
-    await page.waitForSelector('[data-webfontloader="active"]', { state: 'attached' });
+    const fontStatus = await page.waitForSelector(
+      '[data-webfontloader]:not([data-webfontloader="pending"])',
+      { state: 'attached' },
+    );
+    const font = await fontStatus.evaluate((element) => ({
+      state: element.dataset.webfontloader,
+      missing: element.dataset.webfontMissing,
+    }));
+    // Screenshots taken with fallback faces look like a repo-wide text rendering
+    // change. Fail the run instead of publishing them.
+    if (font.state !== 'active') {
+      throw new Error(`Fonts failed to load. Missing: ${font.missing || 'all requested families'}`);
+    }
 
     // Simulate portrait mode for date pickers.
     // See `useIsLandscape`.


### PR DESCRIPTION
## Problem

The visual regression harness loads Roboto, Inter, Material Icons and Font Awesome over the network at runtime (`test/regressions/index.jsx`). It renders as soon as `webfontloader` reports `active`.

`active` fires when at least one family loads. A partial failure therefore passes the gate, and every demo that uses a missing family renders with a fallback face.

This happened on master. Argos build 50963 (commit f191551b69) reported 108 changed screenshots, all text rendering differences. Master auto-approves its own builds, so those screenshots became the baseline, and every PR built since reports the same 108 diffs.

## Change

- Collect each failed face with the `fontinactive` callback.
- Report the load as `inactive` when the list is not empty, so the harness gate does not open.
- Expose the failed faces as `data-webfont-missing`, and throw from the harness with the family names instead of timing out on a selector.

A font hiccup now fails the job instead of publishing a bad baseline.

## Verification

The vite dev server does not start on Node 24 locally (pre-existing rolldown parse error in `sinon@22.1.0`), so I drove `webfontloader@1.6.28` directly in headful Chromium with the same load config:

| Case | State | Missing |
| --- | --- | --- |
| All font hosts reachable | `active` | (none) |
| Google Fonts blocked, Font Awesome reachable | `inactive` | Roboto n3/n4/n5/n7, Inter n3-n9, Material Icons n4 |

The second row is the exact failure that produced the 108 diffs: Font Awesome loads, so `active` fires, and 12 faces silently fall back.

## Notes

The current baseline is still the bad one. It needs an Argos approval on an open PR to restore correct rendering.

Self-hosting the fonts (`@fontsource/*`, `@fortawesome/fontawesome-free`) would remove the network dependency entirely. That shifts the faces slightly and needs its own intentional baseline update, so it is not in this PR.

Generated with [Claude Code](https://claude.com/claude-code)
