### PR TITLE
[pagination] Use compact layout when counts are zero

### DIFF
--- a/packages/mui-material/src/usePagination/usePagination.js
+++ b/packages/mui-material/src/usePagination/usePagination.js
@@ -66,33 +66,39 @@ export default function usePagination(props = {}) {
     count - boundaryCount - 1,
   );
 
+  // Start ellipsis
+  const startEllipsis = [];
+  if (siblingsStart > boundaryCount + 2) {
+    startEllipsis.push('start-ellipsis');
+  } else if (boundaryCount + 1 < count - boundaryCount) {
+    startEllipsis.push(boundaryCount + 1);
+  }
+
+  // End ellipsis
+  const endEllipsis = [];
+  if (siblingsEnd < count - boundaryCount - 1) {
+    endEllipsis.push('end-ellipsis');
+  } else if (count - boundaryCount > boundaryCount) {
+    endEllipsis.push(count - boundaryCount);
+  }
+
+  const body =
+    boundaryCount === 0 && siblingCount === 0
+      ? [page]
+      : [
+          ...startPages,
+          ...startEllipsis,
+          ...range(siblingsStart, siblingsEnd),
+          ...endEllipsis,
+          ...endPages,
+        ];
+
   // Basic list of items to render
   // for example itemList = ['first', 'previous', 1, 'ellipsis', 4, 5, 6, 'ellipsis', 10, 'next', 'last']
   const itemList = [
     ...(showFirstButton ? ['first'] : []),
     ...(hidePrevButton ? [] : ['previous']),
-    ...startPages,
-
-    // Start ellipsis
-    // eslint-disable-next-line no-nested-ternary
-    ...(siblingsStart > boundaryCount + 2
-      ? ['start-ellipsis']
-      : boundaryCount + 1 < count - boundaryCount
-        ? [boundaryCount + 1]
-        : []),
-
-    // Sibling pages
-    ...range(siblingsStart, siblingsEnd),
-
-    // End ellipsis
-    // eslint-disable-next-line no-nested-ternary
-    ...(siblingsEnd < count - boundaryCount - 1
-      ? ['end-ellipsis']
-      : count - boundaryCount > boundaryCount
-        ? [count - boundaryCount]
-        : []),
-
-    ...endPages,
+    ...body,
     ...(hideNextButton ? [] : ['next']),
     ...(showLastButton ? ['last'] : []),
   ];

--- a/packages/mui-material/src/usePagination/usePagination.js
+++ b/packages/mui-material/src/usePagination/usePagination.js
@@ -83,7 +83,7 @@ export default function usePagination(props = {}) {
   }
 
   const body =
