### PR TITLE
[code-infra] Drop the vitest globals from the shared test setup

### DIFF
--- a/docs/src/modules/sandbox/CodeSandbox.test.js
+++ b/docs/src/modules/sandbox/CodeSandbox.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import CodeSandbox from './CodeSandbox';
 
 const testCase = `import * as React from 'react';

--- a/docs/src/modules/sandbox/Dependencies.test.js
+++ b/docs/src/modules/sandbox/Dependencies.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeAll, afterAll, it, expect } from 'vitest';
 import SandboxDependencies from './Dependencies';
 
 describe('Dependencies', () => {

--- a/docs/src/modules/sandbox/StackBlitz.test.js
+++ b/docs/src/modules/sandbox/StackBlitz.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import StackBlitz from './StackBlitz';
 
 const testCase = `import * as React from 'react';

--- a/docs/src/modules/utils/extractTemplates.test.js
+++ b/docs/src/modules/utils/extractTemplates.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import extractTemplates from './extractTemplates';
 
 describe('extractTemplates', () => {

--- a/docs/src/modules/utils/replaceMarkdownLinks.test.js
+++ b/docs/src/modules/utils/replaceMarkdownLinks.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import {
   replaceMaterialLinks,
   replaceAPILinks,

--- a/docs/src/theming.test.tsx
+++ b/docs/src/theming.test.tsx
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { ThemeProvider, createTheme, useColorScheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -152,6 +152,12 @@ export default defineConfig(
       'testing-library/no-container': 'off',
       // TODO: investigate and fix
       'vitest/expect-expect': 'off',
+      // The assertions are chai style (`.to.have.property`) on Vitest's chai
+      // based `expect`. Now that `expect` is imported from `vitest` the plugin
+      // reads those chains and rejects every chai modifier. mui-x turns these
+      // off for the same reason.
+      'vitest/valid-expect': 'off',
+      'vitest/no-conditional-expect': 'off',
     },
   },
   // Test end

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,6 @@ import { fixupPluginRules } from '@eslint/compat';
 import { defineConfig } from 'eslint/config';
 import eslintPluginConsistentName from 'eslint-plugin-consistent-default-export-name';
 import * as path from 'node:path';
-import vitestPlugin from '@vitest/eslint-plugin';
 import { fileURLToPath } from 'url';
 
 const filename = fileURLToPath(import.meta.url);
@@ -141,11 +140,6 @@ export default defineConfig(
       useMocha: false,
       useVitest: true,
     }),
-    languageOptions: {
-      globals: {
-        ...vitestPlugin.environments.env.globals,
-      },
-    },
     rules: {
       'mui/material-ui-no-empty-box': 'off',
       // Disabled temporarily. Enable one by one.

--- a/packages-internal/api-docs-builder-core/materialUi/getMaterialUiComponentInfo.test.ts
+++ b/packages-internal/api-docs-builder-core/materialUi/getMaterialUiComponentInfo.test.ts
@@ -1,6 +1,6 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
 import fs from 'fs';
-import { expect } from 'chai';
 import sinon from 'sinon';
 import { getMaterialUiComponentInfo } from './getMaterialUiComponentInfo';
 

--- a/packages-internal/api-docs-builder/buildApiUtils.test.ts
+++ b/packages-internal/api-docs-builder/buildApiUtils.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest';
 import sinon from 'sinon';
 import { extractPackageFile } from './buildApiUtils';
 

--- a/packages-internal/api-docs-builder/utils/escapeCell.test.ts
+++ b/packages-internal/api-docs-builder/utils/escapeCell.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import escapeCell from './escapeCell';
 
 describe('escapeCell', () => {

--- a/packages-internal/api-docs-builder/utils/findApiPages.test.ts
+++ b/packages-internal/api-docs-builder/utils/findApiPages.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { extractApiPage } from './findApiPages';
 
 describe('extractApiPage', () => {

--- a/packages-internal/api-docs-builder/utils/replaceUrl.test.js
+++ b/packages-internal/api-docs-builder/utils/replaceUrl.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import replaceUrl, {
   replaceMaterialLinks,
   replaceAPILinks,

--- a/packages-internal/core-docs/src/HighlightedCode/HighlightedCode.test.tsx
+++ b/packages-internal/core-docs/src/HighlightedCode/HighlightedCode.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { getDesignTokens } from '../branding';

--- a/packages-internal/core-docs/src/findActivePage/findActivePage.test.js
+++ b/packages-internal/core-docs/src/findActivePage/findActivePage.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import findActivePage from './findActivePage';
 
 describe('findActivePage', () => {

--- a/packages-internal/core-docs/src/getProductInfoFromUrl/getProductInfoFromUrl.test.js
+++ b/packages-internal/core-docs/src/getProductInfoFromUrl/getProductInfoFromUrl.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import getProductInfoFromUrl from './getProductInfoFromUrl';
 
 describe('getProductInfoFromUrl', () => {

--- a/packages-internal/core-docs/src/helpers/helpers.test.js
+++ b/packages-internal/core-docs/src/helpers/helpers.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeAll, afterAll, it, expect } from 'vitest';
 import { pageToTitle } from './helpers';
 
 describe('docs getDependencies helpers', () => {

--- a/packages-internal/markdown/extractImports.test.mjs
+++ b/packages-internal/markdown/extractImports.test.mjs
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import extractImports from './extractImports.mjs';
 
 describe('extractImports', () => {

--- a/packages-internal/markdown/parseMarkdown.test.mjs
+++ b/packages-internal/markdown/parseMarkdown.test.mjs
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import {
   getContents,
   getDescription,

--- a/packages-internal/markdown/prepareMarkdown.test.mjs
+++ b/packages-internal/markdown/prepareMarkdown.test.mjs
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import prepareMarkdown from './prepareMarkdown.mjs';
 
 describe('prepareMarkdown', () => {

--- a/packages-internal/markdown/textToHash.test.mjs
+++ b/packages-internal/markdown/textToHash.test.mjs
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { parseInline as renderInlineMarkdown } from 'marked';
 import textToHash from './textToHash.mjs';
 

--- a/packages-internal/scripts/generate-llms-txt/test/processApi.test.ts
+++ b/packages-internal/scripts/generate-llms-txt/test/processApi.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';

--- a/packages-internal/scripts/generate-llms-txt/test/processComponent.test.ts
+++ b/packages-internal/scripts/generate-llms-txt/test/processComponent.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, beforeEach, afterEach, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';

--- a/packages-internal/scripts/typescript-to-proptypes/test/typescript-to-proptypes.test.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/typescript-to-proptypes.test.ts
@@ -1,8 +1,8 @@
 /// <reference types="vite/client" />
+import { describe, beforeAll, it, expect } from 'vitest';
 import path from 'path';
 import fs from 'fs';
 import * as ts from 'typescript';
-import { expect } from 'chai';
 import glob from 'fast-glob';
 import prettier from 'prettier';
 import { TypeScriptProject, createTypeScriptProjectBuilder } from '@mui/internal-docs-utils';

--- a/packages/mui-codemod/src/deprecations/accordion-props/accordion-props.test.js
+++ b/packages/mui-codemod/src/deprecations/accordion-props/accordion-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './accordion-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/accordion-summary-classes/accordion-summary-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/accordion-summary-classes/accordion-summary-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './accordion-summary-classes';

--- a/packages/mui-codemod/src/deprecations/alert-classes/alert-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/alert-classes/alert-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './alert-classes';

--- a/packages/mui-codemod/src/deprecations/alert-props/alert-props.test.js
+++ b/packages/mui-codemod/src/deprecations/alert-props/alert-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './alert-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/autocomplete-props/autocomplete-props.test.js
+++ b/packages/mui-codemod/src/deprecations/autocomplete-props/autocomplete-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './autocomplete-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/avatar-group-props/avatar-group-props.test.js
+++ b/packages/mui-codemod/src/deprecations/avatar-group-props/avatar-group-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './avatar-group-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/avatar-props/avatar-props.test.js
+++ b/packages/mui-codemod/src/deprecations/avatar-props/avatar-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './avatar-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/backdrop-props/backdrop-props.test.js
+++ b/packages/mui-codemod/src/deprecations/backdrop-props/backdrop-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './backdrop-props';
 

--- a/packages/mui-codemod/src/deprecations/badge-props/badge-props.test.js
+++ b/packages/mui-codemod/src/deprecations/badge-props/badge-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './badge-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/button-classes/button-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/button-classes/button-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './button-classes';

--- a/packages/mui-codemod/src/deprecations/button-group-classes/button-group-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/button-group-classes/button-group-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './button-group-classes';

--- a/packages/mui-codemod/src/deprecations/card-header-props/card-header-props.test.js
+++ b/packages/mui-codemod/src/deprecations/card-header-props/card-header-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './card-header-props';
 

--- a/packages/mui-codemod/src/deprecations/checkbox-props/checkbox-props.test.js
+++ b/packages/mui-codemod/src/deprecations/checkbox-props/checkbox-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './checkbox-props';
 

--- a/packages/mui-codemod/src/deprecations/chip-classes/chip-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/chip-classes/chip-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './chip-classes';

--- a/packages/mui-codemod/src/deprecations/circular-progress-classes/circular-progress-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/circular-progress-classes/circular-progress-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './circular-progress-classes';

--- a/packages/mui-codemod/src/deprecations/dialog-classes/dialog-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/dialog-classes/dialog-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './dialog-classes';

--- a/packages/mui-codemod/src/deprecations/dialog-props/dialog-props.test.js
+++ b/packages/mui-codemod/src/deprecations/dialog-props/dialog-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './dialog-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/divider-props/divider-props.test.js
+++ b/packages/mui-codemod/src/deprecations/divider-props/divider-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './divider-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/drawer-classes/drawer-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/drawer-classes/drawer-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './drawer-classes';

--- a/packages/mui-codemod/src/deprecations/drawer-props/drawer-props.test.js
+++ b/packages/mui-codemod/src/deprecations/drawer-props/drawer-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './drawer-props';
 

--- a/packages/mui-codemod/src/deprecations/filled-input-props/filled-input-props.test.js
+++ b/packages/mui-codemod/src/deprecations/filled-input-props/filled-input-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './filled-input-props';
 

--- a/packages/mui-codemod/src/deprecations/form-control-label-props/form-control-label-props.test.js
+++ b/packages/mui-codemod/src/deprecations/form-control-label-props/form-control-label-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './form-control-label-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/image-list-item-bar-classes/image-list-item-bar-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/image-list-item-bar-classes/image-list-item-bar-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './image-list-item-bar-classes';

--- a/packages/mui-codemod/src/deprecations/input-base-classes/input-base-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/input-base-classes/input-base-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './input-base-classes';

--- a/packages/mui-codemod/src/deprecations/input-base-props/input-base-props.test.js
+++ b/packages/mui-codemod/src/deprecations/input-base-props/input-base-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './input-base-props';
 

--- a/packages/mui-codemod/src/deprecations/input-props/input-props.test.js
+++ b/packages/mui-codemod/src/deprecations/input-props/input-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './input-props';
 

--- a/packages/mui-codemod/src/deprecations/linear-progress-classes/linear-progress-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/linear-progress-classes/linear-progress-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './linear-progress-classes';

--- a/packages/mui-codemod/src/deprecations/list-item-props/list-item-props.test.js
+++ b/packages/mui-codemod/src/deprecations/list-item-props/list-item-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './list-item-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/list-item-text-props/list-item-text-props.test.js
+++ b/packages/mui-codemod/src/deprecations/list-item-text-props/list-item-text-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './list-item-text-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/menu-props/menu-props.test.js
+++ b/packages/mui-codemod/src/deprecations/menu-props/menu-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './menu-props';
 

--- a/packages/mui-codemod/src/deprecations/mobile-stepper-props/mobile-stepper-props.test.js
+++ b/packages/mui-codemod/src/deprecations/mobile-stepper-props/mobile-stepper-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './mobile-stepper-props';
 

--- a/packages/mui-codemod/src/deprecations/modal-props/modal-props.test.js
+++ b/packages/mui-codemod/src/deprecations/modal-props/modal-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './modal-props';
 

--- a/packages/mui-codemod/src/deprecations/outlined-input-props/outlined-input-props.test.js
+++ b/packages/mui-codemod/src/deprecations/outlined-input-props/outlined-input-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './outlined-input-props';
 

--- a/packages/mui-codemod/src/deprecations/pagination-item-classes/pagination-item-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/pagination-item-classes/pagination-item-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './pagination-item-classes';

--- a/packages/mui-codemod/src/deprecations/pagination-item-props/pagination-item-props.test.js
+++ b/packages/mui-codemod/src/deprecations/pagination-item-props/pagination-item-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './pagination-item-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/popover-props/popover-props.test.js
+++ b/packages/mui-codemod/src/deprecations/popover-props/popover-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './popover-props';
 

--- a/packages/mui-codemod/src/deprecations/popper-props/popper-props.test.js
+++ b/packages/mui-codemod/src/deprecations/popper-props/popper-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './popper-props';
 

--- a/packages/mui-codemod/src/deprecations/radio-props/radio-props.test.js
+++ b/packages/mui-codemod/src/deprecations/radio-props/radio-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './radio-props';
 

--- a/packages/mui-codemod/src/deprecations/rating-props/rating-props.test.js
+++ b/packages/mui-codemod/src/deprecations/rating-props/rating-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './rating-props';
 

--- a/packages/mui-codemod/src/deprecations/select-classes/select-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/select-classes/select-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './select-classes';

--- a/packages/mui-codemod/src/deprecations/slider-classes/slider-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/slider-classes/slider-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './slider-classes';

--- a/packages/mui-codemod/src/deprecations/slider-props/slider-props.test.js
+++ b/packages/mui-codemod/src/deprecations/slider-props/slider-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './slider-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/snackbar-props/snackbar-props.test.js
+++ b/packages/mui-codemod/src/deprecations/snackbar-props/snackbar-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './snackbar-props';
 

--- a/packages/mui-codemod/src/deprecations/speed-dial-action-props/speed-dial-action-props.test.js
+++ b/packages/mui-codemod/src/deprecations/speed-dial-action-props/speed-dial-action-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './speed-dial-action-props';
 

--- a/packages/mui-codemod/src/deprecations/speed-dial-props/speed-dial-props.test.js
+++ b/packages/mui-codemod/src/deprecations/speed-dial-props/speed-dial-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './speed-dial-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/step-connector-classes/step-connector-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/step-connector-classes/step-connector-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './step-connector-classes';

--- a/packages/mui-codemod/src/deprecations/step-content-props/step-content-props.test.js
+++ b/packages/mui-codemod/src/deprecations/step-content-props/step-content-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './step-content-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/step-label-props/step-label-props.test.js
+++ b/packages/mui-codemod/src/deprecations/step-label-props/step-label-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './step-label-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/deprecations/switch-props/switch-props.test.js
+++ b/packages/mui-codemod/src/deprecations/switch-props/switch-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './switch-props';
 

--- a/packages/mui-codemod/src/deprecations/tab-classes/tab-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/tab-classes/tab-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './tab-classes';

--- a/packages/mui-codemod/src/deprecations/table-pagination-props/table-pagination-props.test.js
+++ b/packages/mui-codemod/src/deprecations/table-pagination-props/table-pagination-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './table-pagination-props';
 

--- a/packages/mui-codemod/src/deprecations/table-sort-label-classes/table-sort-label-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/table-sort-label-classes/table-sort-label-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './table-sort-label-classes';

--- a/packages/mui-codemod/src/deprecations/tabs-classes/tabs-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/tabs-classes/tabs-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './tabs-classes';

--- a/packages/mui-codemod/src/deprecations/tabs-props/tabs-props.test.js
+++ b/packages/mui-codemod/src/deprecations/tabs-props/tabs-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './tabs-props';
 

--- a/packages/mui-codemod/src/deprecations/text-field-props/text-field-props.test.js
+++ b/packages/mui-codemod/src/deprecations/text-field-props/text-field-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './text-field-props';
 

--- a/packages/mui-codemod/src/deprecations/toggle-button-group-classes/toggle-button-group-classes.test.js
+++ b/packages/mui-codemod/src/deprecations/toggle-button-group-classes/toggle-button-group-classes.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import postcss from 'postcss';
 import { jscodeshift } from '../../../testUtils';
 import jsTransform from './toggle-button-group-classes';

--- a/packages/mui-codemod/src/deprecations/tooltip-props/tooltip-props.test.js
+++ b/packages/mui-codemod/src/deprecations/tooltip-props/tooltip-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './tooltip-props';
 

--- a/packages/mui-codemod/src/deprecations/typography-props/typography-props.test.js
+++ b/packages/mui-codemod/src/deprecations/typography-props/typography-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './typography-props';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/util/findComponentJSX.test.js
+++ b/packages/mui-codemod/src/util/findComponentJSX.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import findComponentJSX from './findComponentJSX';
 import { jscodeshift } from '../../testUtils';
 

--- a/packages/mui-codemod/src/v0.15.0/import-path.test.js
+++ b/packages/mui-codemod/src/v0.15.0/import-path.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './import-path';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v1.0.0/color-imports.test.js
+++ b/packages/mui-codemod/src/v1.0.0/color-imports.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './color-imports';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v1.0.0/import-path.test.js
+++ b/packages/mui-codemod/src/v1.0.0/import-path.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './import-path';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v1.0.0/menu-item-primary-text.test.js
+++ b/packages/mui-codemod/src/v1.0.0/menu-item-primary-text.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './menu-item-primary-text';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v1.0.0/svg-icon-imports.test.js
+++ b/packages/mui-codemod/src/v1.0.0/svg-icon-imports.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './svg-icon-imports';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v4.0.0/optimal-imports.test.js
+++ b/packages/mui-codemod/src/v4.0.0/optimal-imports.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './optimal-imports';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v4.0.0/theme-spacing-api.test.js
+++ b/packages/mui-codemod/src/v4.0.0/theme-spacing-api.test.js
@@ -1,6 +1,6 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
 import { EOL } from 'os';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './theme-spacing-api';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v4.0.0/top-level-imports.test.js
+++ b/packages/mui-codemod/src/v4.0.0/top-level-imports.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './top-level-imports';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/adapter-v4.test.js
+++ b/packages/mui-codemod/src/v5.0.0/adapter-v4.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './adapter-v4';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/autocomplete-rename-closeicon.test.js
+++ b/packages/mui-codemod/src/v5.0.0/autocomplete-rename-closeicon.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './autocomplete-rename-closeicon';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/autocomplete-rename-option.test.js
+++ b/packages/mui-codemod/src/v5.0.0/autocomplete-rename-option.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './autocomplete-rename-option';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/avatar-circle-circular.test.js
+++ b/packages/mui-codemod/src/v5.0.0/avatar-circle-circular.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './avatar-circle-circular';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/badge-overlap-value.test.js
+++ b/packages/mui-codemod/src/v5.0.0/badge-overlap-value.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './badge-overlap-value';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/base-hook-imports.test.js
+++ b/packages/mui-codemod/src/v5.0.0/base-hook-imports.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './base-hook-imports';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test.js
+++ b/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './base-remove-component-prop';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/base-remove-unstyled-suffix.test.js
+++ b/packages/mui-codemod/src/v5.0.0/base-remove-unstyled-suffix.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './base-remove-unstyled-suffix';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/base-rename-components-to-slots.test.js
+++ b/packages/mui-codemod/src/v5.0.0/base-rename-components-to-slots.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './base-rename-components-to-slots';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/base-use-named-exports.test.js
+++ b/packages/mui-codemod/src/v5.0.0/base-use-named-exports.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './base-use-named-exports';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/box-borderradius-values.test.js
+++ b/packages/mui-codemod/src/v5.0.0/box-borderradius-values.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './box-borderradius-values';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/box-rename-css.test.js
+++ b/packages/mui-codemod/src/v5.0.0/box-rename-css.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './box-rename-css';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/box-rename-gap.test.js
+++ b/packages/mui-codemod/src/v5.0.0/box-rename-gap.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './box-rename-gap';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/box-sx-prop.test.js
+++ b/packages/mui-codemod/src/v5.0.0/box-sx-prop.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './box-sx-prop';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/button-color-prop.test.js
+++ b/packages/mui-codemod/src/v5.0.0/button-color-prop.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './button-color-prop';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/chip-variant-prop.test.js
+++ b/packages/mui-codemod/src/v5.0.0/chip-variant-prop.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './chip-variant-prop';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/circularprogress-variant.test.js
+++ b/packages/mui-codemod/src/v5.0.0/circularprogress-variant.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './circularprogress-variant';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/collapse-rename-collapsedheight.test.js
+++ b/packages/mui-codemod/src/v5.0.0/collapse-rename-collapsedheight.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './collapse-rename-collapsedheight';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/component-rename-prop.test.js
+++ b/packages/mui-codemod/src/v5.0.0/component-rename-prop.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './component-rename-prop';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/core-styles-import.test.js
+++ b/packages/mui-codemod/src/v5.0.0/core-styles-import.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './core-styles-import';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/create-theme.test.js
+++ b/packages/mui-codemod/src/v5.0.0/create-theme.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './create-theme';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/date-pickers-moved-to-x.test.js
+++ b/packages/mui-codemod/src/v5.0.0/date-pickers-moved-to-x.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './date-pickers-moved-to-x';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/dialog-props.test.js
+++ b/packages/mui-codemod/src/v5.0.0/dialog-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './dialog-props';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/dialog-title-props.test.js
+++ b/packages/mui-codemod/src/v5.0.0/dialog-title-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './dialog-title-props';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/emotion-prepend-cache.test.js
+++ b/packages/mui-codemod/src/v5.0.0/emotion-prepend-cache.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './emotion-prepend-cache';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/expansion-panel-component.test.js
+++ b/packages/mui-codemod/src/v5.0.0/expansion-panel-component.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './expansion-panel-component';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/fab-variant.test.js
+++ b/packages/mui-codemod/src/v5.0.0/fab-variant.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './fab-variant';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/fade-rename-alpha.test.js
+++ b/packages/mui-codemod/src/v5.0.0/fade-rename-alpha.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './fade-rename-alpha';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/grid-justify-justifycontent.test.js
+++ b/packages/mui-codemod/src/v5.0.0/grid-justify-justifycontent.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './grid-justify-justifycontent';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/grid-list-component.test.js
+++ b/packages/mui-codemod/src/v5.0.0/grid-list-component.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './grid-list-component';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/icon-button-size.test.js
+++ b/packages/mui-codemod/src/v5.0.0/icon-button-size.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './icon-button-size';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/joy-avatar-remove-imgProps.test.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-avatar-remove-imgProps.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './joy-avatar-remove-imgProps';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/joy-rename-classname-prefix.test.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-rename-classname-prefix.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './joy-rename-classname-prefix';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/joy-rename-components-to-slots.test.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-rename-components-to-slots.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './joy-rename-components-to-slots';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/joy-rename-row-prop.test.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-rename-row-prop.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './joy-rename-row-prop';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/joy-text-field-to-input.test.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-text-field-to-input.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './joy-text-field-to-input';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-styled.test.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-styled.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './jss-to-styled';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshiftWithDefaultParser from 'jscodeshift';
 import transform from './jss-to-tss-react';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/link-underline-hover.test.js
+++ b/packages/mui-codemod/src/v5.0.0/link-underline-hover.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './link-underline-hover';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/material-ui-styles.test.js
+++ b/packages/mui-codemod/src/v5.0.0/material-ui-styles.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './material-ui-styles';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/material-ui-types.test.js
+++ b/packages/mui-codemod/src/v5.0.0/material-ui-types.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './material-ui-types';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/modal-props.test.js
+++ b/packages/mui-codemod/src/v5.0.0/modal-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './modal-props';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/moved-lab-modules.test.js
+++ b/packages/mui-codemod/src/v5.0.0/moved-lab-modules.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './moved-lab-modules';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/mui-replace.test.js
+++ b/packages/mui-codemod/src/v5.0.0/mui-replace.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './mui-replace';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/optimal-imports.test.js
+++ b/packages/mui-codemod/src/v5.0.0/optimal-imports.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './optimal-imports';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/pagination-round-circular.test.js
+++ b/packages/mui-codemod/src/v5.0.0/pagination-round-circular.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './pagination-round-circular';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/path-imports.test.js
+++ b/packages/mui-codemod/src/v5.0.0/path-imports.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './path-imports';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/preset-safe.test.js
+++ b/packages/mui-codemod/src/v5.0.0/preset-safe.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './preset-safe';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/rename-css-variables.test.js
+++ b/packages/mui-codemod/src/v5.0.0/rename-css-variables.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './rename-css-variables';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/root-ref.test.js
+++ b/packages/mui-codemod/src/v5.0.0/root-ref.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './root-ref';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/skeleton-variant.test.js
+++ b/packages/mui-codemod/src/v5.0.0/skeleton-variant.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './skeleton-variant';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/styled-engine-provider.test.js
+++ b/packages/mui-codemod/src/v5.0.0/styled-engine-provider.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './styled-engine-provider';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/table-props.test.js
+++ b/packages/mui-codemod/src/v5.0.0/table-props.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './table-props';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/tabs-scroll-buttons.test.js
+++ b/packages/mui-codemod/src/v5.0.0/tabs-scroll-buttons.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './tabs-scroll-buttons';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/textarea-minmax-rows.test.js
+++ b/packages/mui-codemod/src/v5.0.0/textarea-minmax-rows.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './textarea-minmax-rows';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/theme-breakpoints-width.test.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-breakpoints-width.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './theme-breakpoints-width';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/theme-breakpoints.test.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-breakpoints.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './theme-breakpoints';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/theme-options.test.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-options.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './theme-options';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/theme-palette-mode.test.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-palette-mode.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './theme-palette-mode';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/theme-provider.test.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-provider.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './theme-provider';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './theme-spacing';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/theme-typography-round.test.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-typography-round.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './theme-typography-round';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/top-level-imports.test.js
+++ b/packages/mui-codemod/src/v5.0.0/top-level-imports.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './top-level-imports';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/transitions.test.js
+++ b/packages/mui-codemod/src/v5.0.0/transitions.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './transitions';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/tree-view-moved-to-x.test.js
+++ b/packages/mui-codemod/src/v5.0.0/tree-view-moved-to-x.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './tree-view-moved-to-x';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/use-autocomplete.test.js
+++ b/packages/mui-codemod/src/v5.0.0/use-autocomplete.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './use-autocomplete';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/use-transitionprops.test.js
+++ b/packages/mui-codemod/src/v5.0.0/use-transitionprops.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './use-transitionprops';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/variant-prop.test.js
+++ b/packages/mui-codemod/src/v5.0.0/variant-prop.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './variant-prop';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/with-mobile-dialog.test.js
+++ b/packages/mui-codemod/src/v5.0.0/with-mobile-dialog.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './with-mobile-dialog';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v5.0.0/with-width.test.js
+++ b/packages/mui-codemod/src/v5.0.0/with-width.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './with-width';
 import readFile from '../util/readFile';

--- a/packages/mui-codemod/src/v6.0.0/grid-v2-props/grid-v2-props.test.js
+++ b/packages/mui-codemod/src/v6.0.0/grid-v2-props/grid-v2-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './grid-v2-props';
 

--- a/packages/mui-codemod/src/v6.0.0/list-item-button-prop/list-item-button-prop.test.js
+++ b/packages/mui-codemod/src/v6.0.0/list-item-button-prop/list-item-button-prop.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './list-item-button-prop';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/v6.0.0/styled/styled-v6.test.js
+++ b/packages/mui-codemod/src/v6.0.0/styled/styled-v6.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './styled-v6';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.test.js
+++ b/packages/mui-codemod/src/v6.0.0/sx-prop/sx-v6.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './sx-v6';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/v6.0.0/system-props/removeSystemProps.test.js
+++ b/packages/mui-codemod/src/v6.0.0/system-props/removeSystemProps.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './removeSystemProps';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/v6.0.0/theme-v6/theme-v6.test.js
+++ b/packages/mui-codemod/src/v6.0.0/theme-v6/theme-v6.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './theme-v6';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/v7.0.0/grid-props/grid-props.test.js
+++ b/packages/mui-codemod/src/v7.0.0/grid-props/grid-props.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './grid-props';
 

--- a/packages/mui-codemod/src/v7.0.0/input-label-size-normal-medium/input-label-size-normal-medium.test.js
+++ b/packages/mui-codemod/src/v7.0.0/input-label-size-normal-medium/input-label-size-normal-medium.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './input-label-size-normal-medium';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/src/v7.0.0/lab-removed-components/lab-removed-components.test.js
+++ b/packages/mui-codemod/src/v7.0.0/lab-removed-components/lab-removed-components.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './lab-removed-components';
 

--- a/packages/mui-codemod/src/v7.0.0/theme-color-functions/theme-color-functions.test.js
+++ b/packages/mui-codemod/src/v7.0.0/theme-color-functions/theme-color-functions.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { describeJscodeshiftTransform } from '../../../testUtils';
 import transform from './theme-color-functions';
 

--- a/packages/mui-codemod/src/v9.0.0/system-props/removeSystemProps.test.js
+++ b/packages/mui-codemod/src/v9.0.0/system-props/removeSystemProps.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { expect } from 'chai';
 import { jscodeshift } from '../../../testUtils';
 import transform from './removeSystemProps';
 import readFile from '../../util/readFile';

--- a/packages/mui-codemod/testUtils/index.js
+++ b/packages/mui-codemod/testUtils/index.js
@@ -1,8 +1,7 @@
-/* eslint-disable no-undef */
+import { describe, it, expect } from 'vitest';
 import j from 'jscodeshift';
 import { EOL } from 'os';
 import path from 'path';
-import { expect } from 'chai';
 import readFile from '../src/util/readFile';
 
 export const jscodeshift = j.withParser('tsx');

--- a/packages/mui-envinfo/src/envinfo.test.js
+++ b/packages/mui-envinfo/src/envinfo.test.js
@@ -1,8 +1,8 @@
+import { describe, expect, it } from 'vitest';
 import { isJsdom } from '@mui/internal-test-utils/env';
 
 const { execFileSync } = require('child_process');
 const path = require('path');
-const { expect } = require('chai');
 
 describe('@mui/envinfo', () => {
   const packagePath = __dirname;

--- a/packages/mui-icons-material/builder.test.mjs
+++ b/packages/mui-icons-material/builder.test.mjs
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';

--- a/packages/mui-lab/src/AlertTitle/AlertTitle.test.js
+++ b/packages/mui-lab/src/AlertTitle/AlertTitle.test.js
@@ -1,3 +1,5 @@
+import { describe, it } from 'vitest';
+
 describe('<AlertTitle />', () => {
   it('To do', () => {});
 });

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import {
   createRenderer,
   reactMajor,
@@ -6,7 +7,6 @@ import {
   flushEffects,
   isJsdom,
 } from '@mui/internal-test-utils';
-import { expect } from 'chai';
 import { createTheme } from '@mui/material/styles';
 import defaultTheme from '@mui/material/styles/defaultTheme';
 import Masonry, { masonryClasses as classes } from '@mui/lab/Masonry';

--- a/packages/mui-lab/src/TabContext/TabContext.test.js
+++ b/packages/mui-lab/src/TabContext/TabContext.test.js
@@ -1,7 +1,7 @@
 // @ts-check
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import TabContext, { getPanelId, getTabId, useTabContext } from './TabContext';
 

--- a/packages/mui-lab/src/TabList/TabList.test.js
+++ b/packages/mui-lab/src/TabList/TabList.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Tab from '@mui/material/Tab';
 import Tabs, { tabsClasses as classes } from '@mui/material/Tabs';

--- a/packages/mui-lab/src/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-lab/src/TabPanel/TabPanel.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import TabPanel, { tabPanelClasses as classes } from '@mui/lab/TabPanel';
 import TabContext from '../TabContext';

--- a/packages/mui-lab/src/Timeline/Timeline.test.tsx
+++ b/packages/mui-lab/src/Timeline/Timeline.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Timeline, { timelineClasses as classes } from '@mui/lab/Timeline';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-lab/src/TimelineConnector/TimelineConnector.test.js
+++ b/packages/mui-lab/src/TimelineConnector/TimelineConnector.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import TimelineConnector, { timelineConnectorClasses as classes } from '@mui/lab/TimelineConnector';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-lab/src/TimelineContent/TimelineContent.test.js
+++ b/packages/mui-lab/src/TimelineContent/TimelineContent.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Typography from '@mui/material/Typography';
 import Timeline from '@mui/lab/Timeline';

--- a/packages/mui-lab/src/TimelineDot/TimelineDot.test.js
+++ b/packages/mui-lab/src/TimelineDot/TimelineDot.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer } from '@mui/internal-test-utils';
 import TimelineDot, { timelineDotClasses as classes } from '@mui/lab/TimelineDot';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import TimelineItem, { timelineItemClasses as classes } from '@mui/lab/TimelineItem';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
+++ b/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Typography from '@mui/material/Typography';
 import Timeline from '@mui/lab/Timeline';

--- a/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.test.js
+++ b/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import TimelineSeparator, { timelineSeparatorClasses as classes } from '@mui/lab/TimelineSeparator';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-lab/src/index.test.js
+++ b/packages/mui-lab/src/index.test.js
@@ -3,7 +3,7 @@
  * Important: This test also serves as a point to
  * import the entire lib for coverage reporting
  */
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import * as MaterialUI from './index';
 
 describe('@mui/lab', () => {

--- a/packages/mui-lab/test/integration/Tabs.test.js
+++ b/packages/mui-lab/test/integration/Tabs.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Tab from '@mui/material/Tab';
 import TabContext from '@mui/lab/TabContext';

--- a/packages/mui-material/src/Accordion/Accordion.test.js
+++ b/packages/mui-material/src/Accordion/Accordion.test.js
@@ -1,6 +1,6 @@
+import { describe, it, expect, beforeEach } from 'vitest';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, fireEvent, reactMajor, screen } from '@mui/internal-test-utils';
 import Accordion, { accordionClasses as classes } from '@mui/material/Accordion';

--- a/packages/mui-material/src/AccordionActions/AccordionActions.test.js
+++ b/packages/mui-material/src/AccordionActions/AccordionActions.test.js
@@ -1,9 +1,9 @@
+import { describe, expect, it } from 'vitest';
 import { createRenderer, isJsdom } from '@mui/internal-test-utils';
 import AccordionActions, {
   accordionActionsClasses as classes,
 } from '@mui/material/AccordionActions';
 import Button from '@mui/material/Button';
-import { expect } from 'chai';
 import describeConformance from '../../test/describeConformance';
 
 describe('<AccordionActions />', () => {

--- a/packages/mui-material/src/AccordionDetails/AccordionDetails.test.js
+++ b/packages/mui-material/src/AccordionDetails/AccordionDetails.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import AccordionDetails, {
   accordionDetailsClasses as classes,

--- a/packages/mui-material/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/mui-material/src/AccordionSummary/AccordionSummary.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen, isJsdom } from '@mui/internal-test-utils';
 import AccordionSummary, {

--- a/packages/mui-material/src/Alert/Alert.test.js
+++ b/packages/mui-material/src/Alert/Alert.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Alert, { alertClasses as classes } from '@mui/material/Alert';

--- a/packages/mui-material/src/AlertTitle/AlertTitle.test.js
+++ b/packages/mui-material/src/AlertTitle/AlertTitle.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import AlertTitle, { alertTitleClasses as classes } from '@mui/material/AlertTitle';
 import Typography from '@mui/material/Typography';

--- a/packages/mui-material/src/AppBar/AppBar.test.js
+++ b/packages/mui-material/src/AppBar/AppBar.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import AppBar, { appBarClasses as classes } from '@mui/material/AppBar';
 import Paper from '@mui/material/Paper';

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1,6 +1,6 @@
+import { expect, describe, it, beforeEach } from 'vitest';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { expect } from 'chai';
 import {
   act,
   createRenderer,

--- a/packages/mui-material/src/Avatar/Avatar.test.js
+++ b/packages/mui-material/src/Avatar/Avatar.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, fireEvent } from '@mui/internal-test-utils';
 import { spy } from 'sinon';
 import Avatar, { avatarClasses as classes } from '@mui/material/Avatar';

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.test.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import Avatar from '@mui/material/Avatar';
 import AvatarGroup, { avatarGroupClasses as classes } from '@mui/material/AvatarGroup';

--- a/packages/mui-material/src/Backdrop/Backdrop.test.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { createRenderer } from '@mui/internal-test-utils';
 import Backdrop, { backdropClasses as classes } from '@mui/material/Backdrop';

--- a/packages/mui-material/src/Badge/Badge.test.js
+++ b/packages/mui-material/src/Badge/Badge.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Badge, { badgeClasses as classes } from '@mui/material/Badge';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/mui-material/src/BottomNavigation/BottomNavigation.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import BottomNavigation, {

--- a/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, within, screen } from '@mui/internal-test-utils';
 import BottomNavigationAction, {

--- a/packages/mui-material/src/Box/Box.test.js
+++ b/packages/mui-material/src/Box/Box.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, expect, afterEach, it } from 'vitest';
 import { createRenderer, isJsdom } from '@mui/internal-test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Box from '@mui/material/Box';

--- a/packages/mui-material/src/Breadcrumbs/BreadcrumbCollapsed.test.js
+++ b/packages/mui-material/src/Breadcrumbs/BreadcrumbCollapsed.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { fireEvent, createRenderer, screen } from '@mui/internal-test-utils';
 import BreadcrumbCollapsed from './BreadcrumbCollapsed';

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import {
   act,
   createRenderer,

--- a/packages/mui-material/src/Button/Button.test.js
+++ b/packages/mui-material/src/Button/Button.test.js
@@ -1,5 +1,5 @@
+import { describe, expect, it, vi } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import {
   createRenderer,
   screen,

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -1,6 +1,6 @@
 // @ts-check
+import { describe, beforeAll, it, expect, beforeEach, vi } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import {
   act,

--- a/packages/mui-material/src/ButtonBase/Ripple.test.js
+++ b/packages/mui-material/src/ButtonBase/Ripple.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { createRenderer } from '@mui/internal-test-utils';
 import Ripple from './Ripple';

--- a/packages/mui-material/src/ButtonBase/TouchRipple.test.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { act, createRenderer } from '@mui/internal-test-utils';
 import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/ButtonBase/useButtonBase.test.tsx
+++ b/packages/mui-material/src/ButtonBase/useButtonBase.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import useButtonBase, { UseButtonBaseParameters } from './useButtonBase';

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import ButtonGroup, { buttonGroupClasses as classes } from '@mui/material/ButtonGroup';
 import { ThemeProvider, createTheme } from '@mui/material/styles';

--- a/packages/mui-material/src/Card/Card.test.tsx
+++ b/packages/mui-material/src/Card/Card.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import Card, { cardClasses as classes } from '@mui/material/Card';
 import Paper from '@mui/material/Paper';

--- a/packages/mui-material/src/CardActionArea/CardActionArea.test.js
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer } from '@mui/internal-test-utils';
 import CardActionArea, { cardActionAreaClasses as classes } from '@mui/material/CardActionArea';
 import ButtonBase from '@mui/material/ButtonBase';

--- a/packages/mui-material/src/CardActions/CardActions.test.js
+++ b/packages/mui-material/src/CardActions/CardActions.test.js
@@ -1,7 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import { createRenderer, isJsdom } from '@mui/internal-test-utils';
 import CardActions, { cardActionsClasses as classes } from '@mui/material/CardActions';
 import Button from '@mui/material/Button';
-import { expect } from 'chai';
 import describeConformance from '../../test/describeConformance';
 
 describe('<CardActions />', () => {

--- a/packages/mui-material/src/CardContent/CardContent.test.js
+++ b/packages/mui-material/src/CardContent/CardContent.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import CardContent, { cardContentClasses as classes } from '@mui/material/CardContent';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/CardHeader/CardHeader.test.js
+++ b/packages/mui-material/src/CardHeader/CardHeader.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import { typographyClasses } from '@mui/material/Typography';
 import Avatar from '@mui/material/Avatar';

--- a/packages/mui-material/src/CardMedia/CardMedia.test.js
+++ b/packages/mui-material/src/CardMedia/CardMedia.test.js
@@ -1,6 +1,6 @@
+import { describe, it, expect, beforeEach } from 'vitest';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import CardMedia, { cardMediaClasses as classes } from '@mui/material/CardMedia';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/Checkbox/Checkbox.test.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import Checkbox, { checkboxClasses as classes } from '@mui/material/Checkbox';

--- a/packages/mui-material/src/Chip/Chip.test.js
+++ b/packages/mui-material/src/Chip/Chip.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import {
   act,

--- a/packages/mui-material/src/CircularProgress/CircularProgress.test.js
+++ b/packages/mui-material/src/CircularProgress/CircularProgress.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import CircularProgress, {
   circularProgressClasses as classes,

--- a/packages/mui-material/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/mui-material/src/ClickAwayListener/ClickAwayListener.test.js
@@ -1,6 +1,6 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import Portal from '@mui/material/Portal';

--- a/packages/mui-material/src/Collapse/Collapse.test.js
+++ b/packages/mui-material/src/Collapse/Collapse.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, beforeEach } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import { act, createRenderer, isJsdom } from '@mui/internal-test-utils';
 import { Transition } from 'react-transition-group';

--- a/packages/mui-material/src/Container/Container.test.js
+++ b/packages/mui-material/src/Container/Container.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import Container, { containerClasses as classes } from '@mui/material/Container';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/CssBaseline/CssBaseline.test.js
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, isJsdom } from '@mui/internal-test-utils';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider, createTheme, hexToRgb } from '@mui/material/styles';

--- a/packages/mui-material/src/Dialog/Dialog.test.js
+++ b/packages/mui-material/src/Dialog/Dialog.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen, isJsdom } from '@mui/internal-test-utils';
 import Modal from '@mui/material/Modal';

--- a/packages/mui-material/src/DialogActions/DialogActions.test.js
+++ b/packages/mui-material/src/DialogActions/DialogActions.test.js
@@ -1,7 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import { createRenderer, isJsdom } from '@mui/internal-test-utils';
 import DialogActions, { dialogActionsClasses as classes } from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
-import { expect } from 'chai';
 import describeConformance from '../../test/describeConformance';
 
 describe('<DialogActions />', () => {

--- a/packages/mui-material/src/DialogContent/DialogContent.test.js
+++ b/packages/mui-material/src/DialogContent/DialogContent.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import DialogContent, { dialogContentClasses as classes } from '@mui/material/DialogContent';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/DialogContentText/DialogContentText.test.js
+++ b/packages/mui-material/src/DialogContentText/DialogContentText.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Typography from '@mui/material/Typography';
 import DialogContentText, {

--- a/packages/mui-material/src/DialogTitle/DialogTitle.test.js
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Typography from '@mui/material/Typography';
 import DialogTitle, { dialogTitleClasses as classes } from '@mui/material/DialogTitle';

--- a/packages/mui-material/src/Divider/Divider.test.js
+++ b/packages/mui-material/src/Divider/Divider.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import { styled } from '@mui/material/styles';
 import Divider, { dividerClasses as classes } from '@mui/material/Divider';

--- a/packages/mui-material/src/Drawer/Drawer.test.js
+++ b/packages/mui-material/src/Drawer/Drawer.test.js
@@ -1,5 +1,5 @@
+import { describe, expect, it } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';

--- a/packages/mui-material/src/Fab/Fab.test.js
+++ b/packages/mui-material/src/Fab/Fab.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import Fab, { fabClasses as classes } from '@mui/material/Fab';
 import ButtonBase, { touchRippleClasses } from '@mui/material/ButtonBase';

--- a/packages/mui-material/src/Fade/Fade.test.js
+++ b/packages/mui-material/src/Fade/Fade.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import { Transition } from 'react-transition-group';

--- a/packages/mui-material/src/FilledInput/FilledInput.test.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import { styled } from '@mui/material/styles';
 import FilledInput, { filledInputClasses as classes } from '@mui/material/FilledInput';

--- a/packages/mui-material/src/FormControl/FormControl.test.js
+++ b/packages/mui-material/src/FormControl/FormControl.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, createRenderer } from '@mui/internal-test-utils';
 import FormControl, { formControlClasses as classes } from '@mui/material/FormControl';

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import FormControlLabel, {
   formControlLabelClasses as classes,

--- a/packages/mui-material/src/FormGroup/FormGroup.test.js
+++ b/packages/mui-material/src/FormGroup/FormGroup.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import FormGroup, { formGroupClasses as classes } from '@mui/material/FormGroup';
 import FormControl from '@mui/material/FormControl';

--- a/packages/mui-material/src/FormHelperText/FormHelperText.test.js
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import FormHelperText, { formHelperTextClasses as classes } from '@mui/material/FormHelperText';
 import FormControl from '@mui/material/FormControl';

--- a/packages/mui-material/src/FormLabel/FormLabel.test.js
+++ b/packages/mui-material/src/FormLabel/FormLabel.test.js
@@ -1,6 +1,6 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { expect } from 'chai';
 import { act, createRenderer, screen } from '@mui/internal-test-utils';
 import FormLabel, { formLabelClasses as classes } from '@mui/material/FormLabel';
 import FormControl, { useFormControl } from '@mui/material/FormControl';

--- a/packages/mui-material/src/GlobalStyles/GlobalStyles.test.js
+++ b/packages/mui-material/src/GlobalStyles/GlobalStyles.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, expect, it } from 'vitest';
 import { createRenderer, isJsdom } from '@mui/internal-test-utils';
 import GlobalStyles from '@mui/material/GlobalStyles';
 import { ThemeProvider, createTheme } from '@mui/material/styles/';

--- a/packages/mui-material/src/Grid/Grid.test.js
+++ b/packages/mui-material/src/Grid/Grid.test.js
@@ -1,7 +1,7 @@
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Grid, { gridClasses as classes } from '@mui/material/Grid';
 import { createTheme, ThemeProvider, THEME_ID } from '@mui/material/styles';
-import { expect } from 'chai';
 import describeConformance from '../../test/describeConformance';
 
 // The main tests are in mui-system Grid folder

--- a/packages/mui-material/src/Grow/Grow.test.js
+++ b/packages/mui-material/src/Grow/Grow.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer } from '@mui/internal-test-utils';
 import { Transition } from 'react-transition-group';

--- a/packages/mui-material/src/Icon/Icon.test.js
+++ b/packages/mui-material/src/Icon/Icon.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Icon, { iconClasses as classes } from '@mui/material/Icon';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { createRenderer, reactMajor, screen, within } from '@mui/internal-test-utils';
 import capitalize from '@mui/utils/capitalize';

--- a/packages/mui-material/src/ImageList/ImageList.test.js
+++ b/packages/mui-material/src/ImageList/ImageList.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import ImageList, { imageListClasses as classes } from '@mui/material/ImageList';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/ImageListItem/ImageListItem.test.js
+++ b/packages/mui-material/src/ImageListItem/ImageListItem.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import ImageList from '@mui/material/ImageList';

--- a/packages/mui-material/src/ImageListItemBar/ImageListItemBar.test.js
+++ b/packages/mui-material/src/ImageListItemBar/ImageListItemBar.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import ImageListItemBar, {
   imageListItemBarClasses as classes,

--- a/packages/mui-material/src/InitColorSchemeScript/InitColorSchemeScript.test.tsx
+++ b/packages/mui-material/src/InitColorSchemeScript/InitColorSchemeScript.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import InitColorSchemeScript from '@mui/material/InitColorSchemeScript';
 

--- a/packages/mui-material/src/Input/Input.test.js
+++ b/packages/mui-material/src/Input/Input.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import InputBase from '@mui/material/InputBase';
 import Input, { inputClasses as classes } from '@mui/material/Input';

--- a/packages/mui-material/src/InputAdornment/InputAdornment.test.js
+++ b/packages/mui-material/src/InputAdornment/InputAdornment.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import {
   createRenderer,
   strictModeDoubleLoggingSuppressed,

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -1,6 +1,6 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
   act,

--- a/packages/mui-material/src/InputBase/utils.test.js
+++ b/packages/mui-material/src/InputBase/utils.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { hasValue, isFilled } from './utils';
 
 describe('Input/utils.js', () => {

--- a/packages/mui-material/src/InputLabel/InputLabel.test.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import PropTypes from 'prop-types';
-import { expect } from 'chai';
 import { act, createRenderer, screen } from '@mui/internal-test-utils';
 import { ClassNames } from '@emotion/react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';

--- a/packages/mui-material/src/LinearProgress/LinearProgress.test.js
+++ b/packages/mui-material/src/LinearProgress/LinearProgress.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import {
   createRenderer,
   screen,

--- a/packages/mui-material/src/Link/Link.test.js
+++ b/packages/mui-material/src/Link/Link.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen, isJsdom } from '@mui/internal-test-utils';
 import Link, { linkClasses as classes } from '@mui/material/Link';

--- a/packages/mui-material/src/Link/getTextDecoration.test.js
+++ b/packages/mui-material/src/Link/getTextDecoration.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createTheme, extendTheme } from '../styles';
 import getTextDecoration from './getTextDecoration';
 

--- a/packages/mui-material/src/List/List.test.js
+++ b/packages/mui-material/src/List/List.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer } from '@mui/internal-test-utils';
 import ListSubheader, { listSubheaderClasses } from '@mui/material/ListSubheader';
 import ListItem, { listItemClasses } from '@mui/material/ListItem';

--- a/packages/mui-material/src/ListItem/ListItem.test.js
+++ b/packages/mui-material/src/ListItem/ListItem.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import ListItem, { listItemClasses as classes } from '@mui/material/ListItem';
 import ListContext from '../List/ListContext';

--- a/packages/mui-material/src/ListItemAvatar/ListItemAvatar.test.js
+++ b/packages/mui-material/src/ListItemAvatar/ListItemAvatar.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import ListItemAvatar, { listItemAvatarClasses as classes } from '@mui/material/ListItemAvatar';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/ListItemButton/ListItemButton.test.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { act, createRenderer, fireEvent, screen, isJsdom } from '@mui/internal-test-utils';
 import ListItemButton, { listItemButtonClasses as classes } from '@mui/material/ListItemButton';
 import ButtonBase from '@mui/material/ButtonBase';

--- a/packages/mui-material/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/mui-material/src/ListItemIcon/ListItemIcon.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import ListItemIcon, { listItemIconClasses as classes } from '@mui/material/ListItemIcon';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
+++ b/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import ListItem from '@mui/material/ListItem';
 import ListItemSecondaryAction, {

--- a/packages/mui-material/src/ListItemText/ListItemText.test.js
+++ b/packages/mui-material/src/ListItemText/ListItemText.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Typography, { typographyClasses } from '@mui/material/Typography';
 import ListItemText, { listItemTextClasses as classes } from '@mui/material/ListItemText';

--- a/packages/mui-material/src/ListSubheader/ListSubheader.test.js
+++ b/packages/mui-material/src/ListSubheader/ListSubheader.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import ListSubheader, { listSubheaderClasses as classes } from '@mui/material/ListSubheader';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/Menu/Menu.test.js
+++ b/packages/mui-material/src/Menu/Menu.test.js
@@ -1,6 +1,6 @@
+import { describe, beforeAll, afterAll, it, expect } from 'vitest';
 import * as React from 'react';
 import { spy } from 'sinon';
-import { expect } from 'chai';
 import { createRenderer, screen, fireEvent, reactMajor, isJsdom } from '@mui/internal-test-utils';
 import Menu, { menuClasses as classes } from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';

--- a/packages/mui-material/src/MenuItem/MenuItem.test.js
+++ b/packages/mui-material/src/MenuItem/MenuItem.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen, supportsTouch } from '@mui/internal-test-utils';
 import MenuItem, { menuItemClasses as classes } from '@mui/material/MenuItem';

--- a/packages/mui-material/src/MenuList/MenuList.test.js
+++ b/packages/mui-material/src/MenuList/MenuList.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import Divider from '@mui/material/Divider';

--- a/packages/mui-material/src/MobileStepper/MobileStepper.test.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import Paper, { paperClasses } from '@mui/material/Paper';
 import Button from '@mui/material/Button';

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -1,6 +1,6 @@
+import { describe, beforeAll, beforeEach, afterAll, it, expect, afterEach } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
 import { act, createRenderer, fireEvent, within, screen, isJsdom } from '@mui/internal-test-utils';

--- a/packages/mui-material/src/Modal/ModalManager.test.ts
+++ b/packages/mui-material/src/Modal/ModalManager.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeAll, afterAll, it, expect, beforeEach, afterEach } from 'vitest';
 import getScrollbarSize from '@mui/utils/getScrollbarSize';
 import { ModalManager } from './ModalManager';
 

--- a/packages/mui-material/src/NativeSelect/NativeSelect.test.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import { createTheme, ThemeProvider, styled } from '@mui/material/styles';
 import NativeSelect, { nativeSelectClasses as classes } from '@mui/material/NativeSelect';

--- a/packages/mui-material/src/NativeSelect/NativeSelectInput.test.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelectInput.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { createRenderer, fireEvent, isJsdom } from '@mui/internal-test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';

--- a/packages/mui-material/src/NoSsr/NoSsr.test.tsx
+++ b/packages/mui-material/src/NoSsr/NoSsr.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import NoSsr from '@mui/material/NoSsr';
 

--- a/packages/mui-material/src/OutlinedInput/NotchedOutline.test.js
+++ b/packages/mui-material/src/OutlinedInput/NotchedOutline.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, isJsdom } from '@mui/internal-test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import NotchedOutline from './NotchedOutline';

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer } from '@mui/internal-test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import OutlinedInput, { outlinedInputClasses as classes } from '@mui/material/OutlinedInput';

--- a/packages/mui-material/src/Pagination/Pagination.test.js
+++ b/packages/mui-material/src/Pagination/Pagination.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';

--- a/packages/mui-material/src/PaginationItem/PaginationItem.test.js
+++ b/packages/mui-material/src/PaginationItem/PaginationItem.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft';
 import KeyboardDoubleArrowRightIcon from '@mui/icons-material/KeyboardDoubleArrowRight';

--- a/packages/mui-material/src/Paper/Paper.test.js
+++ b/packages/mui-material/src/Paper/Paper.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect, beforeEach } from 'vitest';
 import PropTypes from 'prop-types';
 import {
   createRenderer,

--- a/packages/mui-material/src/Popover/Popover.test.js
+++ b/packages/mui-material/src/Popover/Popover.test.js
@@ -1,5 +1,5 @@
+import { describe, beforeAll, afterAll, it, expect, beforeEach, afterEach } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy, stub, match } from 'sinon';
 import { act, createRenderer, reactMajor, screen } from '@mui/internal-test-utils';
 import PropTypes from 'prop-types';

--- a/packages/mui-material/src/Popper/Popper.test.js
+++ b/packages/mui-material/src/Popper/Popper.test.js
@@ -1,5 +1,5 @@
+import { describe, beforeAll, afterAll, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, fireEvent, screen, isJsdom } from '@mui/internal-test-utils';
 import { ThemeProvider } from '@mui/system';
 import createTheme from '@mui/system/createTheme';

--- a/packages/mui-material/src/Portal/Portal.test.tsx
+++ b/packages/mui-material/src/Portal/Portal.test.tsx
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, reactMajor, isJsdom } from '@mui/internal-test-utils';
 import Portal, { PortalProps } from '@mui/material/Portal';

--- a/packages/mui-material/src/Radio/Radio.test.js
+++ b/packages/mui-material/src/Radio/Radio.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import Radio, { radioClasses as classes } from '@mui/material/Radio';
 import FormControl from '@mui/material/FormControl';

--- a/packages/mui-material/src/RadioGroup/RadioGroup.test.js
+++ b/packages/mui-material/src/RadioGroup/RadioGroup.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';

--- a/packages/mui-material/src/Rating/Rating.test.js
+++ b/packages/mui-material/src/Rating/Rating.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { stub, spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen, isJsdom } from '@mui/internal-test-utils';
 import Rating, { ratingClasses as classes } from '@mui/material/Rating';

--- a/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.test.js
+++ b/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import ScopedCssBaseline, {
   scopedCssBaselineClasses as classes,

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import {
   ErrorBoundary,

--- a/packages/mui-material/src/Skeleton/Skeleton.test.js
+++ b/packages/mui-material/src/Skeleton/Skeleton.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import Skeleton, { skeletonClasses as classes } from '@mui/material/Skeleton';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/Slide/Slide.test.js
+++ b/packages/mui-material/src/Slide/Slide.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import { act, createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import { Transition } from 'react-transition-group';

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1,7 +1,7 @@
+import { it, expect, describe, beforeEach } from 'vitest';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { spy, stub } from 'sinon';
-import { expect } from 'chai';
 import {
   act,
   createRenderer,

--- a/packages/mui-material/src/Slider/useSlider.test.js
+++ b/packages/mui-material/src/Slider/useSlider.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
 import { useSlider } from './useSlider';

--- a/packages/mui-material/src/Snackbar/Snackbar.test.js
+++ b/packages/mui-material/src/Snackbar/Snackbar.test.js
@@ -1,6 +1,6 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import clsx from 'clsx';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen, isJsdom } from '@mui/internal-test-utils';
 import Snackbar, { snackbarClasses as classes } from '@mui/material/Snackbar';

--- a/packages/mui-material/src/Snackbar/useSnackbar.test.tsx
+++ b/packages/mui-material/src/Snackbar/useSnackbar.test.tsx
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { fireEvent, createRenderer, screen } from '@mui/internal-test-utils';
 import useSnackbar from './useSnackbar';

--- a/packages/mui-material/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/mui-material/src/SnackbarContent/SnackbarContent.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Paper, { paperClasses } from '@mui/material/Paper';
 import SnackbarContent, { snackbarContentClasses as classes } from '@mui/material/SnackbarContent';

--- a/packages/mui-material/src/SpeedDial/SpeedDial.test.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import {
   createRenderer,

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import Icon from '@mui/material/Icon';
 import Tooltip from '@mui/material/Tooltip';

--- a/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.test.js
+++ b/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Icon from '@mui/material/Icon';
 import SpeedDialIcon, { speedDialIconClasses as classes } from '@mui/material/SpeedDialIcon';

--- a/packages/mui-material/src/Stack/Stack.test.js
+++ b/packages/mui-material/src/Stack/Stack.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import Stack, { stackClasses as classes } from '@mui/material/Stack';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/Step/Step.test.js
+++ b/packages/mui-material/src/Step/Step.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Step, { stepClasses as classes } from '@mui/material/Step';
 import Stepper, { StepperContext } from '@mui/material/Stepper';

--- a/packages/mui-material/src/StepButton/StepButton.test.js
+++ b/packages/mui-material/src/StepButton/StepButton.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, screen, fireEvent, supportsTouch } from '@mui/internal-test-utils';
 import StepButton, { stepButtonClasses as classes } from '@mui/material/StepButton';

--- a/packages/mui-material/src/StepConnector/StepConnector.test.js
+++ b/packages/mui-material/src/StepConnector/StepConnector.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import Step from '@mui/material/Step';
 import StepConnector, { stepConnectorClasses as classes } from '@mui/material/StepConnector';

--- a/packages/mui-material/src/StepContent/StepContent.test.js
+++ b/packages/mui-material/src/StepContent/StepContent.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import { collapseClasses } from '@mui/material/Collapse';
 import Stepper from '@mui/material/Stepper';

--- a/packages/mui-material/src/StepIcon/StepIcon.test.js
+++ b/packages/mui-material/src/StepIcon/StepIcon.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import StepIcon, { stepIconClasses as classes } from '@mui/material/StepIcon';
 import SvgIcon from '@mui/material/SvgIcon';

--- a/packages/mui-material/src/StepLabel/StepLabel.test.js
+++ b/packages/mui-material/src/StepLabel/StepLabel.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Typography from '@mui/material/Typography';
 import Stepper from '@mui/material/Stepper';

--- a/packages/mui-material/src/Stepper/Stepper.test.tsx
+++ b/packages/mui-material/src/Stepper/Stepper.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Step, { StepProps, stepClasses } from '@mui/material/Step';

--- a/packages/mui-material/src/SvgIcon/SvgIcon.test.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeAll, it, expect } from 'vitest';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import SvgIcon, { svgIconClasses as classes } from '@mui/material/SvgIcon';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
   fireEvent,

--- a/packages/mui-material/src/Switch/Switch.test.js
+++ b/packages/mui-material/src/Switch/Switch.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import Switch, { switchClasses as classes } from '@mui/material/Switch';
 import FormControl from '@mui/material/FormControl';

--- a/packages/mui-material/src/Tab/Tab.test.js
+++ b/packages/mui-material/src/Tab/Tab.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, simulatePointerDevice, screen, isJsdom } from '@mui/internal-test-utils';
 import Tab, { tabClasses as classes } from '@mui/material/Tab';

--- a/packages/mui-material/src/TabScrollButton/TabScrollButton.test.js
+++ b/packages/mui-material/src/TabScrollButton/TabScrollButton.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import TabScrollButton, { tabScrollButtonClasses as classes } from '@mui/material/TabScrollButton';
 import { createSvgIcon } from '@mui/material/utils';

--- a/packages/mui-material/src/Table/Table.test.js
+++ b/packages/mui-material/src/Table/Table.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Table, { tableClasses as classes } from '@mui/material/Table';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/TableBody/TableBody.test.js
+++ b/packages/mui-material/src/TableBody/TableBody.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import TableBody, { tableBodyClasses as classes } from '@mui/material/TableBody';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/TableCell/TableCell.test.js
+++ b/packages/mui-material/src/TableCell/TableCell.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import TableCell, { tableCellClasses as classes } from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';

--- a/packages/mui-material/src/TableContainer/TableContainer.test.js
+++ b/packages/mui-material/src/TableContainer/TableContainer.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import TableContainer, { tableContainerClasses as classes } from '@mui/material/TableContainer';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/TableFooter/TableFooter.test.js
+++ b/packages/mui-material/src/TableFooter/TableFooter.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import TableFooter, { tableFooterClasses as classes } from '@mui/material/TableFooter';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/TableHead/TableHead.test.js
+++ b/packages/mui-material/src/TableHead/TableHead.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import TableHead, { tableHeadClasses as classes } from '@mui/material/TableHead';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/TablePagination/TablePagination.test.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, beforeEach } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
 import { fireEvent, createRenderer, screen } from '@mui/internal-test-utils';

--- a/packages/mui-material/src/TablePaginationActions/TablePaginationActions.test.js
+++ b/packages/mui-material/src/TablePaginationActions/TablePaginationActions.test.js
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import TablePaginationActions, {
   tablePaginationActionsClasses as classes,

--- a/packages/mui-material/src/TableRow/TableRow.test.js
+++ b/packages/mui-material/src/TableRow/TableRow.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import TableRow, { tableRowClasses as classes } from '@mui/material/TableRow';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import TableSortLabel, { tableSortLabelClasses as classes } from '@mui/material/TableSortLabel';
 import ButtonBase from '@mui/material/ButtonBase';

--- a/packages/mui-material/src/Tabs/ScrollbarSize.test.js
+++ b/packages/mui-material/src/Tabs/ScrollbarSize.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy, stub } from 'sinon';
 import { createRenderer } from '@mui/internal-test-utils';
 import ScrollbarSize from './ScrollbarSize';

--- a/packages/mui-material/src/Tabs/Tabs.test.js
+++ b/packages/mui-material/src/Tabs/Tabs.test.js
@@ -1,5 +1,5 @@
+import { it, expect, describe, beforeAll, afterAll } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
   act,

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, fireEvent, screen, isJsdom } from '@mui/internal-test-utils';
 import FormControl from '@mui/material/FormControl';

--- a/packages/mui-material/src/TextareaAutosize/TextareaAutosize.test.tsx
+++ b/packages/mui-material/src/TextareaAutosize/TextareaAutosize.test.tsx
@@ -1,5 +1,5 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import sinon, { spy, stub } from 'sinon';
 import { act, screen, waitFor, createRenderer, fireEvent, isJsdom } from '@mui/internal-test-utils';
 import TextareaAutosize from '@mui/material/TextareaAutosize';

--- a/packages/mui-material/src/ToggleButton/ToggleButton.test.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import ToggleButton, { toggleButtonClasses as classes } from '@mui/material/ToggleButton';

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import ToggleButtonGroup, {

--- a/packages/mui-material/src/ToggleButtonGroup/isValueSelected.test.js
+++ b/packages/mui-material/src/ToggleButtonGroup/isValueSelected.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import isValueSelected from './isValueSelected';
 
 describe('<ToggleButton /> isValueSelected', () => {

--- a/packages/mui-material/src/Toolbar/Toolbar.test.js
+++ b/packages/mui-material/src/Toolbar/Toolbar.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import Toolbar, { toolbarClasses as classes } from '@mui/material/Toolbar';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -1,5 +1,5 @@
+import { describe, beforeEach, it, expect, afterEach } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
   act,

--- a/packages/mui-material/src/Typography/Typography.test.js
+++ b/packages/mui-material/src/Typography/Typography.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Typography, { typographyClasses as classes } from '@mui/material/Typography';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
@@ -1,6 +1,6 @@
+import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { expect } from 'chai';
 import { act, createRenderer, reactMajor, screen } from '@mui/internal-test-utils';
 import FocusTrap from '@mui/material/Unstable_TrapFocus';
 import Portal from '@mui/material/Portal';

--- a/packages/mui-material/src/Zoom/Zoom.test.js
+++ b/packages/mui-material/src/Zoom/Zoom.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import { Transition } from 'react-transition-group';

--- a/packages/mui-material/src/index.test.js
+++ b/packages/mui-material/src/index.test.js
@@ -3,7 +3,7 @@
  * Important: This test also serves as a point to
  * import the entire lib for coverage reporting
  */
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import * as MaterialUI from './index';
 
 // To skip them in the undefined exports test

--- a/packages/mui-material/src/internal/SwitchBase.test.js
+++ b/packages/mui-material/src/internal/SwitchBase.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { act, createRenderer, reactMajor, screen, fireEvent } from '@mui/internal-test-utils';
 import SwitchBase from './SwitchBase';

--- a/packages/mui-material/src/internal/animate.test.js
+++ b/packages/mui-material/src/internal/animate.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { beforeAll, afterAll, it, expect, describe } from 'vitest';
 import { isJsdom } from '@mui/internal-test-utils/env';
 import animate from './animate';
 

--- a/packages/mui-material/src/locale/utils/buildFormatNumber.test.ts
+++ b/packages/mui-material/src/locale/utils/buildFormatNumber.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import buildFormatNumber from './buildFormatNumber';
 
 describe('buildFormatNumber', () => {

--- a/packages/mui-material/src/styles/ThemeProvider.test.tsx
+++ b/packages/mui-material/src/styles/ThemeProvider.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 import { createRenderer, renderHook, screen } from '@mui/internal-test-utils';
 import { ThemeProvider, createTheme, useColorScheme, useTheme } from '@mui/material/styles';
 import Button from '@mui/material/Button';

--- a/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
+++ b/packages/mui-material/src/styles/ThemeProviderWithVars.test.js
@@ -1,5 +1,5 @@
+import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen, fireEvent, isJsdom } from '@mui/internal-test-utils';
 import Box from '@mui/material/Box';
 import {

--- a/packages/mui-material/src/styles/adaptV4Theme.test.js
+++ b/packages/mui-material/src/styles/adaptV4Theme.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import defaultTheme from '@mui/material/styles/defaultTheme';
 import adaptV4Theme from './adaptV4Theme';
 

--- a/packages/mui-material/src/styles/createMixins.test.js
+++ b/packages/mui-material/src/styles/createMixins.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createTheme } from '@mui/material/styles';
 import createMixins from './createMixins';
 

--- a/packages/mui-material/src/styles/createPalette.test.js
+++ b/packages/mui-material/src/styles/createPalette.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { darken, lighten } from '@mui/system/colorManipulator';
 import { deepOrange, blue, purple, indigo } from '../colors';
 import createPalette, { dark, light } from './createPalette';

--- a/packages/mui-material/src/styles/createTheme.test.js
+++ b/packages/mui-material/src/styles/createTheme.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, isJsdom, screen } from '@mui/internal-test-utils';
 import {
   alpha as systemAlpha,

--- a/packages/mui-material/src/styles/createTransitions.test.js
+++ b/packages/mui-material/src/styles/createTransitions.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createTheme } from '@mui/material/styles';
 import createTransitions, { easing, duration } from './createTransitions';
 

--- a/packages/mui-material/src/styles/createTypography.test.js
+++ b/packages/mui-material/src/styles/createTypography.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeAll, it, expect } from 'vitest';
 import createPalette from './createPalette';
 import createTypography from './createTypography';
 

--- a/packages/mui-material/src/styles/cssUtils.test.js
+++ b/packages/mui-material/src/styles/cssUtils.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import {
   isUnitless,
   getUnit,

--- a/packages/mui-material/src/styles/excludeVariablesFromRoot.test.ts
+++ b/packages/mui-material/src/styles/excludeVariablesFromRoot.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import excludeVariablesFromRoot from './excludeVariablesFromRoot';
 
 describe('excludeVariablesFromRoot', () => {

--- a/packages/mui-material/src/styles/extendTheme.test.js
+++ b/packages/mui-material/src/styles/extendTheme.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 import sinon from 'sinon';
 import { createRenderer } from '@mui/internal-test-utils';
 import Button from '@mui/material/Button';

--- a/packages/mui-material/src/styles/responsiveFontSizes.test.js
+++ b/packages/mui-material/src/styles/responsiveFontSizes.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createTheme } from '@mui/material/styles';
 import defaultTheme from './defaultTheme';
 import responsiveFontSizes from './responsiveFontSizes';

--- a/packages/mui-material/src/styles/stringifyTheme.test.ts
+++ b/packages/mui-material/src/styles/stringifyTheme.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createTheme } from '@mui/material/styles';
 import { stringifyTheme } from './stringifyTheme';
 

--- a/packages/mui-material/src/styles/styled.test.js
+++ b/packages/mui-material/src/styles/styled.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, beforeAll } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import createTheme from './createTheme';
 import styled from './styled';

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, beforeEach } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import {
   createRenderer,
   screen,

--- a/packages/mui-material/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/mui-material/src/useMediaQuery/useMediaQuery.test.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -8,7 +9,6 @@ import {
   strictModeDoubleLoggingSuppressed,
 } from '@mui/internal-test-utils';
 import mediaQuery from 'css-mediaquery';
-import { expect } from 'chai';
 import { stub } from 'sinon';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { THEME_ID, ThemeProvider, createTheme } from '@mui/material/styles';

--- a/packages/mui-material/src/usePagination/usePagination.test.js
+++ b/packages/mui-material/src/usePagination/usePagination.test.js
@@ -1,6 +1,6 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import { createRenderer } from '@mui/internal-test-utils';
-import { expect } from 'chai';
 import usePagination from '@mui/material/usePagination';
 
 describe('usePagination', () => {

--- a/packages/mui-material/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/mui-material/src/useScrollTrigger/useScrollTrigger.test.js
@@ -1,6 +1,6 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { expect } from 'chai';
 import { act, createRenderer, RenderCounter, screen, isJsdom } from '@mui/internal-test-utils';
 import useScrollTrigger from '@mui/material/useScrollTrigger';
 import Container from '@mui/material/Container';

--- a/packages/mui-material/src/utils/isMuiElement.test.js
+++ b/packages/mui-material/src/utils/isMuiElement.test.js
@@ -1,5 +1,4 @@
-import { expect } from 'chai';
-
+import { describe, it, expect } from 'vitest';
 import { isMuiElement } from '.';
 import { Input, ListItemSecondaryAction, SvgIcon } from '..';
 

--- a/packages/mui-material/src/utils/mergeSlotProps.test.ts
+++ b/packages/mui-material/src/utils/mergeSlotProps.test.ts
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { SxProps } from '@mui/material/styles';
 

--- a/packages/mui-material/src/utils/useFocusableWhenDisabled.test.tsx
+++ b/packages/mui-material/src/utils/useFocusableWhenDisabled.test.tsx
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { renderHook } from '@mui/internal-test-utils';
 import useFocusableWhenDisabled from './useFocusableWhenDisabled';

--- a/packages/mui-material/src/utils/useSlot.test.tsx
+++ b/packages/mui-material/src/utils/useSlot.test.tsx
@@ -1,5 +1,5 @@
+import { describe, beforeAll, afterAll, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Popper from '../Popper/BasePopper';
 import { styled } from '../styles';

--- a/packages/mui-material/test/integration/DialogIntegration.test.js
+++ b/packages/mui-material/test/integration/DialogIntegration.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';

--- a/packages/mui-material/test/integration/Menu.test.js
+++ b/packages/mui-material/test/integration/Menu.test.js
@@ -1,6 +1,6 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { expect } from 'chai';
 import {
   act,
   createRenderer,

--- a/packages/mui-material/test/integration/MenuList.test.js
+++ b/packages/mui-material/test/integration/MenuList.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect, beforeAll } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
   act,

--- a/packages/mui-material/test/integration/NestedMenu.test.js
+++ b/packages/mui-material/test/integration/NestedMenu.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, within, screen } from '@mui/internal-test-utils';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';

--- a/packages/mui-material/test/integration/PopperChildrenLayout.test.js
+++ b/packages/mui-material/test/integration/PopperChildrenLayout.test.js
@@ -1,5 +1,5 @@
+import { beforeEach, afterEach, describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, isJsdom } from '@mui/internal-test-utils';
 import Collapse from '@mui/material/Collapse';

--- a/packages/mui-material/test/integration/Select.test.js
+++ b/packages/mui-material/test/integration/Select.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';

--- a/packages/mui-material/test/integration/Table.test.js
+++ b/packages/mui-material/test/integration/Table.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import Table from '@mui/material/Table';
 import TableHead from '@mui/material/TableHead';

--- a/packages/mui-material/test/integration/TableCell.test.js
+++ b/packages/mui-material/test/integration/TableCell.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import TableCell, { tableCellClasses as classes } from '@mui/material/TableCell';
 import Table from '@mui/material/Table';

--- a/packages/mui-material/test/integration/TableRow.test.js
+++ b/packages/mui-material/test/integration/TableRow.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import TableFooter from '@mui/material/TableFooter';
 import TableHead from '@mui/material/TableHead';

--- a/packages/mui-material/test/integration/Tooltip.test.js
+++ b/packages/mui-material/test/integration/Tooltip.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, expect, it } from 'vitest';
 import { createRenderer, screen, isJsdom, act, fireEvent } from '@mui/internal-test-utils';
 import Tooltip from '@mui/material/Tooltip';
 import Input from '@mui/material/Input';

--- a/packages/mui-private-theming/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/mui-private-theming/src/ThemeProvider/ThemeProvider.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import {
   createRenderer,
   RenderCounter,

--- a/packages/mui-private-theming/src/useTheme/useTheme.test.js
+++ b/packages/mui-private-theming/src/useTheme/useTheme.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer } from '@mui/internal-test-utils';
 import useTheme from './useTheme';
 import ThemeProvider from '../ThemeProvider';

--- a/packages/mui-styled-engine-sc/src/GlobalStyles/GlobalStyles.test.js
+++ b/packages/mui-styled-engine-sc/src/GlobalStyles/GlobalStyles.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, expect, it } from 'vitest';
 import { createRenderer, isJsdom } from '@mui/internal-test-utils';
 import { ThemeProvider } from 'styled-components';
 import styled from '..';

--- a/packages/mui-styled-engine-sc/src/styled.test.js
+++ b/packages/mui-styled-engine-sc/src/styled.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import styled from '@mui/styled-engine-sc';
 

--- a/packages/mui-styled-engine/src/GlobalStyles/GlobalStyles.test.js
+++ b/packages/mui-styled-engine/src/GlobalStyles/GlobalStyles.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, expect, it } from 'vitest';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import { ThemeProvider } from '@emotion/react';
 import styled from '..';

--- a/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.test.js
+++ b/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.test.js
@@ -1,7 +1,7 @@
+import { describe, beforeAll, afterAll, beforeEach, it, expect } from 'vitest';
 import { __unsafe_useEmotionCache } from '@emotion/react';
 import { StyledEngineProvider, GlobalStyles } from '@mui/styled-engine';
 import { createRenderer } from '@mui/internal-test-utils';
-import { expect } from 'chai';
 import { TEST_INTERNALS_DO_NOT_USE } from './StyledEngineProvider';
 
 describe('[Emotion] StyledEngineProvider', () => {

--- a/packages/mui-styled-engine/src/styled.test.js
+++ b/packages/mui-styled-engine/src/styled.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import styled from './index';
 
 describe('styled', () => {

--- a/packages/mui-stylis-plugin-rtl/src/index.test.ts
+++ b/packages/mui-stylis-plugin-rtl/src/index.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { compile, Middleware, middleware, prefixer, serialize, stringify } from 'stylis';
 import muiRtlPlugin from '@mui/stylis-plugin-rtl';
 

--- a/packages/mui-system/src/Box/Box.test.js
+++ b/packages/mui-system/src/Box/Box.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import { Box, ThemeProvider, boxClasses as classes } from '@mui/system';
 import createTheme from '@mui/system/createTheme';

--- a/packages/mui-system/src/Container/Container.test.js
+++ b/packages/mui-system/src/Container/Container.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import { Container, containerClasses as classes } from '@mui/system';
 import describeConformance from '../../test/describeConformance';

--- a/packages/mui-system/src/GlobalStyles/GlobalStyles.test.tsx
+++ b/packages/mui-system/src/GlobalStyles/GlobalStyles.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import { GlobalStyles } from '@mui/system';
 

--- a/packages/mui-system/src/Grid/Grid.test.js
+++ b/packages/mui-system/src/Grid/Grid.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer, screen, isJsdom } from '@mui/internal-test-utils';
 import { ThemeProvider } from '@mui/system';
 import createTheme from '@mui/system/createTheme';

--- a/packages/mui-system/src/Grid/gridGenerator.test.js
+++ b/packages/mui-system/src/Grid/gridGenerator.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import sinon from 'sinon';
 import createSpacing from '../createTheme/createSpacing';
 import createBreakpoints from '../createBreakpoints/createBreakpoints';

--- a/packages/mui-system/src/Grid/traverseBreakpoints.test.ts
+++ b/packages/mui-system/src/Grid/traverseBreakpoints.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import createBreakpoints from '../createBreakpoints/createBreakpoints';
 import { traverseBreakpoints, filterBreakpointKeys } from './traverseBreakpoints';
 

--- a/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.test.js
+++ b/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-eval */
-import { expect } from 'chai';
+import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import InitColorSchemeScript from '@mui/system/InitColorSchemeScript';
 import {

--- a/packages/mui-system/src/Stack/Stack.test.js
+++ b/packages/mui-system/src/Stack/Stack.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import Stack from '@mui/system/Stack';
 import createTheme from '@mui/system/createTheme';

--- a/packages/mui-system/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/mui-system/src/ThemeProvider/ThemeProvider.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer } from '@mui/internal-test-utils';
 import { useTheme as usePrivateTheme } from '@mui/private-theming';
 import { ThemeContext } from '@mui/styled-engine';

--- a/packages/mui-system/src/ThemeProvider/useLayerOrder.test.tsx
+++ b/packages/mui-system/src/ThemeProvider/useLayerOrder.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, afterEach, it, expect } from 'vitest';
 import { ThemeContext } from '@mui/styled-engine';
 import { createRenderer } from '@mui/internal-test-utils';
 import useLayerOrder from './useLayerOrder';

--- a/packages/mui-system/src/borders/borders.test.js
+++ b/packages/mui-system/src/borders/borders.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import borders from './borders';
 
 describe('borders', () => {

--- a/packages/mui-system/src/breakpoints/breakpoints.test.js
+++ b/packages/mui-system/src/breakpoints/breakpoints.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import breakpoints, {
   computeBreakpointsBase,
   resolveBreakpointValues,

--- a/packages/mui-system/src/colorManipulator/colorManipulator.test.js
+++ b/packages/mui-system/src/colorManipulator/colorManipulator.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { blend } from '@mui/system';
 
 import {

--- a/packages/mui-system/src/compose/compose.test.js
+++ b/packages/mui-system/src/compose/compose.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import compose from './compose';
 import style from '../style';
 

--- a/packages/mui-system/src/createBox/createBox.test.js
+++ b/packages/mui-system/src/createBox/createBox.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { createRenderer } from '@mui/internal-test-utils';
 import { createBox, ThemeProvider } from '@mui/system';

--- a/packages/mui-system/src/createBreakpoints/createBreakpoints.test.js
+++ b/packages/mui-system/src/createBreakpoints/createBreakpoints.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import createBreakpoints from './createBreakpoints';
 
 describe('createBreakpoints', () => {

--- a/packages/mui-system/src/createTheme/applyStyles.test.ts
+++ b/packages/mui-system/src/createTheme/applyStyles.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import applyStyles from './applyStyles';
 
 describe('applyStyles', () => {

--- a/packages/mui-system/src/createTheme/createSpacing.test.ts
+++ b/packages/mui-system/src/createTheme/createSpacing.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import createSpacing, { Spacing } from './createSpacing';
 
 describe('createSpacing', () => {

--- a/packages/mui-system/src/createTheme/createTheme.test.js
+++ b/packages/mui-system/src/createTheme/createTheme.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, expect, it } from 'vitest';
 import { createRenderer, isJsdom } from '@mui/internal-test-utils';
 import { styled, ThemeProvider } from '@mui/system';
 

--- a/packages/mui-system/src/cssContainerQueries/cssContainerQueries.test.ts
+++ b/packages/mui-system/src/cssContainerQueries/cssContainerQueries.test.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai';
-
+import { describe, it, expect } from 'vitest';
 import createTheme from '@mui/system/createTheme';
 import {
   isCqShorthand,

--- a/packages/mui-system/src/cssGrid/cssGrid.test.js
+++ b/packages/mui-system/src/cssGrid/cssGrid.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import grid from './cssGrid';
 
 describe('grid', () => {

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
 import { ThemeProvider } from '@mui/system';

--- a/packages/mui-system/src/cssVars/createGetCssVar.test.ts
+++ b/packages/mui-system/src/cssVars/createGetCssVar.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import createGetCssVar from './createGetCssVar';
 
 describe('createGetCssVar', () => {

--- a/packages/mui-system/src/cssVars/cssVarsParser.test.ts
+++ b/packages/mui-system/src/cssVars/cssVarsParser.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import cssVarsParser, { assignNestedKeys, walkObjectDeep } from './cssVarsParser';
 
 describe('cssVarsParser', () => {

--- a/packages/mui-system/src/cssVars/prepareCssVars.test.ts
+++ b/packages/mui-system/src/cssVars/prepareCssVars.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import prepareCssVars from './prepareCssVars';
 
 describe('prepareCssVars', () => {

--- a/packages/mui-system/src/cssVars/prepareTypographyVars.test.ts
+++ b/packages/mui-system/src/cssVars/prepareTypographyVars.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { createTheme } from '@mui/material/styles';
 import prepareTypographyVars from './prepareTypographyVars';
 

--- a/packages/mui-system/src/cssVars/useCurrentColorScheme.test.js
+++ b/packages/mui-system/src/cssVars/useCurrentColorScheme.test.js
@@ -1,5 +1,5 @@
+import { describe, beforeAll, afterAll, beforeEach, afterEach, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, fireEvent, act, screen } from '@mui/internal-test-utils';
 import {

--- a/packages/mui-system/src/merge/merge.test.js
+++ b/packages/mui-system/src/merge/merge.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import merge from './merge';
 
 describe('merge', () => {

--- a/packages/mui-system/src/palette/palette.test.js
+++ b/packages/mui-system/src/palette/palette.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import palette from './palette';
 
 const theme = {

--- a/packages/mui-system/src/propsToClassKey/propsToClassKey.test.js
+++ b/packages/mui-system/src/propsToClassKey/propsToClassKey.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import propsToClassKey from './propsToClassKey';
 
 describe('propsToClassKey', () => {

--- a/packages/mui-system/src/sizing/sizing.test.js
+++ b/packages/mui-system/src/sizing/sizing.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import createTheme from '@mui/system/createTheme';
 import sizing from './sizing';
 

--- a/packages/mui-system/src/spacing/spacing.test.js
+++ b/packages/mui-system/src/spacing/spacing.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import spacing, { margin, padding } from './spacing';
 
 describe('system spacing', () => {

--- a/packages/mui-system/src/style/style.test.js
+++ b/packages/mui-system/src/style/style.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import style from './style';
 
 describe('style', () => {

--- a/packages/mui-system/src/styleFunctionSx/extendSxProp.test.js
+++ b/packages/mui-system/src/styleFunctionSx/extendSxProp.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import extendSxProp from './extendSxProp';
 
 describe('extendSxProp', () => {

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import styleFunctionSx from './styleFunctionSx';
 import cssContainerQueries from '../cssContainerQueries';
 import createBreakpoints from '../createBreakpoints/createBreakpoints';

--- a/packages/mui-system/src/styled/styled.test.js
+++ b/packages/mui-system/src/styled/styled.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import { styled, ThemeProvider } from '@mui/system';
 

--- a/packages/mui-system/src/useThemeProps/getThemeProps.test.js
+++ b/packages/mui-system/src/useThemeProps/getThemeProps.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import getThemeProps from './getThemeProps';
 
 describe('getThemeProps', () => {

--- a/packages/mui-utils/src/appendOwnerState/appendOwnerState.test.ts
+++ b/packages/mui-utils/src/appendOwnerState/appendOwnerState.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import appendOwnerState from '@mui/utils/appendOwnerState';
 
 const ownerState = {

--- a/packages/mui-utils/src/capitalize/capitalize.test.ts
+++ b/packages/mui-utils/src/capitalize/capitalize.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import capitalize from '@mui/utils/capitalize';
 
 describe('capitalize', () => {

--- a/packages/mui-utils/src/chainPropTypes/chainPropTypes.test.ts
+++ b/packages/mui-utils/src/chainPropTypes/chainPropTypes.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeEach, it, expect } from 'vitest';
 import PropTypes from 'prop-types';
 import chainPropTypes from './chainPropTypes';
 

--- a/packages/mui-utils/src/clamp/clamp.test.ts
+++ b/packages/mui-utils/src/clamp/clamp.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import clamp from './clamp';
 
 describe('clamp', () => {

--- a/packages/mui-utils/src/composeClasses/composeClasses.test.ts
+++ b/packages/mui-utils/src/composeClasses/composeClasses.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import composeClasses from '@mui/utils/composeClasses';
 
 describe('composeClasses', () => {

--- a/packages/mui-utils/src/debounce/debounce.test.ts
+++ b/packages/mui-utils/src/debounce/debounce.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 import { spy, useFakeTimers } from 'sinon';
 import debounce from './debounce';
 

--- a/packages/mui-utils/src/deepmerge/deepmerge.test.ts
+++ b/packages/mui-utils/src/deepmerge/deepmerge.test.ts
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { isJsdom } from '@mui/internal-test-utils/env';
 import deepmerge from './deepmerge';
 

--- a/packages/mui-utils/src/deprecatedPropType/deprecatedPropType.test.ts
+++ b/packages/mui-utils/src/deprecatedPropType/deprecatedPropType.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeEach, it, expect } from 'vitest';
 import PropTypes from 'prop-types';
 import deprecatedPropType from '@mui/utils/deprecatedPropType';
 

--- a/packages/mui-utils/src/elementAcceptingRef/elementAcceptingRef.test.tsx
+++ b/packages/mui-utils/src/elementAcceptingRef/elementAcceptingRef.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prefer-stateless-function */
+import { describe, beforeEach, expect, it } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { createRenderer, waitFor, reactMajor } from '@mui/internal-test-utils';
 import elementAcceptingRef from './elementAcceptingRef';

--- a/packages/mui-utils/src/elementTypeAcceptingRef/elementTypeAcceptingRef.test.tsx
+++ b/packages/mui-utils/src/elementTypeAcceptingRef/elementTypeAcceptingRef.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prefer-stateless-function */
+import { describe, beforeEach, expect, it } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { createRenderer, waitFor } from '@mui/internal-test-utils';
 import elementTypeAcceptingRef from './elementTypeAcceptingRef';

--- a/packages/mui-utils/src/exactProp/exactProp.test.ts
+++ b/packages/mui-utils/src/exactProp/exactProp.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeEach, it, expect } from 'vitest';
 import PropTypes from 'prop-types';
 import exactProp from './exactProp';
 

--- a/packages/mui-utils/src/extractEventHandlers/extractEventHandlers.test.ts
+++ b/packages/mui-utils/src/extractEventHandlers/extractEventHandlers.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import extractEventHandlers from '@mui/utils/extractEventHandlers';
 
 describe('extractEventHandlers', () => {

--- a/packages/mui-utils/src/fastObjectShallowCompare/fastObjectShallowCompare.test.ts
+++ b/packages/mui-utils/src/fastObjectShallowCompare/fastObjectShallowCompare.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import fastObjectShallowCompare from './fastObjectShallowCompare';
 
 describe('fastObjectShallowCompare', () => {

--- a/packages/mui-utils/src/generateUtilityClass/generateUtilityClass.test.ts
+++ b/packages/mui-utils/src/generateUtilityClass/generateUtilityClass.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect, afterEach } from 'vitest';
 import generateUtilityClass from '@mui/utils/generateUtilityClass';
 import ClassNameGenerator from '@mui/utils/ClassNameGenerator';
 

--- a/packages/mui-utils/src/generateUtilityClasses/generateUtilityClasses.test.ts
+++ b/packages/mui-utils/src/generateUtilityClasses/generateUtilityClasses.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import generateUtilityClasses from '@mui/utils/generateUtilityClasses';
 
 describe('generateUtilityClasses', () => {

--- a/packages/mui-utils/src/getActiveElement/getActiveElement.test.ts
+++ b/packages/mui-utils/src/getActiveElement/getActiveElement.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import { stub } from 'sinon';
 import getActiveElement from './getActiveElement';
 

--- a/packages/mui-utils/src/getDisplayName/getDisplayName.test.tsx
+++ b/packages/mui-utils/src/getDisplayName/getDisplayName.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prefer-stateless-function */
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import getDisplayName from './getDisplayName';
 
 describe('utils/getDisplayName.js', () => {

--- a/packages/mui-utils/src/getReactElementRef/getReactElementRef.test.tsx
+++ b/packages/mui-utils/src/getReactElementRef/getReactElementRef.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import getReactElementRef from '@mui/utils/getReactElementRef';
 import * as React from 'react';
 

--- a/packages/mui-utils/src/getScrollbarSize/getScrollbarSize.test.ts
+++ b/packages/mui-utils/src/getScrollbarSize/getScrollbarSize.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeEach, afterEach, expect, it } from 'vitest';
 import { isJsdom } from '@mui/internal-test-utils/env';
 import getScrollbarSize from './getScrollbarSize';
 

--- a/packages/mui-utils/src/integerPropType/integerPropType.test.tsx
+++ b/packages/mui-utils/src/integerPropType/integerPropType.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unknown-property */
-import { expect } from 'chai';
+import { describe, expect, beforeEach, it } from 'vitest';
 import PropTypes from 'prop-types';
 import integerPropType from '@mui/utils/integerPropType';
 import { getTypeByValue } from './integerPropType';

--- a/packages/mui-utils/src/mergeSlotProps/mergeSlotProps.test.ts
+++ b/packages/mui-utils/src/mergeSlotProps/mergeSlotProps.test.ts
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { EventHandlers } from '@mui/utils/types';
 import mergeSlotProps from '@mui/utils/mergeSlotProps';
 

--- a/packages/mui-utils/src/omitEventHandlers/omitEventHandlers.test.ts
+++ b/packages/mui-utils/src/omitEventHandlers/omitEventHandlers.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import omitEventHandlers from '@mui/utils/omitEventHandlers';
 
 describe('omitEventHandlers', () => {

--- a/packages/mui-utils/src/requirePropFactory/requirePropFactory.test.tsx
+++ b/packages/mui-utils/src/requirePropFactory/requirePropFactory.test.tsx
@@ -1,5 +1,5 @@
+import { describe, beforeAll, it, expect, beforeEach } from 'vitest';
 import PropTypes from 'prop-types';
-import { expect } from 'chai';
 import requirePropFactory from './requirePropFactory';
 
 describe('requirePropFactory', () => {

--- a/packages/mui-utils/src/resolveProps/resolveProps.test.ts
+++ b/packages/mui-utils/src/resolveProps/resolveProps.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import resolveProps from './resolveProps';
 
 describe('resolveProps', () => {

--- a/packages/mui-utils/src/setRef/setRef.test.ts
+++ b/packages/mui-utils/src/setRef/setRef.test.ts
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import setRef from './setRef';
 

--- a/packages/mui-utils/src/unsupportedProp/unsupportedProp.test.ts
+++ b/packages/mui-utils/src/unsupportedProp/unsupportedProp.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import unsupportedProp from './unsupportedProp';
 
 describe('unsupportedProp', () => {

--- a/packages/mui-utils/src/useControlled/useControlled.test.tsx
+++ b/packages/mui-utils/src/useControlled/useControlled.test.tsx
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { act, createRenderer } from '@mui/internal-test-utils';
 import useControlled from './useControlled';
 

--- a/packages/mui-utils/src/useForkRef/useForkRef.test.tsx
+++ b/packages/mui-utils/src/useForkRef/useForkRef.test.tsx
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, reactMajor, MuiRenderResult, screen } from '@mui/internal-test-utils';
 import useForkRef from './useForkRef';

--- a/packages/mui-utils/src/useId/useId.test.tsx
+++ b/packages/mui-utils/src/useId/useId.test.tsx
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import useId from '@mui/utils/useId';
 

--- a/packages/mui-utils/src/useIsFocusVisible/useIsFocusVisible.test.tsx
+++ b/packages/mui-utils/src/useIsFocusVisible/useIsFocusVisible.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, beforeAll, beforeEach, afterEach, it, expect } from 'vitest';
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
 import {

--- a/packages/mui-utils/src/useRovingTabIndex/useRovingTabIndex.test.tsx
+++ b/packages/mui-utils/src/useRovingTabIndex/useRovingTabIndex.test.tsx
@@ -1,5 +1,5 @@
+import { describe, test, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import {
   type UseRovingTabIndexParams,

--- a/packages/mui-utils/src/useSlotProps/useSlotProps.test.tsx
+++ b/packages/mui-utils/src/useSlotProps/useSlotProps.test.tsx
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer } from '@mui/internal-test-utils';
 import { EventHandlers } from '@mui/utils/types';

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -1,5 +1,5 @@
 import { Page, Browser, chromium, expect } from '@playwright/test';
-import { describe, it, beforeAll } from 'vitest';
+import { describe, it, beforeAll, afterAll } from 'vitest';
 import '@mui/internal-test-utils/initPlaywrightMatchers';
 
 const BASE_URL = 'http://localhost:5001';

--- a/test/integration/mui-system/createStyled.test.js
+++ b/test/integration/mui-system/createStyled.test.js
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import createStyled from '@mui/system/createStyled';
 import { ThemeProvider, createTheme } from '@mui/material/styles';

--- a/test/integration/mui-system/styleFunctionSx.test.js
+++ b/test/integration/mui-system/styleFunctionSx.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { describe, it, expect } from 'vitest';
 import styleFunctionSx from '@mui/system/styleFunctionSx';
 import {
   private_createMixins as createMixins,

--- a/test/integration/mui-system/theme-scoping.test.tsx
+++ b/test/integration/mui-system/theme-scoping.test.tsx
@@ -1,5 +1,5 @@
+import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 import * as React from 'react';
-import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import { ThemeContext } from '@mui/styled-engine';

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterAll, it } from 'vitest';
 import * as url from 'url';
 import * as path from 'path';
 import * as fs from 'node:fs/promises';

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -76,7 +76,6 @@ export default async function create(
     test: {
       name,
       exclude: ['**/node_modules/**', '**/build/**', '**/*.spec.*', '**/.next/**', ...excludes],
-      globals: true,
       disableConsoleIntercept: true,
       setupFiles: [path.resolve(MONOREPO_ROOT, './test/setupVitest.ts')],
       server: {


### PR DESCRIPTION
Second of two. Blocked by #49034, which makes every test file import its globals. The globals cannot come out before that lands.

**The diff currently shows #49034's commit too.** GitHub will not take a fork branch as a base, so this targets `master` and carries both. Once #49034 merges this shrinks to the three files below.

## What changed

- `globals: true` is gone from `vitest.shared.mts`. Nothing needs the runner to inject the globals any more.
- The hand rolled vitest globals block in `eslint.config.mjs` is gone. `createTestConfig` injected the mocha globals instead, so material-ui declared the vitest ones itself; mui/mui-public#1798 fixes that upstream.
- `packages/mui-codemod/testUtils/index.js` imports `describe`, `it` and `expect` rather than carrying an `eslint-disable no-undef`.

## On that last one

It was the only shared helper still reading the globals off the environment. Everything else that defines tests outside a test file, `describeConformance` and `createDescribe` in `@mui/internal-test-utils`, already imports from `vitest`, so nothing else had to change.

Worth knowing for the other repos: this file is what kept `globals: true` load bearing, and it is invisible until you actually turn the globals off. Grepping for helpers that call `describe`/`it`/`vi` without importing them is the way to find them ahead of time.

## Verification

Run with #49034 applied:

- `pnpm test:unit --run`: 435 files, 5993 tests pass with `globals: true` removed.
- `pnpm eslint`, `pnpm typescript`, `pnpm prettier`: clean.
