### PR TITLE
[website] Remove unnecessary usage of sx prop

### DIFF
--- a/docs/src/components/home/GetStartedButtons.tsx
+++ b/docs/src/components/home/GetStartedButtons.tsx
@@ -101,7 +101,7 @@ export default function GetStartedButtons(props: GetStartedButtonsProps) {
           </Button>
         ) : null}
       </Box>
-      {altInstallation && <NpmCopyButton installation={altInstallation} />}
+      {altInstallation && <NpmCopyButton installation={altInstallation} sx={{ mt: 2 }} />}
     </React.Fragment>
   );
 }

--- a/docs/src/components/home/GetStartedButtons.tsx
+++ b/docs/src/components/home/GetStartedButtons.tsx
@@ -101,7 +101,7 @@ export default function GetStartedButtons(props: GetStartedButtonsProps) {
           </Button>
         ) : null}
       </Box>
-      {altInstallation && <NpmCopyButton installation={altInstallation} sx={{ mt: 2 }} />}
+      {altInstallation && <NpmCopyButton installation={altInstallation} />}
     </React.Fragment>
   );
 }

--- a/packages-internal/core-docs/src/AppLayout/components/NpmCopyButton.tsx
+++ b/packages-internal/core-docs/src/AppLayout/components/NpmCopyButton.tsx
@@ -77,9 +77,9 @@ const CopyButton = styled('button')(({ theme }) => ({
 }));
 
 export function NpmCopyButton(
-  props: React.HTMLAttributes<HTMLButtonElement> & { installation: string; sx?: SxProps<Theme> },
+  props: React.HTMLAttributes<HTMLButtonElement> & { installation: string },
 ) {
-  const { installation, onClick, sx, ...other } = props;
+  const { installation, onClick, ...other } = props;
   const [copied, setCopied] = React.useState(false);
   const handleCopy = () => {
     setCopied(true);
@@ -88,7 +88,7 @@ export function NpmCopyButton(
     });
   };
   return (
-    <Root sx={sx}>
+    <Root>
       <code>$ {installation}</code>
       <CopyButton
         type="button"

--- a/packages-internal/core-docs/src/AppLayout/components/NpmCopyButton.tsx
+++ b/packages-internal/core-docs/src/AppLayout/components/NpmCopyButton.tsx
@@ -2,8 +2,7 @@
 import * as React from 'react';
 import copy from 'clipboard-copy';
 import { visuallyHidden } from '@mui/utils';
-import type { SxProps } from '@mui/system';
-import { styled, alpha, type Theme } from '@mui/material/styles';
+import { styled, alpha } from '@mui/material/styles';
 import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded';
 import CheckRounded from '@mui/icons-material/CheckRounded';
 
@@ -77,9 +76,9 @@ const CopyButton = styled('button')(({ theme }) => ({
 }));
 
 export function NpmCopyButton(
-  props: React.HTMLAttributes<HTMLButtonElement> & { installation: string; sx?: SxProps<Theme> },
+  props: React.HTMLAttributes<HTMLButtonElement> & { installation: string },
 ) {
-  const { installation, onClick, sx, ...other } = props;
+  const { installation, onClick, ...other } = props;
   const [copied, setCopied] = React.useState(false);
   const handleCopy = () => {
     setCopied(true);
@@ -88,7 +87,7 @@ export function NpmCopyButton(
     });
   };
   return (
-    <Root sx={sx}>
+    <Root>
       <code>$ {installation}</code>
       <CopyButton
         type="button"

--- a/packages-internal/core-docs/src/AppLayout/components/NpmCopyButton.tsx
+++ b/packages-internal/core-docs/src/AppLayout/components/NpmCopyButton.tsx
@@ -2,7 +2,8 @@
 import * as React from 'react';
 import copy from 'clipboard-copy';
 import { visuallyHidden } from '@mui/utils';
-import { styled, alpha } from '@mui/material/styles';
+import type { SxProps } from '@mui/system';
+import { styled, alpha, type Theme } from '@mui/material/styles';
 import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded';
 import CheckRounded from '@mui/icons-material/CheckRounded';
 
@@ -76,9 +77,9 @@ const CopyButton = styled('button')(({ theme }) => ({
 }));
 
 export function NpmCopyButton(
-  props: React.HTMLAttributes<HTMLButtonElement> & { installation: string },
+  props: React.HTMLAttributes<HTMLButtonElement> & { installation: string; sx?: SxProps<Theme> },
 ) {
-  const { installation, onClick, ...other } = props;
+  const { installation, onClick, sx, ...other } = props;
   const [copied, setCopied] = React.useState(false);
   const handleCopy = () => {
     setCopied(true);
@@ -87,7 +88,7 @@ export function NpmCopyButton(
     });
   };
   return (
-    <Root>
+    <Root sx={sx}>
       <code>$ {installation}</code>
       <CopyButton
         type="button"

--- a/packages-internal/core-docs/src/AppLayout/components/NpmCopyButton.tsx
+++ b/packages-internal/core-docs/src/AppLayout/components/NpmCopyButton.tsx
@@ -2,8 +2,7 @@
 import * as React from 'react';
 import copy from 'clipboard-copy';
 import { visuallyHidden } from '@mui/utils';
-import type { SxProps } from '@mui/system';
-import { styled, alpha, type Theme } from '@mui/material/styles';
+import { styled, alpha } from '@mui/material/styles';
 import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded';
 import CheckRounded from '@mui/icons-material/CheckRounded';
 


### PR DESCRIPTION
Noticed in #48963 that the `sx` prop supplied in https://github.com/mui/material-ui/blob/master/docs/src/components/home/GetStartedButtons.tsx#L104 is redundant because Root already has `marginTop: 16` applied to it via the `styled` API. 
`NpmCopyButton` component is not used anywhere else.