### PR TITLE
[docs] Fix broken links reported by Ahrefs

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -24,6 +24,8 @@
 /r/custom-component-variants /material-ui/customization/how-to-customize/#adding-new-component-variants 302
 /r/migration-v4 /material-ui/migration/migration-v4/ 302
 /r/pigment /blog/introducing-pigment-css/ 302
+# The Discord server is closed, point the stale links to the support page.
+/r/discord /material-ui/getting-started/support/ 302
 
 # Legacy redirection
 # Added in chronological order (the last line is the most recent one)

--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -563,7 +563,7 @@ const rowHeaders: Record<string, React.ReactNode> = {
   ),
   // Scheduler - Event Timeline
   'scheduler/timeline-views': (
-    <ColumnHead label="Timeline views" href="/x/react-scheduler/event-timeline/views/" />
+    <ColumnHead label="Timeline views" href="/x/react-scheduler/event-timeline/presets/" />
   ),
   'scheduler/timeline-drag-and-drop': (
     <ColumnHead label="Drag & drop" href="/x/react-scheduler/event-timeline/drag-interactions/" />
@@ -587,7 +587,10 @@ const rowHeaders: Record<string, React.ReactNode> = {
     <ColumnHead label="Lazy loading" href="/x/react-scheduler/event-timeline/lazy-loading/" />
   ),
   'scheduler/timeline-zooming': (
-    <ColumnHead label="Zoom in/out" href="/x/react-scheduler/event-timeline/views/#zoom-in-out" />
+    <ColumnHead
+      label="Zoom in/out"
+      href="/x/react-scheduler/event-timeline/presets/#zoom-in-and-out"
+    />
   ),
   'scheduler/timeline-virtualization': (
     <ColumnHead label="Virtualization" href="/x/react-scheduler/event-timeline/virtualization/" />


### PR DESCRIPTION
Two broken internal links from the Ahrefs site audit:

- `/r/discord` 404s since #47858 removed it, but 56 links still point there and the `/r/*` namespace exists for links we cannot edit later (npm-published code, old issues). Redirect it to the support page.
- The pricing table links to `/x/react-scheduler/event-timeline/views/`, renamed to `.../presets/` in mui/mui-x#22130. The zoom anchor also changed to `#zoom-in-and-out`.