### PR TITLE
[material-ui][ButtonBase] Fix LazyRipple retaining event objects when ripples are disabled

### DIFF
--- a/packages/mui-material/src/useLazyRipple/useLazyRipple.test.tsx
+++ b/packages/mui-material/src/useLazyRipple/useLazyRipple.test.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { spy } from 'sinon';
+import { act, createRenderer } from '@mui/internal-test-utils';
+import useLazyRipple, { LazyRipple } from './useLazyRipple';
+import { TouchRippleActions } from '../ButtonBase/TouchRipple';
+
+describe('useLazyRipple', () => {
+  const { render } = createRenderer();
+
+  function Fixture({ onRipple }: { onRipple: (ripple: LazyRipple) => void }) {
+    const ripple = useLazyRipple();
+    onRipple(ripple);
+    return null;
+  }
+
+  it('resolves mount() even when no ripple is rendered', async () => {
+    let ripple!: LazyRipple;
+    render(
+      <Fixture
+        onRipple={(instance) => {
+          ripple = instance;
+        }}
+      />,
+    );
+
+    await act(async () => {
+      ripple.start({} as React.SyntheticEvent);
+    });
+
+    await ripple.mount();
+
+    expect(ripple.shouldMount).to.equal(true);
+    expect(ripple.ref.current).to.equal(null);
+  });
+
+  it('forwards queued actions to the ripple when one is mounted', async () => {
+    let ripple!: LazyRipple;
+    render(
+      <Fixture
+        onRipple={(instance) => {
+          ripple = instance;
+        }}
+      />,
+    );
+
+    const actions = { start: spy(), stop: spy(), pulsate: spy() };
+    ripple.ref.current = actions as unknown as TouchRippleActions;
+
+    const event = {} as React.SyntheticEvent;
+    await act(async () => {
+      ripple.start(event);
+    });
+    await ripple.mount();
+
+    expect(actions.start.callCount).to.equal(1);
+    expect(actions.start.firstCall.args[0]).to.equal(event);
+  });
+});

--- a/packages/mui-material/src/useLazyRipple/useLazyRipple.ts
+++ b/packages/mui-material/src/useLazyRipple/useLazyRipple.ts
@@ -67,8 +67,8 @@ export class LazyRipple {
     if (this.shouldMount && !this.didMount) {
       if (this.ref.current !== null) {
         this.didMount = true;
-        this.mounted!.resolve();
       }
+      this.mounted!.resolve();
     }
   };
 


### PR DESCRIPTION
Fixes #48999

`LazyRipple.mounted` is resolved in `mountEffect` only when `this.ref.current !== null`, i.e. only when a `TouchRipple` actually mounted. With `disableRipple` (commonly set app-wide via `MuiButtonBase.defaultProps`), no `TouchRipple` ever renders, so `mounted` never settles — but the ripple handlers still run on every mousedown/mouseup/blur (they are skipped only for `disableTouchRipple`), and each `start(event)`/`stop(event)` queues `this.mount().then(() => this.ref.current?.stop(...args))` on that forever-pending promise. Every interaction with every ripple-disabled ButtonBase therefore permanently retains its event object; when the event's `target`/`relatedTarget` sits in later-removed DOM (a closed Dialog, an unmounted view), the entire detached tree is pinned for the page lifetime.

Live reproduction: https://codesandbox.io/s/s44gdq — 100 clicks retain ~200 `MouseEvent`s, each held via `PromiseReaction` → `LazyRipple.mounted`; three Dialog open/close cycles retain three detached `MuiDialog-container` trees.

The fix resolves `mounted` in `mountEffect` regardless of whether a ripple rendered. The queued actions are already null-safe (`this.ref.current?.start(...)`), so with no ripple they settle as no-ops instead of accumulating. When a ripple does render, the ref is attached during commit — before the effect — so the `didMount` bookkeeping and action forwarding behave exactly as before (covered by the second test).

Adds `useLazyRipple.test.tsx` (the hook previously had no dedicated tests): a regression test asserting `mount()` settles when no ripple is rendered, and a test asserting queued actions still reach a mounted ripple's actions object.