### PR TITLE
[test] Fix typo 'overriden' -> 'overridden' in Alert test comment

### DIFF
--- a/packages/mui-material/src/Alert/Alert.test.js
+++ b/packages/mui-material/src/Alert/Alert.test.js
@@ -234,7 +234,7 @@ describe('<Alert />', () => {
 
       expect(screen.queryByTestId('SuccessOutlinedIcon')).not.to.equal(null);
       expect(screen.queryByTestId('InfoOutlinedIcon')).not.to.equal(null);
-      // overriden icon in theme
+      // overridden icon in theme
       expect(screen.queryByTestId('AlarmIcon')).not.to.equal(null);
       expect(screen.queryByTestId('ErrorOutlineIcon')).not.to.equal(null);
       // default warning icon


### PR DESCRIPTION
## Problem

`packages/mui-material/src/Alert/Alert.test.js` line 237 contains a comment with a typo:

```js
// overriden icon in theme
```

`overriden` should be `overridden`. A previous PR (#48785) fixed this same typo in CHANGELOG.md, but this occurrence in the Alert test file was left behind — it is the only remaining `overriden` in the repo.

```bash
$ grep -rn "overriden" packages/ docs/ --include="*.js" --include="*.tsx" --include="*.ts"
packages/mui-material/src/Alert/Alert.test.js:237:      // overriden icon in theme
```

## Solution

One-word comment fix, no runtime behavior change.

Co-authored-by: FirmamentalSpring <287222957+FirmaSpring@users.noreply.github.com>
