### PR TITLE
[code-infra] Fix new image loading flake after font loading changes

### DIFF
--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -140,6 +140,30 @@ async function main() {
       `[data-testid="testcase"][data-testpath="${route}"]:not([aria-busy="true"])`,
     );
 
+    // `aria-busy` covers fonts, not images. The route handler aborts every
+    // image request, and components like Avatar only swap to their fallback
+    // after the error event triggers a re-render -- strictly later than the
+    // busy flip, so under CI contention the screenshot can catch the pending
+    // <img>: blank where every baseline has the settled fallback. Wait for
+    // each image to settle, then two frames so React commits the swap the
+    // load/error event scheduled.
+    await testcase.evaluate(async (element) => {
+      await Promise.all(
+        Array.from(element.querySelectorAll('img'), (img) => {
+          if (img.complete) {
+            return undefined;
+          }
+          return new Promise((resolve) => {
+            img.addEventListener('load', resolve, { once: true });
+            img.addEventListener('error', resolve, { once: true });
+          });
+        }),
+      );
+      await new Promise((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+      });
+    });
+
     return testcase;
   }
 


### PR DESCRIPTION
The VRT screenshot gate (`aria-busy`) covers fonts only, and `TestViewer` flips it in a synchronous effect right after mount. The harness aborts every image request, and components like Avatar only swap to their letter fallback after the error event triggers a re-render — strictly later than the busy flip. When the abort response is slow — the route handler round-trips through the Node process, which in CI is contended by four pages and the vitest workers — the screenshot wins the race and captures the pending, invisible `<img>`: blank space where every baseline has the settled fallback ([this Argos flake](https://app.argos-ci.com/mui/material-ui/builds/51376/423505195)). The recent `loadFonts` consolidation (#49007) likely narrowed the window — fonts now settle before the fixture mounts, so the busy state no longer absorbs the image race — but the race itself predates it.

After the busy wait, additionally wait for every image inside the testcase to settle (aborted images fire `error` and become `complete`), then two frames so React commits the swap the event scheduled. Settled images short-circuit, so suite duration is unchanged (693 tests in ~33s locally).

Verified end-to-end by making the race deterministic: with a 1.5s delay injected into the harness's image-abort route handler (simulating CI's contended round-trip; locally the gate-clear→capture gap measures ~100ms), the unpatched harness produces the exact Argos failure — missing avatars — in 5/5 runs of the BottomAppBar fixture, while the patched harness produces the baseline-identical screenshot in 5/5.