### PR TITLE
[docs] Fix the LLM generated docs paths

### DIFF
--- a/scripts/buildLlmsDocs/index.ts
+++ b/scripts/buildLlmsDocs/index.ts
@@ -262,14 +262,20 @@ function findNonComponentMarkdownFiles(
       pathname.startsWith('/material-ui/') &&
       !ignoredPaths.some((ignored) => pathname.startsWith(ignored))
     ) {
-      // Match by filename basename to avoid pathname collisions when multiple files
-      // exist in the same directory (e.g., upgrade-to-v7.md and upgrade-to-native-color.md)
-      const lastSegment = parsedPathname.split('/').filter(Boolean).pop();
-      const page = allMarkdownFiles.find((p) => {
-        const fileBasename = path.basename(p.filename).replace(/\.mdx?$/, '');
-        // p.pathname already has the parent path (from findPagesMarkdown which strips the filename)
-        return fileBasename === lastSegment && p.pathname === parsedPathname;
-      });
+      // findPagesMarkdown returns the file's parent directory as its pathname. Match the
+      // filename too to avoid collisions between files in the same directory (for example,
+      // upgrade-to-v7.md and upgrade-to-native-color.md).
+      const lastSegment = path.posix.basename(parsedPathname);
+      const findPage = (expectedPathname: string) =>
+        allMarkdownFiles.find((page) => {
+          const fileBasename = path.basename(page.filename).replace(/\.mdx?$/, '');
+          return fileBasename === lastSegment && page.pathname === expectedPathname;
+        });
+
+      // First support the directory-named layout, where nextjs/nextjs.md has the pathname
+      // /material/integrations/nextjs. Then support the sibling-file layout, where
+      // css-theme-variables/overview.md has the pathname /material/customization/css-theme-variables.
+      const page = findPage(parsedPathname) ?? findPage(path.posix.dirname(parsedPathname));
 
       if (page) {
         files.push({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/49069

## Summary

Fixes five documentation pages being omitted from their generated `.md` routes and `material-ui/llms.txt`.

## Problem

The LLM documentation generator matches routes from `pages.ts` with Markdown files returned by `findPagesMarkdown`.

`findPagesMarkdown` represents a Markdown file using:

- its filename; and
- its parent directory as the pathname.

For example, the overview page has:

- Route: `/material/customization/css-theme-variables/overview`
- File: `customization/css-theme-variables/overview.md`
- Filename: `overview`
- Reported pathname: `/material/customization/css-theme-variables`

The existing matcher correctly matched the filename, but also required the reported pathname to equal the complete route. This only works for a directory-named layout such as:

```text
customization/css-theme-variables/overview/overview.md
```

It does not work for the sibling-file layout actually used by these pages:

```text
customization/css-theme-variables/
├── overview.md
├── usage.md
├── configuration.md
└── native-color.md
```

The same issue affected `integrations/tailwindcss/tailwindcss-v4.md`.

## Fix

The matcher now checks both supported layouts:

1. The file's reported pathname equals the complete route, supporting directory-named files.
2. The file's reported pathname equals the route's parent directory, supporting sibling files.

Both checks still require the filename to match the route's final segment. This preserves the existing protection against selecting the wrong file when multiple Markdown files share a directory.

## Result

The generator now creates the five previously missing files:

```text
material-ui/customization/css-theme-variables/overview.md
material-ui/customization/css-theme-variables/usage.md
material-ui/customization/css-theme-variables/configuration.md
material-ui/customization/css-theme-variables/native-color.md
material-ui/integrations/tailwindcss/tailwindcss-v4.md
```