### PR TITLE
[docs][table] Use and document the row header cells

### DIFF
--- a/docs/data/material/components/table/ColumnGroupingTable.js
+++ b/docs/data/material/components/table/ColumnGroupingTable.js
@@ -104,7 +104,12 @@ export default function ColumnGroupingTable() {
                     {columns.map((column) => {
                       const value = row[column.id];
                       return (
-                        <TableCell key={column.id} align={column.align}>
+                        <TableCell
+                          key={column.id}
+                          component={column.id === 'name' ? 'th' : 'td'}
+                          scope={column.id === 'name' ? 'row' : undefined}
+                          align={column.align}
+                        >
                           {column.format && typeof value === 'number'
                             ? column.format(value)
                             : value}

--- a/docs/data/material/components/table/ColumnGroupingTable.js
+++ b/docs/data/material/components/table/ColumnGroupingTable.js
@@ -100,7 +100,7 @@ export default function ColumnGroupingTable() {
               .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
               .map((row) => {
                 return (
-                  <TableRow hover role="checkbox" tabIndex={-1} key={row.code}>
+                  <TableRow hover key={row.code}>
                     {columns.map((column) => {
                       const value = row[column.id];
                       return (

--- a/docs/data/material/components/table/ColumnGroupingTable.tsx
+++ b/docs/data/material/components/table/ColumnGroupingTable.tsx
@@ -121,7 +121,7 @@ export default function ColumnGroupingTable() {
               .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
               .map((row) => {
                 return (
-                  <TableRow hover role="checkbox" tabIndex={-1} key={row.code}>
+                  <TableRow hover key={row.code}>
                     {columns.map((column) => {
                       const value = row[column.id];
                       return (

--- a/docs/data/material/components/table/ColumnGroupingTable.tsx
+++ b/docs/data/material/components/table/ColumnGroupingTable.tsx
@@ -125,7 +125,12 @@ export default function ColumnGroupingTable() {
                     {columns.map((column) => {
                       const value = row[column.id];
                       return (
-                        <TableCell key={column.id} align={column.align}>
+                        <TableCell
+                          key={column.id}
+                          component={column.id === 'name' ? 'th' : 'td'}
+                          scope={column.id === 'name' ? 'row' : undefined}
+                          align={column.align}
+                        >
                           {column.format && typeof value === 'number'
                             ? column.format(value)
                             : value}

--- a/docs/data/material/components/table/DataTable.js
+++ b/docs/data/material/components/table/DataTable.js
@@ -1,4 +1,4 @@
-import { DataGrid } from '@mui/x-data-grid';
+import { DataGrid, GridCell } from '@mui/x-data-grid';
 import Paper from '@mui/material/Paper';
 
 const columns = [
@@ -35,6 +35,15 @@ const rows = [
 
 const paginationModel = { page: 0, pageSize: 5 };
 
+function renderRowHeaderCell(props) {
+  return (
+    <GridCell
+      {...props}
+      role={props.column.field === 'fullName' ? 'rowheader' : 'gridcell'}
+    />
+  );
+}
+
 export default function DataTable() {
   return (
     <Paper sx={{ height: 400, width: '100%' }}>
@@ -44,6 +53,7 @@ export default function DataTable() {
         initialState={{ pagination: { paginationModel } }}
         pageSizeOptions={[5, 10]}
         checkboxSelection
+        slots={{ cell: renderRowHeaderCell }}
         sx={{ border: 0 }}
       />
     </Paper>

--- a/docs/data/material/components/table/DataTable.tsx
+++ b/docs/data/material/components/table/DataTable.tsx
@@ -1,4 +1,9 @@
-import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import {
+  DataGrid,
+  GridCell,
+  type GridCellProps,
+  type GridColDef,
+} from '@mui/x-data-grid';
 import Paper from '@mui/material/Paper';
 
 const columns: GridColDef[] = [
@@ -35,6 +40,15 @@ const rows = [
 
 const paginationModel = { page: 0, pageSize: 5 };
 
+function renderRowHeaderCell(props: GridCellProps) {
+  return (
+    <GridCell
+      {...props}
+      role={props.column.field === 'fullName' ? 'rowheader' : 'gridcell'}
+    />
+  );
+}
+
 export default function DataTable() {
   return (
     <Paper sx={{ height: 400, width: '100%' }}>
@@ -44,6 +58,7 @@ export default function DataTable() {
         initialState={{ pagination: { paginationModel } }}
         pageSizeOptions={[5, 10]}
         checkboxSelection
+        slots={{ cell: renderRowHeaderCell }}
         sx={{ border: 0 }}
       />
     </Paper>

--- a/docs/data/material/components/table/DataTable.tsx.preview
+++ b/docs/data/material/components/table/DataTable.tsx.preview
@@ -5,6 +5,7 @@
     initialState={{ pagination: { paginationModel } }}
     pageSizeOptions={[5, 10]}
     checkboxSelection
+    slots={{ cell: renderRowHeaderCell }}
     sx={{ border: 0 }}
   />
 </Paper>

--- a/docs/data/material/components/table/ReactVirtualizedTable.js
+++ b/docs/data/material/components/table/ReactVirtualizedTable.js
@@ -89,6 +89,8 @@ function rowContent(_index, row) {
       {columns.map((column) => (
         <TableCell
           key={column.dataKey}
+          component={column.dataKey === 'firstName' ? 'th' : 'td'}
+          scope={column.dataKey === 'firstName' ? 'row' : undefined}
           align={column.numeric || false ? 'right' : 'left'}
         >
           {row[column.dataKey]}

--- a/docs/data/material/components/table/ReactVirtualizedTable.tsx
+++ b/docs/data/material/components/table/ReactVirtualizedTable.tsx
@@ -109,6 +109,8 @@ function rowContent(_index: number, row: Data) {
       {columns.map((column) => (
         <TableCell
           key={column.dataKey}
+          component={column.dataKey === 'firstName' ? 'th' : 'td'}
+          scope={column.dataKey === 'firstName' ? 'row' : undefined}
           align={column.numeric || false ? 'right' : 'left'}
         >
           {row[column.dataKey]}

--- a/docs/data/material/components/table/SpanningTable.js
+++ b/docs/data/material/components/table/SpanningTable.js
@@ -56,7 +56,9 @@ export default function SpanningTable() {
         <TableBody>
           {rows.map((row) => (
             <TableRow key={row.desc}>
-              <TableCell>{row.desc}</TableCell>
+              <TableCell component="th" scope="row">
+                {row.desc}
+              </TableCell>
               <TableCell align="right">{row.qty}</TableCell>
               <TableCell align="right">{row.unit}</TableCell>
               <TableCell align="right">{ccyFormat(row.price)}</TableCell>
@@ -64,16 +66,22 @@ export default function SpanningTable() {
           ))}
           <TableRow>
             <TableCell rowSpan={3} />
-            <TableCell colSpan={2}>Subtotal</TableCell>
+            <TableCell component="th" scope="row" colSpan={2}>
+              Subtotal
+            </TableCell>
             <TableCell align="right">{ccyFormat(invoiceSubtotal)}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell>Tax</TableCell>
+            <TableCell component="th" scope="row">
+              Tax
+            </TableCell>
             <TableCell align="right">{`${(TAX_RATE * 100).toFixed(0)} %`}</TableCell>
             <TableCell align="right">{ccyFormat(invoiceTaxes)}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell colSpan={2}>Total</TableCell>
+            <TableCell component="th" scope="row" colSpan={2}>
+              Total
+            </TableCell>
             <TableCell align="right">{ccyFormat(invoiceTotal)}</TableCell>
           </TableRow>
         </TableBody>

--- a/docs/data/material/components/table/SpanningTable.tsx
+++ b/docs/data/material/components/table/SpanningTable.tsx
@@ -63,7 +63,9 @@ export default function SpanningTable() {
         <TableBody>
           {rows.map((row) => (
             <TableRow key={row.desc}>
-              <TableCell>{row.desc}</TableCell>
+              <TableCell component="th" scope="row">
+                {row.desc}
+              </TableCell>
               <TableCell align="right">{row.qty}</TableCell>
               <TableCell align="right">{row.unit}</TableCell>
               <TableCell align="right">{ccyFormat(row.price)}</TableCell>
@@ -71,16 +73,22 @@ export default function SpanningTable() {
           ))}
           <TableRow>
             <TableCell rowSpan={3} />
-            <TableCell colSpan={2}>Subtotal</TableCell>
+            <TableCell component="th" scope="row" colSpan={2}>
+              Subtotal
+            </TableCell>
             <TableCell align="right">{ccyFormat(invoiceSubtotal)}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell>Tax</TableCell>
+            <TableCell component="th" scope="row">
+              Tax
+            </TableCell>
             <TableCell align="right">{`${(TAX_RATE * 100).toFixed(0)} %`}</TableCell>
             <TableCell align="right">{ccyFormat(invoiceTaxes)}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell colSpan={2}>Total</TableCell>
+            <TableCell component="th" scope="row" colSpan={2}>
+              Total
+            </TableCell>
             <TableCell align="right">{ccyFormat(invoiceTotal)}</TableCell>
           </TableRow>
         </TableBody>

--- a/docs/data/material/components/table/StickyHeadTable.js
+++ b/docs/data/material/components/table/StickyHeadTable.js
@@ -96,7 +96,12 @@ export default function StickyHeadTable() {
                     {columns.map((column) => {
                       const value = row[column.id];
                       return (
-                        <TableCell key={column.id} align={column.align}>
+                        <TableCell
+                          key={column.id}
+                          component={column.id === 'name' ? 'th' : 'td'}
+                          scope={column.id === 'name' ? 'row' : undefined}
+                          align={column.align}
+                        >
                           {column.format && typeof value === 'number'
                             ? column.format(value)
                             : value}

--- a/docs/data/material/components/table/StickyHeadTable.js
+++ b/docs/data/material/components/table/StickyHeadTable.js
@@ -92,7 +92,7 @@ export default function StickyHeadTable() {
               .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
               .map((row) => {
                 return (
-                  <TableRow hover role="checkbox" tabIndex={-1} key={row.code}>
+                  <TableRow hover key={row.code}>
                     {columns.map((column) => {
                       const value = row[column.id];
                       return (

--- a/docs/data/material/components/table/StickyHeadTable.tsx
+++ b/docs/data/material/components/table/StickyHeadTable.tsx
@@ -113,7 +113,7 @@ export default function StickyHeadTable() {
               .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
               .map((row) => {
                 return (
-                  <TableRow hover role="checkbox" tabIndex={-1} key={row.code}>
+                  <TableRow hover key={row.code}>
                     {columns.map((column) => {
                       const value = row[column.id];
                       return (

--- a/docs/data/material/components/table/StickyHeadTable.tsx
+++ b/docs/data/material/components/table/StickyHeadTable.tsx
@@ -117,7 +117,12 @@ export default function StickyHeadTable() {
                     {columns.map((column) => {
                       const value = row[column.id];
                       return (
-                        <TableCell key={column.id} align={column.align}>
+                        <TableCell
+                          key={column.id}
+                          component={column.id === 'name' ? 'th' : 'td'}
+                          scope={column.id === 'name' ? 'row' : undefined}
+                          align={column.align}
+                        >
                           {column.format && typeof value === 'number'
                             ? column.format(value)
                             : value}

--- a/docs/data/material/components/table/table.md
+++ b/docs/data/material/components/table/table.md
@@ -139,6 +139,28 @@ Virtualization helps with performance issues.
 
 (WAI tutorial: <https://www.w3.org/WAI/tutorials/tables/>)
 
+### Row and column headers
+
+Header cells identify the data in each row or column.
+Screen readers use these associations to provide context as users navigate the table.
+
+`TableCell` renders as a `<th>` automatically when it is placed inside a `TableHead`, but it renders as a `<td>` inside a `TableBody`.
+When a body cell contains the label that identifies its row, render it as a row header with `component="th"` and `scope="row"`:
+
+```jsx
+<TableRow>
+  <TableCell component="th" scope="row">
+    {row.name}
+  </TableCell>
+  <TableCell>{row.calories}</TableCell>
+</TableRow>
+```
+
+Choose a meaningful value for the row header, such as a person's name or a product name, rather than an arbitrary index. Multiple cells could be marked as row headers, for example when the table contains both first name and last name columns.
+
+The Data Grid uses ARIA roles instead of native table elements.
+See the [Data Grid row headers guide](/x/react-data-grid/accessibility/#row-headers) to learn how to identify its row header columns.
+
 ### Caption
 
 A caption functions like a heading for a table. Most screen readers announce the content of captions. Captions help users to find a table and understand what it's about and decide if they want to read it.

--- a/docs/data/material/components/table/table.md
+++ b/docs/data/material/components/table/table.md
@@ -158,9 +158,6 @@ When a body cell contains the label that identifies its row, render it as a row 
 
 Choose a meaningful value for the row header, such as a person's name or a product name, rather than an arbitrary index. Multiple cells could be marked as row headers, for example when the table contains both first name and last name columns.
 
-The Data Grid uses ARIA roles instead of native table elements.
-See the [Data Grid row headers guide](/x/react-data-grid/accessibility/#row-headers) to learn how to identify its row header columns.
-
 ### Caption
 
 A caption functions like a heading for a table. Most screen readers announce the content of captions. Captions help users to find a table and understand what it's about and decide if they want to read it.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Improves row-header semantics across the Table documentation demos by rendering cells that identify rows as <th scope="row">.
Also adds guidance explaining when and why to use row headers, and updates the embedded Data Grid demo with equivalent rowheader semantics.