### PR TITLE
[material-ui][Select] Prevent opening mouseup auto-selection

### DIFF
--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -260,6 +260,7 @@ describe('<Select />', () => {
         await sleep(450);
       });
 
+      await user.pointer({ target: screen.getByRole('option', { name: 'Ten' }) });
       await user.pointer({
         keys: '[/MouseLeft]',
         target: screen.getByRole('option', { name: 'Ten' }),
@@ -268,6 +269,33 @@ describe('<Select />', () => {
       expect(onClose.callCount).to.equal(1);
       expect(trigger).to.have.text('Ten');
       expect(screen.queryByRole('listbox', { hidden: false })).to.equal(null);
+    });
+
+    it('does not select an option when the opening mouseup lands on it after the drag delay without moving', async () => {
+      const onChange = spy();
+      const { user } = render(
+        <Select defaultValue={10} onChange={onChange}>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+      await user.pointer({ keys: '[MouseLeft>]', target: trigger });
+
+      await act(async () => {
+        await sleep(450);
+      });
+
+      await user.pointer({
+        keys: '[/MouseLeft]',
+        target: screen.getByRole('option', { name: 'Twenty' }),
+      });
+
+      expect(trigger).to.have.text('Ten');
+      expect(onChange.callCount).to.equal(0);
+      expect(screen.queryByRole('listbox', { hidden: false })).not.to.equal(null);
     });
 
     it('selects an option when dragging from the trigger and releasing after the drag delay', async () => {
@@ -286,6 +314,7 @@ describe('<Select />', () => {
       await act(async () => {
         await sleep(250);
       });
+      await user.pointer({ target: screen.getByRole('option', { name: 'Twenty' }) });
       await user.pointer({
         keys: '[/MouseLeft]',
         target: screen.getByRole('option', { name: 'Twenty' }),
@@ -335,6 +364,7 @@ describe('<Select />', () => {
       await act(async () => {
         await sleep(250);
       });
+      await user.pointer({ target: screen.getByRole('option', { name: 'Twenty' }) });
       await user.pointer({
         keys: '[/MouseLeft]',
         target: screen.getByRole('option', { name: 'Twenty' }),

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -193,6 +193,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   const hasSelectedItemInListRef = React.useRef(false);
   const openingMouseUpListenerCleanupRef = React.useRef(null);
   const didPointerDownOnItemRef = React.useRef(false);
+  const didPointerMoveToItemRef = React.useRef(false);
   const selectionRef = React.useRef({
     allowSelectedMouseUp: false,
     allowUnselectedMouseUp: false,
@@ -257,6 +258,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   const resetMouseUpSelection = React.useCallback(() => {
     clearSelectionTimers();
     didPointerDownOnItemRef.current = false;
+    didPointerMoveToItemRef.current = false;
     selectionRef.current = {
       allowSelectedMouseUp: false,
       allowUnselectedMouseUp: false,
@@ -527,6 +529,10 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       return;
     }
 
+    if (!didPointerMoveToItemRef.current) {
+      return;
+    }
+
     const disallowSelectedMouseUp = !selectionRef.current.allowSelectedMouseUp && selected;
     const disallowUnselectedMouseUp = !selectionRef.current.allowUnselectedMouseUp && !selected;
 
@@ -719,6 +725,14 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       onPointerDown: (event) => {
         didPointerDownOnItemRef.current = true;
         child.props.onPointerDown?.(event);
+      },
+      onMouseMove: (event) => {
+        didPointerMoveToItemRef.current = true;
+        child.props.onMouseMove?.(event);
+      },
+      onPointerMove: (event) => {
+        didPointerMoveToItemRef.current = true;
+        child.props.onPointerMove?.(event);
       },
       onClick: handleItemClick(child),
       onMouseUp: handleItemMouseUp(child, selected),


### PR DESCRIPTION
## Summary

Closes #48956.

Prevent Select from using the opening mouseup to choose an option unless the pointer actually moved into the item. This keeps a delayed touchpad release from selecting the option that appears under the cursor, while preserving drag-to-select.

## Tests

Added Select pointer regression coverage for a delayed mouseup without movement.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
