### PR TITLE
[docs] Fix screen reader row count in collapsible table demo

### DIFF
--- a/docs/data/material/components/table/CollapsibleTable.js
+++ b/docs/data/material/components/table/CollapsibleTable.js
@@ -61,7 +61,7 @@ function Row(props) {
         <TableCell align="right">{row.carbs}</TableCell>
         <TableCell align="right">{row.protein}</TableCell>
       </TableRow>
-      <TableRow>
+      <TableRow aria-hidden={!open}>
         <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={6}>
           <Collapse in={open} timeout="auto" unmountOnExit>
             <Box sx={{ margin: 1 }}>

--- a/docs/data/material/components/table/CollapsibleTable.tsx
+++ b/docs/data/material/components/table/CollapsibleTable.tsx
@@ -67,7 +67,7 @@ function Row(props: { row: ReturnType<typeof createData> }) {
         <TableCell align="right">{row.carbs}</TableCell>
         <TableCell align="right">{row.protein}</TableCell>
       </TableRow>
-      <TableRow>
+      <TableRow aria-hidden={!open}>
         <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={6}>
           <Collapse in={open} timeout="auto" unmountOnExit>
             <Box sx={{ margin: 1 }}>


### PR DESCRIPTION
Fixes #48960.

**Problem:** In the [collapsible table demo](https://mui.com/material-ui/react-table/#collapsible-table), screen readers announce **11 rows** when all rows are collapsed. Each data row renders an extra wrapper `<TableRow>` that hosts the `<Collapse>` content, and these wrappers stay in the DOM (1 header + 5 data rows + 5 empty wrapper rows).

**Fix:** Add `aria-hidden={!open}` to the wrapper row, removing it from the accessibility tree while collapsed. The collapsed content already unmounts via `unmountOnExit`, so this only hides the empty wrapper — no visual or behavioral change, and the expand/collapse animation is preserved. Expanded content remains fully accessible to screen readers.

**Result:** VoiceOver now reports 6 rows (1 header + 5 data rows), matching the visual table.