### PR TITLE
[code-infra] Update CircleCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/487b5aad17ff4335a4863ac74b0e08e501947184/.circleci/orbs/code-infra.yml
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/49ceb69d6aab71ab39f5cd9a3694d9c18faee7bc/.circleci/orbs/code-infra.yml
 
 parameters:
   workflow:


### PR DESCRIPTION
Pins the shared code-infra orb to the merged mui/mui-public#1810, which runs `set-version-overrides` through the lockfile-installed code-infra binary instead of `pnpm dlx`. The dlx install resolves its own dependency graph outside the lockfile, which currently fails pnpm's trust checks (`ERR_PNPM_TRUST_DOWNGRADE` on `@humanwhocodes/momoa`) and breaks the React-version CI jobs.

Same change as mui/mui-x#23418 and mui/base-ui#5565.