### PR TITLE
[Autocomplete] Lazily derive the initial input value

### DIFF
--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -177,10 +177,10 @@ function useAutocomplete(props) {
   const isTouchRef = React.useRef(false);
 
   // Calculate the initial inputValue on mount only.
-  // useRef ensures it doesn't update dynamically with defaultValue or value props.
-  const initialInputValue = React.useRef(
+  // Lazy state ensures it doesn't update dynamically with defaultValue or value props.
+  const [initialInputValue] = React.useState(() =>
     getInputValue(defaultValue ?? valueProp, multiple, getOptionLabel),
-  ).current;
+  );
 
   const [value, setValueState] = useControlled({
     controlled: valueProp,


### PR DESCRIPTION
## What changed

- Derives the mount-only initial input value with a lazy state initializer instead of evaluating the `useRef` argument on every render.
- Avoids an otherwise unused `getOptionLabel` call on every production render (two calls per Strict Mode render cycle).
- No public API or rendered-value behavior changes.

`useRef(expression)` preserves the first result but still evaluates `expression` during every render. A lazy state initializer matches the existing mount-only contract.

## Verification

- External render/rerender control against the base: label calls increased from 6 to 11.
- The same control after the fix: label calls increased from 6 to 9, removing the two mount-only recomputations under Strict Mode.
- `pnpm test:unit run useAutocomplete --project 'node:@mui/material'`
- `pnpm -F @mui/material typescript`
- Targeted ESLint and Prettier checks.
- Full `pnpm release:build`.
- Full Material Node unit suite: 179 passed / 4 skipped files; 4,712 passed / 759 skipped tests.

The browser test project was not run locally because Playwright Chromium is not installed in this checkout.

## Contribution

- [x] I have followed the contributing guide.

This change and PR description were prepared with OpenAI Codex, then self-reviewed and verified locally. No independent human review has occurred yet.