### PR TITLE
[code-infra] Use ESM current directory syntax for Vitest config

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,7 +1,7 @@
 import { defineConfig, coverageConfigDefaults } from 'vitest/config';
 import * as path from 'path';
 
-const MONOREPO_ROOT = path.resolve(__dirname, '.');
+const MONOREPO_ROOT = path.resolve(import.meta.dirname, '.');
 
 const BROWSER_TESTS = ['{docs,packages{-internal,}/*}/vitest.config.browser.mts'];
 const NODE_TESTS = ['{docs,packages{-internal,}/*}/vitest.config.mts'];

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -43,7 +43,7 @@ function getVitestEnvironment(fileName: string): 'browser' | 'node' {
   return 'node';
 }
 
-const MONOREPO_ROOT = path.resolve(__dirname, '.');
+const MONOREPO_ROOT = path.resolve(import.meta.dirname, '.');
 
 export const alias = {
   '@mui/internal-api-docs-builder': path.resolve(


### PR DESCRIPTION
Fixes the following warning when running tests: 
```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (vitest.config.mts:4:36). Use `import.meta.dirname` instead
Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (../../vitest.shared.mts:46:36). Use `import.meta.dirname` instead
```

Can be seen at: https://app.circleci.com/pipelines/github/mui/material-ui/179981/workflows/5f22b185-7c67-4b18-aab4-ab747f819a52/jobs/959030/parallel-runs/0/steps/0-106