### PR TITLE
[test] Skip the CrudDashboard VRT on React 18

### DIFF
--- a/test/regressions/demoMeta.test.ts
+++ b/test/regressions/demoMeta.test.ts
@@ -14,6 +14,16 @@ describe('parseRoute', () => {
     });
   });
 
+  it('parses a getting-started template route into its docs/data path', () => {
+    expect(
+      parseRoute('/docs-getting-started-templates-crud-dashboard/CrudDashboard'),
+    ).to.deep.equal({
+      path: 'docs/data/material/getting-started/templates/crud-dashboard/CrudDashboard',
+      slug: 'crud-dashboard',
+      demo: 'CrudDashboard',
+    });
+  });
+
   it('parses a docs-product route into the matching product*/ docs/src path', () => {
     expect(parseRoute('/docs-product-material/MaterialHero')).to.deep.equal({
       path: 'docs/src/components/productMaterial/MaterialHero',
@@ -70,6 +80,23 @@ describe('getConfig', () => {
       test: 'docs/data/material/components/foo/*',
       enabled: true,
     });
+  });
+});
+
+describe('minReactMajor', () => {
+  it('marks the crud-dashboard template as needing React 19', () => {
+    expect(
+      getConfig(
+        SCREENSHOT_RULES,
+        'docs/data/material/getting-started/templates/crud-dashboard/CrudDashboard',
+      ),
+    ).to.deep.include({ minReactMajor: 19 });
+  });
+
+  it('leaves demos without the field unconstrained', () => {
+    expect(
+      getConfig(SCREENSHOT_RULES, 'docs/data/material/components/autocomplete/Asynchronous'),
+    ).to.not.have.property('minReactMajor');
   });
 });
 