-    boundaryCount === 0 && siblingCount === 0
+    count > 0 && boundaryCount === 0 && siblingCount === 0
       ? [page]
       : [
           ...startPages,

--- a/packages/mui-material/src/usePagination/usePagination.js
+++ b/packages/mui-material/src/usePagination/usePagination.js
@@ -83,7 +83,7 @@ export default function usePagination(props = {}) {
   }
 
   const body =
-    count > 0 && boundaryCount === 0 && siblingCount === 0
+    count > 0 && page >= 1 && page <= count && boundaryCount === 0 && siblingCount === 0
       ? [page]
       : [
           ...startPages,

--- a/packages/mui-material/src/usePagination/usePagination.test.js
+++ b/packages/mui-material/src/usePagination/usePagination.test.js
@@ -170,6 +170,43 @@ describe('usePagination', () => {
     expect(items[1]).to.have.property('disabled', true);
   });
 
+  it('does not render a stale uncontrolled page when count decreases', () => {
+    const result = React.createRef();
+
+    function TestCase({ count }) {
+      const hookResult = usePagination({
+        count,
+        defaultPage: 11,
+        boundaryCount: 0,
+        siblingCount: 0,
+      });
+      React.useEffect(() => {
+        result.current = hookResult;
+      }, [hookResult]);
+      return null;
+    }
+
+    const { rerender } = render(<TestCase count={11} />);
+    expect(serialize(result.current.items)).to.deep.equal(['previous', 11, 'next']);
+
+    rerender(<TestCase count={5} />);
+    expect(serialize(result.current.items)).to.deep.equal([
+      'previous',
+      'start-ellipsis',
+      4,
+      5,
+      'next',
+    ]);
+  });
+
+  it('does not render an out-of-range controlled page', () => {
+    const items = renderHook(() =>
+      usePagination({ count: 5, page: 0, boundaryCount: 0, siblingCount: 0 }),
+    ).result.current.items;
+
+    expect(serialize(items)).to.deep.equal(['previous', 1, 2, 'end-ellipsis', 'next']);
+  });
+
   it('should support boundaryCount={0}', () => {
     const items = renderHook(() =>
       usePagination({ count: 11, page: 6, boundaryCount: 0, siblingCount: 1 }),

--- a/packages/mui-material/src/usePagination/usePagination.test.js
+++ b/packages/mui-material/src/usePagination/usePagination.test.js
@@ -161,6 +161,15 @@ describe('usePagination', () => {
     });
   });
 
+  it('does not render a page when count is zero', () => {
+    const items = renderHook(() => usePagination({ count: 0, boundaryCount: 0, siblingCount: 0 }))
+      .result.current.items;
+
+    expect(serialize(items)).to.deep.equal(['previous', 'next']);
+    expect(items[0]).to.have.property('disabled', true);
+    expect(items[1]).to.have.property('disabled', true);
+  });
+
   it('should support boundaryCount={0}', () => {
     const items = renderHook(() =>
       usePagination({ count: 11, page: 6, boundaryCount: 0, siblingCount: 1 }),

--- a/packages/mui-material/src/usePagination/usePagination.test.js
+++ b/packages/mui-material/src/usePagination/usePagination.test.js
@@ -151,23 +151,21 @@ describe('usePagination', () => {
     expect(items[9]).to.have.property('page', 11);
   });
 
+  it('uses a compact layout when boundaryCount and siblingCount are zero', () => {
+    [1, 6, 11].forEach((page) => {
+      const items = renderHook(() =>
+        usePagination({ count: 11, page, boundaryCount: 0, siblingCount: 0 }),
+      ).result.current.items;
+
+      expect(serialize(items)).to.deep.equal(['previous', page, 'next']);
+    });
+  });
+
   it('should support boundaryCount={0}', () => {
-    let items;
-
-    items = renderHook(() =>
-      usePagination({ count: 11, page: 6, boundaryCount: 0, siblingCount: 0 }),
-    ).result.current.items;
-    expect(serialize(items)).to.deep.equal([
-      'previous',
-      'start-ellipsis',
-      6,
-      'end-ellipsis',
-      'next',
-    ]);
-
-    items = renderHook(() =>
+    const items = renderHook(() =>
       usePagination({ count: 11, page: 6, boundaryCount: 0, siblingCount: 1 }),
     ).result.current.items;
+
     expect(serialize(items)).to.deep.equal([
       'previous',
       'start-ellipsis',


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Summary

- render only the current page between navigation buttons when both `boundaryCount` and `siblingCount` are zero
- preserve the existing range for zero-count and out-of-range pages, including when an uncontrolled count decreases
- cover first, middle, last, zero-count, stale uncontrolled, and out-of-range controlled pages with regression tests

Fixes #24749

## Test plan

- `pnpm test:unit usePagination` (40 passed)
- `pnpm test:unit Pagination` (320 passed, 21 skipped)
- `pnpm -F @mui/material typescript`
- targeted ESLint and Prettier checks for both changed files
- `git diff --check origin/master...HEAD`

## Additional validation

- The full Node package run completed 4,687 tests with 740 skipped; one unrelated `Select` pointer-timing assertion failed and then passed on a focused rerun.
- The full browser package run encountered unrelated dynamic-import and iframe connection failures; all affected files passed a focused rerun (279 passed, 43 skipped).
- The package build transpiled all 656 ESM and 656 CommonJS files. Declaration emission requires prebuilt workspace dependencies in this checkout; the package-level TypeScript check passed.
