### PR TITLE
[Breadcrumbs] Build separators in one pass

### DIFF
--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
@@ -57,9 +57,10 @@ const BreadcrumbsSeparator = styled('li', {
 
 function insertSeparators(items, className, separator, ownerState) {
   return items.reduce((acc, current, index) => {
+    acc.push(current);
+
     if (index < items.length - 1) {
-      acc = acc.concat(
-        current,
+      acc.push(
         <BreadcrumbsSeparator
           aria-hidden
           key={`separator-${index}`}
@@ -69,8 +70,6 @@ function insertSeparators(items, className, separator, ownerState) {
           {separator}
         </BreadcrumbsSeparator>,
       );
-    } else {
-      acc.push(current);
     }
 
     return acc;


### PR DESCRIPTION
## What changed

- Builds the interleaved breadcrumb/separator array with `push` in one pass instead of repeatedly copying the growing accumulator with `concat`.
- Preserves item order, separator order, keys, and rendered output.
- No public API or observable behavior changes.

The previous reduction is quadratic in the number of children because each separator copies all preceding entries. The new reduction is linear.

## Verification

- Synthetic 10,000-item, 7-sample benchmark:
  - before median: 271.284 ms
  - after median: 0.285 ms
- Exact output length, first-item, and last-item assertions passed.
- `pnpm test:unit run Breadcrumbs --project 'node:@mui/material'`
- `pnpm -F @mui/material typescript`
- Targeted ESLint and Prettier checks.
- Full `pnpm release:build`.
- Full Material Node unit suite: 179 passed / 4 skipped files; 4,712 passed / 759 skipped tests.

The browser test project was not run locally because Playwright Chromium is not installed in this checkout.

## Contribution

- [x] I have followed the contributing guide.

This change and PR description were prepared with OpenAI Codex, then self-reviewed and verified locally. No independent human review has occurred yet.