### PR TITLE
[TimelineItem] Keep the spacer selector at one class of specificity

### DIFF
--- a/packages/mui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.js
@@ -40,19 +40,23 @@ const TimelineItemRoot = styled('li', {
   minHeight: 70,
   // The spacer that keeps content centred when there is no opposite content.
   // Kept at plain `&::before` -- (0,1,1) -- so the `Timeline` override the docs
-  // recommend for removing it always wins on specificity. (`:where()` would do
-  // the same, but the docs' `globalSelector` stylis middleware strips the class
-  // in front of any `:where(`/`:is(`, turning the rule global -- see
-  // emotion issue 2836 -- so it cannot be used in component styles.)
+  // recommend for removing it always wins on specificity. A `:where()` selector
+  // would achieve the same, but this package is consumed by docs pipelines that
+  // postprocess selectors around emotion's `:where()`/`:is()` quirk
+  // (https://github.com/emotion-js/emotion/issues/2836), where those
+  // pseudo-classes have been mangled before. Driving the common case from
+  // `ownerState` also keeps the spacer working where `:has()` is unsupported.
   ...(!ownerState.hasOppositeContent && {
     '&::before': {
       content: '""',
       flex: 1,
       padding: '6px 16px',
     },
-    // The children walk behind `hasOppositeContent` only sees direct children.
-    // Suppress the spacer from CSS when opposite content is nested deeper
-    // (see #46663) -- (0,2,1), deliberately above the spacer rule.
+    // The children walk behind `hasOppositeContent` emits the spacer but only
+    // sees direct children; this `:has()` rule removes the spacer again when
+    // opposite content sits deeper in the tree
+    // (https://github.com/mui/material-ui/pull/46663) -- (0,2,1), deliberately
+    // above the spacer rule.
     [`&:has(.${timelineOppositeContentClasses.root})::before`]: {
       content: 'none',
     },

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.js
@@ -39,28 +39,20 @@ const TimelineItemRoot = styled('li', {
   position: 'relative',
   minHeight: 70,
   // The spacer that keeps content centred when there is no opposite content.
-  // Kept at plain `&::before` -- (0,1,1) -- so the `Timeline` override the docs
-  // recommend for removing it always wins on specificity. A `:where()` selector
-  // would achieve the same, but this package is consumed by docs pipelines that
-  // postprocess selectors around emotion's `:where()`/`:is()` quirk
-  // (https://github.com/emotion-js/emotion/issues/2836), where those
-  // pseudo-classes have been mangled before. Driving the common case from
-  // `ownerState` also keeps the spacer working where `:has()` is unsupported.
-  ...(!ownerState.hasOppositeContent && {
-    '&::before': {
-      content: '""',
-      flex: 1,
-      padding: '6px 16px',
-    },
-    // The children walk behind `hasOppositeContent` emits the spacer but only
-    // sees direct children; this `:has()` rule removes the spacer again when
-    // opposite content sits deeper in the tree
-    // (https://github.com/mui/material-ui/pull/46663) -- (0,2,1), deliberately
-    // above the spacer rule.
-    [`&:has(.${timelineOppositeContentClasses.root})::before`]: {
-      content: 'none',
-    },
-  }),
+  // `:where()` contributes no specificity, so the rule sits at (0,1,1) and the
+  // `Timeline` override the docs recommend for removing it always wins. A bare
+  // `:not(:has(...))` would take its argument's specificity -- (0,2,1), level
+  // with that override -- leaving the winner to emotion's insertion order, and
+  // so to the order demos happen to render in
+  // (https://github.com/mui/material-ui/pull/49028). The `:has()` check covers
+  // opposite content that is not a direct child, which the children walk
+  // behind `missingOppositeContent` cannot see
+  // (https://github.com/mui/material-ui/pull/46663).
+  [`&:where(:not(:has(.${timelineOppositeContentClasses.root})))::before`]: {
+    content: '""',
+    flex: 1,
+    padding: '6px 16px',
+  },
   ...(ownerState.position === 'left' && {
     flexDirection: 'row-reverse',
   }),

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.js
@@ -38,16 +38,25 @@ const TimelineItemRoot = styled('li', {
   display: 'flex',
   position: 'relative',
   minHeight: 70,
-  // `:where()` keeps the `:has()` check while contributing no specificity of
-  // its own. Bare `:not(:has(.class))` inherits its argument's specificity,
-  // which put this rule level with the `Timeline` override the docs recommend
-  // for removing the spacer -- and a tie is settled by emotion's insertion
-  // order, so whichever demo rendered first on a page decided the result.
-  [`&:where(:not(:has(.${timelineOppositeContentClasses.root})))::before`]: {
-    content: '""',
-    flex: 1,
-    padding: '6px 16px',
-  },
+  // The spacer that keeps content centred when there is no opposite content.
+  // Kept at plain `&::before` -- (0,1,1) -- so the `Timeline` override the docs
+  // recommend for removing it always wins on specificity. (`:where()` would do
+  // the same, but the docs' `globalSelector` stylis middleware strips the class
+  // in front of any `:where(`/`:is(`, turning the rule global -- see
+  // emotion issue 2836 -- so it cannot be used in component styles.)
+  ...(!ownerState.hasOppositeContent && {
+    '&::before': {
+      content: '""',
+      flex: 1,
+      padding: '6px 16px',
+    },
+    // The children walk behind `hasOppositeContent` only sees direct children.
+    // Suppress the spacer from CSS when opposite content is nested deeper
+    // (see #46663) -- (0,2,1), deliberately above the spacer rule.
+    [`&:has(.${timelineOppositeContentClasses.root})::before`]: {
+      content: 'none',
+    },
+  }),
   ...(ownerState.position === 'left' && {
     flexDirection: 'row-reverse',
   }),

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.js
@@ -38,7 +38,12 @@ const TimelineItemRoot = styled('li', {
   display: 'flex',
   position: 'relative',
   minHeight: 70,
-  [`&:not(:has(.${timelineOppositeContentClasses.root}))::before`]: {
+  // `:where()` keeps the `:has()` check while contributing no specificity of
+  // its own. Bare `:not(:has(.class))` inherits its argument's specificity,
+  // which put this rule level with the `Timeline` override the docs recommend
+  // for removing the spacer -- and a tie is settled by emotion's insertion
+  // order, so whichever demo rendered first on a page decided the result.
+  [`&:where(:not(:has(.${timelineOppositeContentClasses.root})))::before`]: {
     content: '""',
     flex: 1,
     padding: '6px 16px',

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.js
@@ -38,16 +38,9 @@ const TimelineItemRoot = styled('li', {
   display: 'flex',
   position: 'relative',
   minHeight: 70,
-  // The spacer that keeps content centred when there is no opposite content.
-  // `:where()` contributes no specificity, so the rule sits at (0,1,1) and the
-  // `Timeline` override the docs recommend for removing it always wins. A bare
-  // `:not(:has(...))` would take its argument's specificity -- (0,2,1), level
-  // with that override -- leaving the winner to emotion's insertion order, and
-  // so to the order demos happen to render in
-  // (https://github.com/mui/material-ui/pull/49028). The `:has()` check covers
-  // opposite content that is not a direct child, which the children walk
-  // behind `missingOppositeContent` cannot see
-  // (https://github.com/mui/material-ui/pull/46663).
+  // Spacer that keeps content centred when there is no opposite content,
+  // nested or not. `:where()` keeps the specificity at (0,1,1) so user
+  // overrides on `::before` win.
   [`&:where(:not(:has(.${timelineOppositeContentClasses.root})))::before`]: {
     content: '""',
     flex: 1,

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
@@ -45,10 +45,8 @@ describe('<TimelineItem />', () => {
     expect(withOpposite).not.to.have.class(classes.missingOppositeContent);
   });
 
-  // The spacer keeps content centred when there is no opposite content. Its
-  // selector has to stay weak enough that the documented `Timeline` override
-  // wins on specificity alone -- when the two tie, whichever emotion happens to
-  // insert last takes effect, which varies with render order.
+  // The spacer selector must stay weak enough that the documented `Timeline`
+  // override wins on specificity alone.
   it.skipIf(isJsdom())('lets a Timeline sx override remove the spacer', () => {
     const { container } = render(
       <Timeline sx={{ [`& .${classes.root}:before`]: { flex: 0, padding: 0 } }}>
@@ -65,9 +63,8 @@ describe('<TimelineItem />', () => {
     expect(window.getComputedStyle(item, '::before').flexGrow).to.equal('0');
   });
 
-  // The spacer is matched with `:has()` rather than from the children walk
-  // that drives `missingOppositeContent`, so opposite content still counts
-  // when it is not a direct child.
+  // The children walk behind `missingOppositeContent` only sees direct
+  // children; the spacer's `:has()` also covers nested opposite content.
   it.skipIf(isJsdom())('omits the spacer when opposite content is nested', () => {
     const { container } = render(
       <Timeline>

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
@@ -65,9 +65,9 @@ describe('<TimelineItem />', () => {
     expect(window.getComputedStyle(item, '::before').flexGrow).to.equal('0');
   });
 
-  // The spacer is matched with `:has()` rather than from the children walk that
-  // drives `missingOppositeContent`, so that opposite content still counts when
-  // it is not a direct child.
+  // The children walk that emits the spacer only sees direct children; a
+  // `:has()` rule removes the spacer again when opposite content sits deeper
+  // in the tree, so it still counts even when it is not a direct child.
   it.skipIf(isJsdom())('omits the spacer when opposite content is nested', () => {
     const { container } = render(
       <Timeline>

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
@@ -65,9 +65,9 @@ describe('<TimelineItem />', () => {
     expect(window.getComputedStyle(item, '::before').flexGrow).to.equal('0');
   });
 
-  // The children walk that emits the spacer only sees direct children; a
-  // `:has()` rule removes the spacer again when opposite content sits deeper
-  // in the tree, so it still counts even when it is not a direct child.
+  // The spacer is matched with `:has()` rather than from the children walk
+  // that drives `missingOppositeContent`, so opposite content still counts
+  // when it is not a direct child.
   it.skipIf(isJsdom())('omits the spacer when opposite content is nested', () => {
     const { container } = render(
       <Timeline>

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
@@ -1,6 +1,12 @@
-import { describe } from 'vitest';
-import { createRenderer } from '@mui/internal-test-utils';
+import { describe, expect, it } from 'vitest';
+import * as React from 'react';
+import { createRenderer, isJsdom } from '@mui/internal-test-utils';
+import Timeline from '@mui/lab/Timeline';
 import TimelineItem, { timelineItemClasses as classes } from '@mui/lab/TimelineItem';
+import TimelineSeparator from '@mui/lab/TimelineSeparator';
+import TimelineDot from '@mui/lab/TimelineDot';
+import TimelineContent from '@mui/lab/TimelineContent';
+import TimelineOppositeContent from '@mui/lab/TimelineOppositeContent';
 import describeConformance from '../../test/describeConformance';
 
 describe('<TimelineItem />', () => {
@@ -14,4 +20,70 @@ describe('<TimelineItem />', () => {
     refInstanceof: window.HTMLLIElement,
     skip: ['componentProp', 'themeVariants'],
   }));
+
+  it('flags items rendered without opposite content', () => {
+    const { container } = render(
+      <Timeline>
+        <TimelineItem>
+          <TimelineSeparator>
+            <TimelineDot />
+          </TimelineSeparator>
+          <TimelineContent>Eat</TimelineContent>
+        </TimelineItem>
+        <TimelineItem>
+          <TimelineOppositeContent>09:30 am</TimelineOppositeContent>
+          <TimelineSeparator>
+            <TimelineDot />
+          </TimelineSeparator>
+          <TimelineContent>Code</TimelineContent>
+        </TimelineItem>
+      </Timeline>,
+    );
+
+    const [withoutOpposite, withOpposite] = container.querySelectorAll(`.${classes.root}`);
+    expect(withoutOpposite).to.have.class(classes.missingOppositeContent);
+    expect(withOpposite).not.to.have.class(classes.missingOppositeContent);
+  });
+
+  // The spacer keeps content centred when there is no opposite content. Its
+  // selector has to stay weak enough that the documented `Timeline` override
+  // wins on specificity alone -- when the two tie, whichever emotion happens to
+  // insert last takes effect, which varies with render order.
+  it.skipIf(isJsdom())('lets a Timeline sx override remove the spacer', () => {
+    const { container } = render(
+      <Timeline sx={{ [`& .${classes.root}:before`]: { flex: 0, padding: 0 } }}>
+        <TimelineItem>
+          <TimelineSeparator>
+            <TimelineDot />
+          </TimelineSeparator>
+          <TimelineContent>Eat</TimelineContent>
+        </TimelineItem>
+      </Timeline>,
+    );
+
+    const item = container.querySelector(`.${classes.root}`);
+    expect(window.getComputedStyle(item, '::before').flexGrow).to.equal('0');
+  });
+
+  // The spacer is matched with `:has()` rather than from the children walk that
+  // drives `missingOppositeContent`, so that opposite content still counts when
+  // it is not a direct child.
+  it.skipIf(isJsdom())('omits the spacer when opposite content is nested', () => {
+    const { container } = render(
+      <Timeline>
+        <TimelineItem>
+          <React.Fragment>
+            <TimelineOppositeContent>09:30 am</TimelineOppositeContent>
+            <TimelineSeparator>
+              <TimelineDot />
+            </TimelineSeparator>
+          </React.Fragment>
+          <TimelineContent>Eat</TimelineContent>
+        </TimelineItem>
+      </Timeline>,
+    );
+
+    const item = container.querySelector(`.${classes.root}`);
+    expect(window.getComputedStyle(item, '::before').content).to.equal('none');
+  });
 });


### PR DESCRIPTION
`:has()` and `:not()` take the specificity of their argument, so the `::before` spacer rule added in #46663 sits at (0,2,1) — exactly level with the `Timeline` override the docs recommend for removing it. A tie is settled by emotion's insertion order, so the override wins only when another Timeline demo already rendered on the page. In the docs that reads as demos silently losing their override; in the VRT suite, where pages are pooled across concurrent tests, the NoOppositeContent screenshot flips between runs (measured: `::before` `flex-grow` is `1` rendered alone, `0` after any other Timeline demo).

Wrapping the selector in `:where()` zeroes its specificity — (0,1,1), so the documented override always wins deterministically — while keeping the `:has()` behaviour from #46663: opposite content that isn't a direct child still suppresses the spacer. This needed #49029 first: the docs' `globalSelector` middleware used to strip the class in front of `:where(`, which would have turned this rule global. Verified: `flex-grow` is `0` in every render order, full VRT suite green.

This changes the NoOppositeContent screenshot: the demo now renders left-flush, which is what it is meant to show and what mui.com renders — the current Argos baseline is the broken render. #46663 shipped without a test; both properties are now covered, and each test fails without its half of the fix.