--- a/test/regressions/demoMeta.ts
+++ b/test/regressions/demoMeta.ts
@@ -31,6 +31,13 @@ export interface ScreenshotRule {
    * at the default.
    */
   viewportWidth?: number;
+  /**
+   * Skip the demo when the run's React major is below this. For demos whose
+   * third-party dependencies need a newer React than MUI itself supports —
+   * the nightly `test_regressions-react@18` job installs React 18 across the
+   * workspace via pnpm overrides, past any peer range that says otherwise.
+   */
+  minReactMajor?: number;
 }
 
 export interface A11yRule {
@@ -126,6 +133,18 @@ export const SCREENSHOT_RULES: ScreenshotRule[] = [
   // broader product*/** width above.
   { test: 'docs/src/components/productX/**', viewportWidth: 1440 },
 
+  // The template mounts react-router's data router (`createHashRouter` +
+  // `RouterProvider`), which calls `useOptimistic` — React 19 only.
+  // react-router@8 peers on `react >= 19.2.7`, so under the nightly
+  // `test_regressions-react@18` override the whole demo throws on render and
+  // the harness waits out its timeout on a testcase element that never
+  // appears. It is the only demo mounting a data router; the other
+  // react-router demos use `MemoryRouter`/`Link` and are unaffected.
+  {
+    test: 'docs/data/material/getting-started/templates/crud-dashboard/CrudDashboard',
+    minReactMajor: 19,
+  },
+
   // Composites whose Data Grid loads its rows asynchronously via `useDemoData`
   // — `aria-busy` only tracks fonts, not the grid data, so without this the
   // screenshot can capture the loading skeleton. The skeleton's cells carry
@@ -174,6 +193,7 @@ export interface ParsedRoute {
 
 const COMPONENT_ROUTE_REGEX = /^\/docs-components-([^/]+)\/(.+)$/;
 const COMPOSITE_ROUTE_REGEX = /^\/docs-product-([^/]+)\/(.+)$/;
+const TEMPLATE_ROUTE_REGEX = /^\/docs-getting-started-templates-([^/]+)\/(.+)$/;
 
 /**
  * Map a VRT route to its docs path + slug + demo, or `null` for non-component
@@ -182,12 +202,27 @@ const COMPOSITE_ROUTE_REGEX = /^\/docs-product-([^/]+)\/(.+)$/;
  * Recognises two route shapes:
  * - `/docs-components-{slug}/{Demo}` → `docs/data/material/components/{slug}/{Demo}`
  * - `/docs-product-{product}/{Name}` → `docs/src/components/product{Product}/{Name}`
+ * - `/docs-getting-started-templates-{slug}/{Demo}` →
+ *   `docs/data/material/getting-started/templates/{slug}/{Demo}`
+ *
+ * The template shape is matched by its literal prefix: `fixtures.js` joins the
+ * directory segments with `-`, so `getting-started-templates-crud-dashboard`
+ * cannot be split back into directories without knowing where the slug starts.
  */
 export function parseRoute(route: string): ParsedRoute | null {
   const componentMatch = route.match(COMPONENT_ROUTE_REGEX);
   if (componentMatch) {
     const [, slug, demo] = componentMatch;
     return { path: `docs/data/material/components/${slug}/${demo}`, slug, demo };
+  }
+  const templateMatch = route.match(TEMPLATE_ROUTE_REGEX);
+  if (templateMatch) {
+    const [, slug, demo] = templateMatch;
+    return {
+      path: `docs/data/material/getting-started/templates/${slug}/${demo}`,
+      slug,
+      demo,
+    };
   }
   const compositeMatch = route.match(COMPOSITE_ROUTE_REGEX);
   if (compositeMatch) {

--- a/test/regressions/index.jsx
+++ b/test/regressions/index.jsx
@@ -42,6 +42,10 @@ window.muiFixture = {
       { family: 'Font Awesome 5 Free', weight: 900 },
     ],
   }),
+  // Read by `index.test.js` to evaluate `ScreenshotRule.minReactMajor`. Taken
+  // from the bundle rather than the test process's own `react` so the two can
+  // never disagree about which React the demos actually render with.
+  reactVersion: React.version,
 };
 
 function FixtureRenderer({ component: FixtureComponent, path }) {

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -82,6 +82,9 @@ async function main() {
     return links.map((link) => link.href);
   });
   routes = routes.map((route) => route.replace(baseUrl, ''));
+  const reactMajor = Number(
+    (await probePage.evaluate(() => window.muiFixture.reactVersion)).split('.')[0],
+  );
   pool.release(probePage);
 
   const test = base.extend({
@@ -165,7 +168,8 @@ async function main() {
         const parsed = parseRoute(route);
         const screenshotRule = parsed ? getConfig(SCREENSHOT_RULES, parsed.path) : undefined;
         const a11yRule = parsed ? getConfig(A11Y_RULES, parsed.path) : undefined;
-        const runScreenshot = parsed ? (screenshotRule?.enabled ?? true) : true;
+        const meetsReactFloor = reactMajor >= (screenshotRule?.minReactMajor ?? 0);
+        const runScreenshot = parsed ? (screenshotRule?.enabled ?? true) && meetsReactFloor : true;
         const runA11y = a11yRule?.enabled === true;
         if (!runScreenshot && !runA11y) {
           return;


### PR DESCRIPTION
`test_regressions-react@18` has failed every night since react-router v8 landed (#48840). The CrudDashboard template mounts react-router's data router (`createHashRouter` + `RouterProvider`), which calls `useOptimistic` — a React 19 API. react-router@8 peers on `react >= 19.2.7`, but the nightly installs React 18 workspace-wide via pnpm overrides, so the demo throws on render, no testcase element is created, and the harness waits out its full 30s on a selector that can never match.

Adds `ScreenshotRule.minReactMajor` and marks the demo React 19+; it's the only demo mounting a data router, the others use `MemoryRouter`/`Link` and keep running on 18. The React major comes from the bundle via `muiFixture.reactVersion` so it can't disagree with what the demos render with. `parseRoute` also learns the template route shape, which previously returned null and left those routes unreachable from both rule lists. Verified locally: React 19 runs it (664 tests), React 18 skips it and the suite is green (663).