### PR TITLE
[material-ui][Link] Fix crash when the underline color is not parsable

### DIFF
--- a/packages/mui-material/src/Link/Link.test.js
+++ b/packages/mui-material/src/Link/Link.test.js
@@ -53,6 +53,16 @@ describe('<Link />', () => {
     ).not.to.throw();
   });
 
+  it('using a named CSS color should not crash', () => {
+    expect(() =>
+      render(
+        <Link href="/" color="white" underline="always">
+          Test
+        </Link>,
+      ),
+    ).not.to.throw();
+  });
+
   describe('event callbacks', () => {
     it('should fire event callbacks', () => {
       const events = ['onBlur', 'onFocus'];

--- a/packages/mui-material/src/Link/getTextDecoration.test.js
+++ b/packages/mui-material/src/Link/getTextDecoration.test.js
@@ -34,7 +34,7 @@ describe('getTextDecoration', () => {
       expect(getTextDecoration({ theme, ownerState: { color: 'rgb(1, 1, 1)' } })).to.equal(
         'rgba(1, 1, 1, 0.4)',
       );
-      expect(() => getTextDecoration({ theme, ownerState: { color: 'yellow' } })).to.throw();
+      expect(getTextDecoration({ theme, ownerState: { color: 'yellow' } })).to.equal('yellow');
     });
 
     it('work with a custom palette', () => {
@@ -109,7 +109,7 @@ describe('getTextDecoration', () => {
       expect(getTextDecoration({ theme, ownerState: { color: 'rgb(1, 1, 1)' } })).to.equal(
         'rgba(1, 1, 1, 0.4)',
       );
-      expect(() => getTextDecoration({ theme, ownerState: { color: 'yellow' } })).to.throw();
+      expect(getTextDecoration({ theme, ownerState: { color: 'yellow' } })).to.equal('yellow');
     });
   });
 

--- a/packages/mui-material/src/Link/getTextDecoration.ts
+++ b/packages/mui-material/src/Link/getTextDecoration.ts
@@ -1,5 +1,5 @@
 import { getPath } from '@mui/system/style';
-import { alpha } from '@mui/system/colorManipulator';
+import { private_safeAlpha as safeAlpha } from '@mui/system/colorManipulator';
 import type { Theme } from '../styles';
 
 const getTextDecoration = <T extends Theme>({
@@ -27,7 +27,7 @@ const getTextDecoration = <T extends Theme>({
   if ('vars' in theme && channelColor) {
     return `rgba(${channelColor} / 0.4)`;
   }
-  return alpha(color, 0.4);
+  return safeAlpha(color, 0.4);
 };
 
 export default getTextDecoration;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes https://github.com/mui/material-ui/issues/49052

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

`getTextDecoration` runs `alpha()` on the resolved color, so `underline="always"` together with a CSS color keyword like `color="white"` throws `MUI: Unsupported \`white\` color` during render and can take the whole app down with it. It now uses `private_safeAlpha`, the helper `createThemeWithVars` already relies on for the same reason, so a color the parser cannot decompose falls back to itself instead of throwing.

Only the crash is covered here, the customization and opt-out points raised in the issue are separate.
