### PR TITLE
[docs][Backdrop] Move Backdrop to Utils and clarify it is a low-level utility

### DIFF
--- a/docs/data/material/components/backdrop/backdrop.md
+++ b/docs/data/material/components/backdrop/backdrop.md
@@ -8,17 +8,20 @@ githubSource: packages/mui-material/src/Backdrop
 
 # Backdrop
 
-<p class="description">The Backdrop component narrows the user's focus to a particular element on the screen.</p>
+<p class="description">The Backdrop component is a low-level utility that adds a dimmed layer over the application.</p>
 
-The Backdrop signals a state change within the application and can be used for creating loaders, dialogs, and more.
-In its simplest form, the Backdrop component will add a dimmed layer over your application.
+Backdrop is normally used through higher-level components such as [Dialog](/material-ui/react-dialog/) and [Modal](/material-ui/react-modal/), which already include it and handle focus and assistive technology.
+
+Most apps should not use Backdrop directly. Reach for it only when you need a custom overlay (for example a full-screen loader you fully control).
 
 {{"component": "@mui/internal-core-docs/ComponentLinkHeader"}}
 
 ## Example
 
-The demo below shows a basic Backdrop with a Circular Progress component in the foreground to indicate a loading state.
+The demo below is a low-level example: a basic Backdrop with a Circular Progress component in the foreground to indicate a loading state.
 After clicking **Show Backdrop**, you can click anywhere on the page to close it.
+
+For loading and overlay UI that must communicate state to assistive technology, prefer Dialog or Modal, which already manage the backdrop.
 
 {{"demo": "SimpleBackdrop.js"}}
 

--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -72,7 +72,6 @@ const pages: MuiPage[] = [
         subheader: 'feedback',
         children: [
           { pathname: '/material-ui/react-alert' },
-          { pathname: '/material-ui/react-backdrop' },
           { pathname: '/material-ui/react-dialog' },
           { pathname: '/material-ui/react-progress' },
           { pathname: '/material-ui/react-skeleton' },
@@ -130,6 +129,7 @@ const pages: MuiPage[] = [
             title: 'InitColorSchemeScript',
           },
           { pathname: '/material-ui/react-modal' },
+          { pathname: '/material-ui/react-backdrop' },
           { pathname: '/material-ui/react-no-ssr', title: 'No SSR' },
           { pathname: '/material-ui/react-popover' },
           { pathname: '/material-ui/react-popper' },


### PR DESCRIPTION
Fixes #31371

## Scope

Maintainer [@mj12albert](https://github.com/mj12albert) reframed this on 19 Apr 2026: the original report is a poor/unrealistic demo, not a library ARIA bug. Components that usually use a backdrop (Dialog, Modal) already include it. Typical apps should not use Backdrop directly.

This PR is docs-only. No Backdrop component runtime or ARIA changes.

## Changes

- Move Backdrop from **Feedback** to **Utils** in the Material UI docs nav (`docs/data/material/pages.ts`), next to Modal.
- Update the Backdrop page so it describes Backdrop as a low-level utility normally used through Dialog/Modal, and note that the SimpleBackdrop demo is a low-level example.

## Why not component ARIA

WCAG 4.1.2 on the standalone Backdrop demo is expected: Backdrop is a dimmed layer, not a dialog. Accessible overlay patterns already live on Dialog and Modal (focus trap, labeling, assistive tech). Adding generic ARIA onto Backdrop would be the wrong layer, which is why the 2023 component approach in #37202 was abandoned.

## Test plan

- [ ] Docs nav lists Backdrop under Utils, not Feedback
- [ ] Backdrop page copy matches the maintainer's utility framing
- [ ] No changes under `packages/mui-material/src/Backdrop`