### PR TITLE
[ButtonGroup] Prevent sticky hover border on touch devices

### DIFF
--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -168,8 +168,10 @@ const ButtonGroupRoot = styled('div', {
         style: {
           [`& .${buttonGroupClasses.firstButton},& .${buttonGroupClasses.middleButton}`]: {
             borderRightColor: 'transparent',
-            '&:hover': {
-              borderRightColor: 'currentColor',
+            '@media (hover: hover)': {
+              '&:hover': {
+                borderRightColor: 'currentColor',
+              },
             },
           },
           [`& .${buttonGroupClasses.lastButton},& .${buttonGroupClasses.middleButton}`]: {
@@ -182,8 +184,10 @@ const ButtonGroupRoot = styled('div', {
         style: {
           [`& .${buttonGroupClasses.firstButton},& .${buttonGroupClasses.middleButton}`]: {
             borderBottomColor: 'transparent',
-            '&:hover': {
-              borderBottomColor: 'currentColor',
+            '@media (hover: hover)': {
+              '&:hover': {
+                borderBottomColor: 'currentColor',
+              },
             },
           },
           [`& .${buttonGroupClasses.lastButton},& .${buttonGroupClasses.middleButton}`]: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #48992

## Summary

On **touch devices**, tapping a button inside an `ButtonGroup` with `variant="outlined"` leaves its right border (horizontal) or bottom border (vertical) permanently darkened, until another element is tapped.

`ButtonGroup` restores the divider border on hover:

https://github.com/mui/material-ui/blob/0e0c9352a4e7a7ffcf82ca2c3e8a7d4e6c1f414c/packages/mui-material/src/ButtonGroup/ButtonGroup.js#L169-L174

`Button` already guards all of its own hover styles behind `@media (hover: hover)`:

https://github.com/mui/material-ui/blob/0e0c9352a4e7a7ffcf82ca2c3e8a7d4e6c1f414c/packages/mui-material/src/Button/Button.js#L177-L179

(So the sticky tap-hover is currently not applied to a `Button` at all.)

**This PR applies the same `@media (hover: hover)` guard to `ButtonGroup`.**

## Technical detail

The `ButtonGroup` has a `&:hover` specification, which cancels the `borderRightColor: 'transparent'` (or `borderBottomColor` for vertical orientation). The rest of hover style is done in the `Button`.

- `Button` does not do any hover for touch device
- `ButtonGroup` still cancels the transparation of right/bottom border
- => so it suddenly becomes visible and inconsistent on touch device.

## Scope

Only the `outlined` variant has a border with a `hover` rule.

The remaining `&:hover` in https://github.com/mui/material-ui/blob/0e0c9352a4e7a7ffcf82ca2c3e8a7d4e6c1f414c/packages/mui-material/src/ButtonGroup/ButtonGroup.js#L75-L77 is intentionally not touched.
