### PR TITLE
[codemod] Upgrade required `node` version in `engines` field in codemod package

### DIFF
--- a/packages/mui-codemod/package.json
+++ b/packages/mui-codemod/package.json
@@ -48,6 +48,6 @@
     "directory": "build"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=20.19.0"
   }
 }


### PR DESCRIPTION
After updating `yargs` to `18.1.0` which now supports minimum node version of `20.19.0` since v18, forgot to update the minimum required `node` version in `engines` field for our `@mui/codemod` package which depends on `yargs`.

## Changelog

`@mui/codemod` minimum supported Node version is `20.19`.
This was only the case due to using the v18 `yargs` package; this only explicitly aligns with it.