### PR TITLE
[Select] Fix flaky opening mouseup timing

### DIFF
--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -256,7 +256,8 @@ describe('<Select />', () => {
       await user.pointer({ keys: '[MouseLeft>]', target: trigger });
 
       await act(async () => {
-        await sleep(450);
+        // Well past the 400ms selected-item window; a tight margin flakes on slow CI.
+        await sleep(700);
       });
 
       await user.pointer({
@@ -283,7 +284,8 @@ describe('<Select />', () => {
       await user.pointer({ keys: '[MouseLeft>]', target: trigger });
 
       await act(async () => {
-        await sleep(250);
+        // Well past the 200ms drag window; a tight margin flakes on slow CI.
+        await sleep(400);
       });
       await user.pointer({
         keys: '[/MouseLeft]',
@@ -332,7 +334,8 @@ describe('<Select />', () => {
       await user.pointer({ keys: '[MouseLeft>]', target: trigger });
 
       await act(async () => {
-        await sleep(250);
+        // Well past the 200ms drag window; a tight margin flakes on slow CI.
+        await sleep(400);
       });
       await user.pointer({
         keys: '[/MouseLeft]',

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -383,14 +383,16 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         selectionRef.current.allowUnselectedMouseUp = true;
       });
     } else {
+      // Both timers start from the mousedown. Chaining the selected timer inside the
+      // unselected callback would compound setTimeout jitter past the 400ms window.
       // mousedown -> move to unselected item -> mouseup should not select within 200ms.
       unselectedMouseUpTimer.start(UNSELECTED_MOUSE_UP_DELAY, () => {
         selectionRef.current.allowUnselectedMouseUp = true;
+      });
 
-        // mousedown -> mouseup on selected item should not select within 400ms.
-        selectedMouseUpTimer.start(UNSELECTED_MOUSE_UP_DELAY, () => {
-          selectionRef.current.allowSelectedMouseUp = true;
-        });
+      // mousedown -> mouseup on selected item should not select within 400ms.
+      selectedMouseUpTimer.start(SELECTED_MOUSE_UP_DELAY, () => {
+        selectionRef.current.allowSelectedMouseUp = true;
       });
     }
   };


### PR DESCRIPTION
Fixes a flaky WebKit failure in `Select > pointer interactions > closes when the opening mouseup lands on the selected option after the selected-item delay`.

## The problem

`SelectInput` starts the selected-item timer inside the unselected timer's callback. The chain runs 200ms + 200ms. Each `setTimeout` adds its own jitter, so the real window drifts past 400ms on a loaded runner. The test slept 450ms, a 50ms margin. WebKit on CI misses that margin, the mouseup arrives while `allowSelectedMouseUp` is still `false`, and the menu never closes.

## The fix

- Start both timers from the mousedown. The unselected timer runs 200ms. The selected timer runs the full 400ms (`SELECTED_MOUSE_UP_DELAY`). The jitter no longer compounds, and the flat delay matches the existing code comments.
- Widen the test sleeps: 450ms → 700ms for the selected-item window, 250ms → 400ms for the two drag-delay tests. The drag tests had the same 50ms margin.

Both timers were already cleared together in `clearSelectionTimers`, so no cleanup path depended on the nesting.

## Test plan

- `pnpm test:browser Select -t "pointer interactions"` passes in WebKit and Chromium (22 tests).
- `pnpm test:unit Select` passes in jsdom (407 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HgD6GEW3UxNRvC2abbTy9