### PR TITLE
[website] Fix WCAG criteria for code copy button

### DIFF
--- a/packages-internal/core-docs/src/AppLayout/components/NpmCopyButton.tsx
+++ b/packages-internal/core-docs/src/AppLayout/components/NpmCopyButton.tsx
@@ -1,46 +1,44 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
 import copy from 'clipboard-copy';
+import { visuallyHidden } from '@mui/utils';
 import type { SxProps } from '@mui/system';
 import { styled, alpha, type Theme } from '@mui/material/styles';
 import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded';
 import CheckRounded from '@mui/icons-material/CheckRounded';
 
-const Button = styled('button')(({ theme }) => ({
+const Root = styled('span')(({ theme }) => ({
   boxSizing: 'border-box',
   minWidth: 64,
   margin: 0,
   marginTop: 16,
-  cursor: 'copy',
-  padding: 0,
   position: 'relative',
   display: 'inline-flex',
   alignItems: 'flex-start',
   justifyContent: 'center',
   verticalAlign: 'middle',
   gap: 8,
-  outline: 0,
-  border: 0,
-  boxShadow: 'none',
-  backgroundColor: 'transparent',
   fontFamily: theme.typography.fontFamilyCode,
   fontSize: theme.typography.pxToRem(12),
-  textDecoration: 'none',
-  textTransform: 'initial',
   lineHeight: 1.5,
   letterSpacing: 0,
   transition: theme.transitions.create('color', {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.shortest,
   }),
-  WebkitTapHighlightColor: 'transparent',
   WebkitFontSmoothing: 'subpixel-antialiased',
   color: (theme.vars || theme).palette.text.tertiary,
-  '&:hover, &:focus-visible': {
+  '& code': {
+    fontFamily: 'inherit',
+  },
+  '&:hover': {
     color: (theme.vars || theme).palette.primary.main,
     '@media (hover: none)': {
       color: (theme.vars || theme).palette.text.tertiary,
     },
+  },
+  '&:focus-within': {
+    color: (theme.vars || theme).palette.primary.main,
   },
   '& svg': {
     display: 'inline-block',
@@ -53,23 +51,30 @@ const Button = styled('button')(({ theme }) => ({
       duration: theme.transitions.duration.shortest,
     }),
   },
-  '&:focus, &:hover svg': {
+  '&:hover svg, &:focus-within svg': {
     opacity: 1,
   },
+}));
+
+const CopyButton = styled('button')(({ theme }) => ({
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  margin: 0,
+  padding: 0,
+  border: 0,
+  outline: 0,
+  boxShadow: 'none',
+  backgroundColor: 'transparent',
+  cursor: 'copy',
+  WebkitTapHighlightColor: 'transparent',
   '&:focus-visible': {
     outline: `3px solid ${alpha(theme.palette.primary[500], 0.5)}`,
     outlineOffset: '2px',
   },
 }));
-
-const LiveRegion = styled('span')({
-  position: 'absolute',
-  width: 1,
-  height: 1,
-  overflow: 'hidden',
-  clip: 'rect(0 0 0 0)',
-  whiteSpace: 'nowrap',
-});
 
 export function NpmCopyButton(
   props: React.HTMLAttributes<HTMLButtonElement> & { installation: string; sx?: SxProps<Theme> },
@@ -83,23 +88,26 @@ export function NpmCopyButton(
     });
   };
   return (
-    <Button
-      aria-label="Copy installation command"
-      onClick={(event: any) => {
-        handleCopy();
-        onClick?.(event);
-      }}
-      {...other}
-    >
+    <Root sx={sx}>
       <code>$ {installation}</code>
-      {copied ? (
-        <CheckRounded color="inherit" sx={{ fontSize: 15 }} aria-hidden />
-      ) : (
-        <ContentCopyRounded color="inherit" sx={{ fontSize: 15 }} aria-hidden />
-      )}
-      <LiveRegion role="status" aria-live="polite">
+      <CopyButton
+        type="button"
+        onClick={(event: any) => {
+          handleCopy();
+          onClick?.(event);
+        }}
+        {...other}
+      >
+        <span style={visuallyHidden}>Copy Material UI installation command</span>
+        {copied ? (
+          <CheckRounded color="inherit" sx={{ fontSize: 15 }} />
+        ) : (
+          <ContentCopyRounded color="inherit" sx={{ fontSize: 15 }} />
+        )}
+      </CopyButton>
+      <span style={visuallyHidden} role="status" aria-live="polite">
         {copied ? 'Copied command to clipboard' : ''}
-      </LiveRegion>
-    </Button>
+      </span>
+    </Root>
   );
 }

--- a/packages-internal/core-docs/src/AppLayout/components/NpmCopyButton.tsx
+++ b/packages-internal/core-docs/src/AppLayout/components/NpmCopyButton.tsx
@@ -62,6 +62,15 @@ const Button = styled('button')(({ theme }) => ({
   },
 }));
 
+const LiveRegion = styled('span')({
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+});
+
 export function NpmCopyButton(
   props: React.HTMLAttributes<HTMLButtonElement> & { installation: string; sx?: SxProps<Theme> },
 ) {
@@ -75,18 +84,22 @@ export function NpmCopyButton(
   };
   return (
     <Button
+      aria-label="Copy installation command"
       onClick={(event: any) => {
         handleCopy();
         onClick?.(event);
       }}
       {...other}
     >
-      $ {installation}
+      <code>$ {installation}</code>
       {copied ? (
-        <CheckRounded color="inherit" sx={{ fontSize: 15 }} />
+        <CheckRounded color="inherit" sx={{ fontSize: 15 }} aria-hidden />
       ) : (
-        <ContentCopyRounded color="inherit" sx={{ fontSize: 15 }} />
+        <ContentCopyRounded color="inherit" sx={{ fontSize: 15 }} aria-hidden />
       )}
+      <LiveRegion role="status" aria-live="polite">
+        {copied ? 'Copied command to clipboard' : ''}
+      </LiveRegion>
     </Button>
   );
 }


### PR DESCRIPTION
## Fixes #48957

### Changes

1. **Accessible name**: Added `aria-label="Copy installation command"` to override the command text as the button's accessible name, fixing WCAG 2.5.3 Label in Name (Level A). Voice control can now target "Click Copy installation command".
2. **Semantic code element**: Wrapped the installation command text in `<code>`, fixing WCAG 1.3.1 Info and Relationships (Level A).
3. **Live region feedback**: Added `role="status"` + `aria-live="polite"` region that announces "Copied command to clipboard" when the copy action completes, fixing WCAG 4.1.3 Status Messages (Level AA).
4. **Decorative icons**: Added `aria-hidden` to the copy/check icons so they are not announced by screen readers.

### Verification

- NVDA + keyboard: button now has clear accessible name "Copy installation command"
- After activation, screen reader announces "Copied command to clipboard"
- Visual appearance unchanged

-----

Before: https://mui.com/material-ui/
After: https://deploy-preview-48963--material-ui.netlify.app/material-ui/