### PR TITLE
[core] Use @typescript/typescript6 for the docs tooling

### DIFF
--- a/packages-internal/api-docs-builder/package.json
+++ b/packages-internal/api-docs-builder/package.json
@@ -18,6 +18,7 @@
     "@babel/types": "^7.29.8",
     "@mui/internal-docs-utils": "workspace:^",
     "@mui/internal-markdown": "workspace:^",
+    "@typescript/typescript6": "^6.0.2",
     "doctrine": "^3.0.0",
     "es-toolkit": "^1.51.0",
     "fast-glob": "^3.3.3",
@@ -25,7 +26,6 @@
     "react-docgen": "^8.0.3",
     "recast": "^0.24.0",
     "remark": "^15.0.1",
-    "typescript": "^6.0.3",
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {

--- a/packages-internal/api-docs-builder/src/buildApiUtils.ts
+++ b/packages-internal/api-docs-builder/src/buildApiUtils.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import * as ts from 'typescript';
+import * as ts from '@typescript/typescript6';
 import * as prettier from 'prettier';
 import { kebabCase } from 'es-toolkit/string';
 import { getLineFeed } from '@mui/internal-docs-utils';

--- a/packages-internal/api-docs-builder/src/types/ApiBuilder.types.ts
+++ b/packages-internal/api-docs-builder/src/types/ApiBuilder.types.ts
@@ -1,5 +1,5 @@
 import type { Documentation } from 'react-docgen';
-import { JSDocTagInfo } from 'typescript';
+import { JSDocTagInfo } from '@typescript/typescript6';
 import { ComponentInfo, Slot, HookInfo, SeeMore, ApiItemDescription } from './utils.types';
 
 export type AdditionalPropsInfo = {

--- a/packages-internal/api-docs-builder/src/utils/createTypeScriptProject.ts
+++ b/packages-internal/api-docs-builder/src/utils/createTypeScriptProject.ts
@@ -1,6 +1,11 @@
 import path from 'path';
 import fs from 'fs';
-import * as ts from 'typescript';
+// TypeScript 7 ships no importable compiler API: its root export is just
+// `version`, and the replacement is still behind `typescript/unstable/*`.
+// `@typescript/typescript6` is Microsoft's republished 6.x API for exactly
+// this case. Swap it for the stable API once TypeScript 7.1 ships it
+// (https://github.com/microsoft/TypeScript/issues/63703).
+import * as ts from '@typescript/typescript6';
 
 export interface TypeScriptProject {
   name: string;

--- a/packages-internal/api-docs-builder/src/utils/extractInfoFromEnum.ts
+++ b/packages-internal/api-docs-builder/src/utils/extractInfoFromEnum.ts
@@ -1,4 +1,10 @@
-import { Symbol, isPropertySignature, isEnumDeclaration, forEachChild, Node } from 'typescript';
+import {
+  Symbol,
+  isPropertySignature,
+  isEnumDeclaration,
+  forEachChild,
+  Node,
+} from '@typescript/typescript6';
 import { TypeScriptProject } from './createTypeScriptProject';
 import { ParsedProperty } from '../types/ApiBuilder.types';
 import { getSymbolDescription, getSymbolJSDocTags, stringifySymbol } from '../buildApiUtils';

--- a/packages-internal/api-docs-builder/src/utils/extractInfoFromType.ts
+++ b/packages-internal/api-docs-builder/src/utils/extractInfoFromType.ts
@@ -1,4 +1,4 @@
-import { Symbol, isPropertySignature } from 'typescript';
+import { Symbol, isPropertySignature } from '@typescript/typescript6';
 import { TypeScriptProject } from './createTypeScriptProject';
 import { ParsedProperty } from '../types/ApiBuilder.types';
 import { getSymbolDescription, getSymbolJSDocTags, stringifySymbol } from '../buildApiUtils';

--- a/packages-internal/api-docs-builder/src/utils/getPropsFromComponentNode.ts
+++ b/packages-internal/api-docs-builder/src/utils/getPropsFromComponentNode.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from '@typescript/typescript6';
 import { TypeScriptProject } from './createTypeScriptProject';
 
 export interface ParsedProp {

--- a/packages-internal/api-docs-builder/src/utils/parseSlotsAndClasses.ts
+++ b/packages-internal/api-docs-builder/src/utils/parseSlotsAndClasses.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from '@typescript/typescript6';
 import type { ComponentClassDefinition } from '../types/ApiBuilder.types';
 import { renderMarkdown } from '../buildApi';
 import { getSymbolDescription, getSymbolJSDocTags } from '../buildApiUtils';

--- a/packages-internal/api-docs-builder/src/utils/resolveExportSpecifier.ts
+++ b/packages-internal/api-docs-builder/src/utils/resolveExportSpecifier.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from '@typescript/typescript6';
 import { TypeScriptProject } from './createTypeScriptProject';
 
 function shouldAliasSymbol(symbol: ts.Symbol) {

--- a/packages-internal/docs-utils/package.json
+++ b/packages-internal/docs-utils/package.json
@@ -16,6 +16,7 @@
     "release:publish:dry-run": "pnpm build && pnpm publish --tag latest --registry=\"http://localhost:4873/\""
   },
   "dependencies": {
+    "@typescript/typescript6": "^6.0.2",
     "rimraf": "^6.1.3"
   },
   "publishConfig": {
@@ -24,11 +25,5 @@
   },
   "exports": {
     ".": "./src/index.ts"
-  },
-  "devDependencies": {
-    "typescript": "6.0.3"
-  },
-  "peerDependencies": {
-    "typescript": "^5.9.3 || ^6.0.0"
   }
 }

--- a/packages-internal/docs-utils/src/createTypeScriptProject.ts
+++ b/packages-internal/docs-utils/src/createTypeScriptProject.ts
@@ -1,6 +1,11 @@
 import path from 'path';
 import fs from 'fs';
-import * as ts from 'typescript';
+// TypeScript 7 ships no importable compiler API: its root export is just
+// `version`, and the replacement is still behind `typescript/unstable/*`.
+// `@typescript/typescript6` is Microsoft's republished 6.x API for exactly
+// this case. Swap it for the stable API once TypeScript 7.1 ships it
+// (https://github.com/microsoft/TypeScript/issues/63703).
+import * as ts from '@typescript/typescript6';
 
 export interface TypeScriptProject {
   name: string;

--- a/packages-internal/docs-utils/src/getPropsFromComponentNode.ts
+++ b/packages-internal/docs-utils/src/getPropsFromComponentNode.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from '@typescript/typescript6';
 import { TypeScriptProject } from './createTypeScriptProject';
 
 export interface ParsedProp {

--- a/packages-internal/scripts/package.json
+++ b/packages-internal/scripts/package.json
@@ -34,9 +34,9 @@
     "@babel/plugin-syntax-typescript": "^7.29.7",
     "@babel/types": "^7.29.8",
     "@mui/internal-docs-utils": "workspace:^",
+    "@typescript/typescript6": "^6.0.2",
     "doctrine": "^3.0.0",
-    "es-toolkit": "^1.51.0",
-    "typescript": "^6.0.3"
+    "es-toolkit": "^1.51.0"
   },
   "devDependencies": {
     "@babel/register": "7.29.7",

--- a/packages-internal/scripts/typescript-to-proptypes/src/createType.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/src/createType.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import ts from '@typescript/typescript6';
 import { uniqBy } from 'es-toolkit/array';
 import {
   PropType,

--- a/packages-internal/scripts/typescript-to-proptypes/src/getPropTypesFromFile.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/src/getPropTypesFromFile.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import ts from '@typescript/typescript6';
 import * as doctrine from 'doctrine';
 import {
   GetPropsFromComponentDeclarationOptions,

--- a/packages-internal/scripts/typescript-to-proptypes/src/models.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/src/models.ts
@@ -1,4 +1,9 @@
-import ts from 'typescript';
+// TypeScript 7 ships no importable compiler API: its root export is just
+// `version`, and the replacement is still behind `typescript/unstable/*`.
+// `@typescript/typescript6` is Microsoft's republished 6.x API for exactly
+// this case. Swap it for the stable API once TypeScript 7.1 ships it
+// (https://github.com/microsoft/TypeScript/issues/63703).
+import ts from '@typescript/typescript6';
 
 export interface PropTypeDefinition {
   name: string;

--- a/packages-internal/scripts/typescript-to-proptypes/test/typescript-to-proptypes.test.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/typescript-to-proptypes.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 import path from 'path';
 import fs from 'fs';
-import * as ts from 'typescript';
+import * as ts from '@typescript/typescript6';
 import glob from 'fast-glob';
 import prettier from 'prettier';
 import { TypeScriptProject, createTypeScriptProjectBuilder } from '@mui/internal-docs-utils';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ catalogs:
       version: 4.2.0
 
 overrides:
-  '@mui/internal-api-docs-builder>typescript': ^6.0.3
-  '@mui/internal-docs-utils>typescript': ^6.0.3
-  '@mui/internal-scripts>typescript': ^6.0.3
   docs>stylis: 4.2.0
   docs>react-is: 19.2.8
   caniuse-lite: ^1.0.30001809
@@ -594,6 +591,9 @@ importers:
       '@mui/internal-markdown':
         specifier: workspace:^
         version: link:../markdown
+      '@typescript/typescript6':
+        specifier: ^6.0.2
+        version: 6.0.2
       doctrine:
         specifier: ^3.0.0
         version: 3.0.0
@@ -615,9 +615,6 @@ importers:
       remark:
         specifier: ^15.0.1
         version: 15.0.1(supports-color@11.0.0)
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
@@ -791,13 +788,12 @@ importers:
 
   packages-internal/docs-utils:
     dependencies:
+      '@typescript/typescript6':
+        specifier: ^6.0.2
+        version: 6.0.2
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
-    devDependencies:
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
     publishDirectory: build
 
   packages-internal/markdown:
@@ -835,15 +831,15 @@ importers:
       '@mui/internal-docs-utils':
         specifier: workspace:^
         version: link:../docs-utils/build
+      '@typescript/typescript6':
+        specifier: ^6.0.2
+        version: 6.0.2
       doctrine:
         specifier: ^3.0.0
         version: 3.0.0
       es-toolkit:
         specifier: ^1.51.0
         version: 1.51.0
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
     devDependencies:
       '@babel/register':
         specifier: 7.29.7
@@ -5171,6 +5167,10 @@ packages:
   '@typescript/native-preview@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
     engines: {node: '>=16.20.0'}
+    hasBin: true
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
     hasBin: true
 
   '@ungap/structured-clone@1.3.3':
@@ -15117,6 +15117,10 @@ snapshots:
       '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@ungap/structured-clone@1.3.3': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ catalogs:
       version: 4.2.0
 
 overrides:
+  '@mui/internal-api-docs-builder>typescript': ^6.0.3
+  '@mui/internal-docs-utils>typescript': ^6.0.3
+  '@mui/internal-scripts>typescript': ^6.0.3
   docs>stylis: 4.2.0
   docs>react-is: 19.2.8
   caniuse-lite: ^1.0.30001809
@@ -793,7 +796,7 @@ importers:
         version: 6.1.3
     devDependencies:
       typescript:
-        specifier: 6.0.3
+        specifier: ^6.0.3
         version: 6.0.3
     publishDirectory: build
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,15 @@ catalogs:
     '@emotion/styled': '^11.14.1'
 
 overrides:
+  # The API docs and prop-types generators drive the TypeScript compiler API
+  # (ts.Program, ts.TypeChecker, ts.isIdentifier, ...). TypeScript 7 removed that
+  # API from the package root, which now only exports `version`; the replacement
+  # lives behind the unstable `typescript/unstable/*` subpaths. Keep these packages
+  # on 6.x so the nightly `test_types_next` job, which installs typescript@next
+  # workspace-wide, can still report on the public typings it exists to check.
+  '@mui/internal-api-docs-builder>typescript': '^6.0.3'
+  '@mui/internal-docs-utils>typescript': '^6.0.3'
+  '@mui/internal-scripts>typescript': '^6.0.3'
   # Both were bundled twice in the docs build
   'docs>stylis': '4.2.0'
   'docs>react-is': '19.2.8'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,15 +43,6 @@ catalogs:
     '@emotion/styled': '^11.14.1'
 
 overrides:
-  # The API docs and prop-types generators drive the TypeScript compiler API
-  # (ts.Program, ts.TypeChecker, ts.isIdentifier, ...). TypeScript 7 removed that
-  # API from the package root, which now only exports `version`; the replacement
-  # lives behind the unstable `typescript/unstable/*` subpaths. Keep these packages
-  # on 6.x so the nightly `test_types_next` job, which installs typescript@next
-  # workspace-wide, can still report on the public typings it exists to check.
-  '@mui/internal-api-docs-builder>typescript': '^6.0.3'
-  '@mui/internal-docs-utils>typescript': '^6.0.3'
-  '@mui/internal-scripts>typescript': '^6.0.3'
   # Both were bundled twice in the docs build
   'docs>stylis': '4.2.0'
   'docs>react-is': '19.2.8'


### PR DESCRIPTION
TypeScript 7.0 is stable (`typescript@latest` is 7.0.2) but deliberately ships no importable compiler API — the package root exports only `version`, and the replacement is still behind `typescript/unstable/*`. `api-docs-builder`, `docs-utils` and `typescript-to-proptypes` all build on `ts.Program`/`ts.TypeChecker`, so the nightly `test_types_next` job fails with 128 errors before it reaches the public typings. It has been red every night for 30 days. There is nothing to migrate to yet: typescript-eslint, ts-morph and the Vue/Svelte/Angular tooling are all in the same position, and Microsoft publishes `@typescript/typescript6` for exactly this.

So these three depend on `@typescript/typescript6` by name — the constraint sits in the packages that have it rather than in a workspace-wide override, the `typescript@next` override can't reach them, and nothing silently holds them back when the repo moves its own `typescript` to 7.x. `typescript` is no longer imported in them and drops from their dependencies (`tsgo` comes from `@typescript/native-preview`). TypeScript 7.1 plans to stabilise the API (microsoft/TypeScript#63703, stable planned 2026-11-10), which is when this gets swapped back.

Verified with typescript@7.1.0-dev installed over the workspace: all three job steps pass. On a normal install `typescript:ci` is green, the 67 typescript-to-proptypes tests pass, and `pnpm proptypes` + `pnpm docs:api:build` regenerate byte-identical output.