### PR TITLE
[website] Fix overline duplicating the h2 heading

### DIFF
--- a/packages-internal/core-docs/src/SectionHeadline/SectionHeadline.tsx
+++ b/packages-internal/core-docs/src/SectionHeadline/SectionHeadline.tsx
@@ -21,6 +21,7 @@ export default function SectionHeadline(props: SectionHeadlineProps) {
       {overline && (
         <Typography
           id={id}
+          component="div"
           variant="body2"
           sx={{
             fontWeight: 'bold',

--- a/packages-internal/core-docs/src/SectionHeadline/SectionHeadline.tsx
+++ b/packages-internal/core-docs/src/SectionHeadline/SectionHeadline.tsx
@@ -21,7 +21,6 @@ export default function SectionHeadline(props: SectionHeadlineProps) {
       {overline && (
         <Typography
           id={id}
-          component="h2"
           variant="body2"
           sx={{
             fontWeight: 'bold',


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The "Products" label above the homepage headline is meant to be a small eyebrow tag, but `SectionHeadline` hardcodes it to an `<h2>`, so the section ends up with two consecutive `<h2>` elements. Screen readers announce them as duplicate same-level headings, which breaks the page's heading outline (WCAG 1.3.1).

Removing the `component="h2"` override lets the label fall back to `Typography`'s default mapping for `body2`, which is `<p>`, so the section title stays the only heading. This affects every page that renders `SectionHeadline` with an overline, not just the homepage.

Fixes #48952