### PR TITLE
[link] Revert to color-mix when underline color is not accepted

### DIFF
--- a/packages/mui-material/src/Link/Link.test.js
+++ b/packages/mui-material/src/Link/Link.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen, isJsdom } from '@mui/internal-test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
@@ -51,6 +51,71 @@ describe('<Link />', () => {
         </Link>,
       ),
     ).not.to.throw();
+  });
+
+  describe('underline color', () => {
+    let reference;
+
+    afterEach(() => {
+      reference?.remove();
+      reference = undefined;
+    });
+
+    it('using a named CSS color should not crash', () => {
+      expect(() =>
+        render(
+          <Link href="/" color="white" underline="always">
+            Test
+          </Link>,
+        ),
+      ).not.to.throw();
+    });
+
+    it.skipIf(isJsdom())('should apply transparency to a named CSS color', () => {
+      render(
+        <Link href="/" color="white" underline="always">
+          Test
+        </Link>,
+      );
+      const link = screen.getByRole('link');
+      reference = document.createElement('span');
+      reference.style.textDecorationColor = 'color-mix(in srgb, white 40%, transparent)';
+      expect(reference.style.textDecorationColor).not.to.equal('');
+      document.body.appendChild(reference);
+
+      expect(getComputedStyle(link).textDecorationColor).to.equal(
+        getComputedStyle(reference).textDecorationColor,
+      );
+    });
+
+    it.skipIf(isJsdom())('should derive the underline color from the color prop', () => {
+      const theme = createTheme({
+        components: {
+          MuiLink: {
+            styleOverrides: {
+              root: {
+                color: '#ff5252',
+              },
+            },
+          },
+        },
+      });
+      render(
+        <ThemeProvider theme={theme}>
+          <Link href="/">Test</Link>
+        </ThemeProvider>,
+      );
+      const link = screen.getByRole('link');
+      reference = document.createElement('span');
+      reference.style.color = '#ff5252';
+      reference.style.textDecorationColor = theme.alpha(theme.palette.primary.main, 0.4);
+      document.body.appendChild(reference);
+
+      expect(getComputedStyle(link).color).to.equal(getComputedStyle(reference).color);
+      expect(getComputedStyle(link).textDecorationColor).to.equal(
+        getComputedStyle(reference).textDecorationColor,
+      );
+    });
   });
 
   describe('event callbacks', () => {

--- a/packages/mui-material/src/Link/Link.test.js
+++ b/packages/mui-material/src/Link/Link.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen, isJsdom } from '@mui/internal-test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
@@ -54,13 +54,6 @@ describe('<Link />', () => {
   });
 
   describe('underline color', () => {
-    let reference;
-
-    afterEach(() => {
-      reference?.remove();
-      reference = undefined;
-    });
-
     it('using a named CSS color should not crash', () => {
       expect(() =>
         render(
@@ -78,14 +71,8 @@ describe('<Link />', () => {
         </Link>,
       );
       const link = screen.getByRole('link');
-      reference = document.createElement('span');
-      reference.style.textDecorationColor = 'color-mix(in srgb, white 40%, transparent)';
-      expect(reference.style.textDecorationColor).not.to.equal('');
-      document.body.appendChild(reference);
 
-      expect(getComputedStyle(link).textDecorationColor).to.equal(
-        getComputedStyle(reference).textDecorationColor,
-      );
+      expect(getComputedStyle(link).textDecorationColor).to.equal('color(srgb 1 1 1 / 0.4)');
     });
 
     it.skipIf(isJsdom())('should derive the underline color from the color prop', () => {
@@ -106,15 +93,9 @@ describe('<Link />', () => {
         </ThemeProvider>,
       );
       const link = screen.getByRole('link');
-      reference = document.createElement('span');
-      reference.style.color = '#ff5252';
-      reference.style.textDecorationColor = theme.alpha(theme.palette.primary.main, 0.4);
-      document.body.appendChild(reference);
 
-      expect(getComputedStyle(link).color).to.equal(getComputedStyle(reference).color);
-      expect(getComputedStyle(link).textDecorationColor).to.equal(
-        getComputedStyle(reference).textDecorationColor,
-      );
+      expect(getComputedStyle(link).color).to.equal('rgb(255, 82, 82)');
+      expect(getComputedStyle(link).textDecorationColor).to.equal('rgba(25, 118, 210, 0.4)');
     });
   });
 

--- a/packages/mui-material/src/Link/getTextDecoration.test.js
+++ b/packages/mui-material/src/Link/getTextDecoration.test.js
@@ -34,7 +34,12 @@ describe('getTextDecoration', () => {
       expect(getTextDecoration({ theme, ownerState: { color: 'rgb(1, 1, 1)' } })).to.equal(
         'rgba(1, 1, 1, 0.4)',
       );
-      expect(() => getTextDecoration({ theme, ownerState: { color: 'yellow' } })).to.throw();
+      expect(getTextDecoration({ theme, ownerState: { color: 'rgba(1, 1, 1, 0.4)' } })).to.equal(
+        'rgba(1, 1, 1, 0.4)',
+      );
+      expect(getTextDecoration({ theme, ownerState: { color: 'yellow' } })).to.equal(
+        'color-mix(in srgb, yellow 40%, transparent)',
+      );
     });
 
     it('work with a custom palette', () => {
@@ -109,7 +114,9 @@ describe('getTextDecoration', () => {
       expect(getTextDecoration({ theme, ownerState: { color: 'rgb(1, 1, 1)' } })).to.equal(
         'rgba(1, 1, 1, 0.4)',
       );
-      expect(() => getTextDecoration({ theme, ownerState: { color: 'yellow' } })).to.throw();
+      expect(getTextDecoration({ theme, ownerState: { color: 'yellow' } })).to.equal(
+        'color-mix(in srgb, yellow 40%, transparent)',
+      );
     });
   });
 

--- a/packages/mui-material/src/Link/getTextDecoration.test.js
+++ b/packages/mui-material/src/Link/getTextDecoration.test.js
@@ -34,7 +34,7 @@ describe('getTextDecoration', () => {
       expect(getTextDecoration({ theme, ownerState: { color: 'rgb(1, 1, 1)' } })).to.equal(
         'rgba(1, 1, 1, 0.4)',
       );
-      expect(getTextDecoration({ theme, ownerState: { color: 'rgba(1, 1, 1, 0.4)' } })).to.equal(
+      expect(getTextDecoration({ theme, ownerState: { color: 'rgba(1, 1, 1, 0.8)' } })).to.equal(
         'rgba(1, 1, 1, 0.4)',
       );
       expect(getTextDecoration({ theme, ownerState: { color: 'yellow' } })).to.equal(

--- a/packages/mui-material/src/Link/getTextDecoration.ts
+++ b/packages/mui-material/src/Link/getTextDecoration.ts
@@ -27,7 +27,12 @@ const getTextDecoration = <T extends Theme>({
   if ('vars' in theme && channelColor) {
     return `rgba(${channelColor} / 0.4)`;
   }
-  return alpha(color, 0.4);
+
+  try {
+    return alpha(color, 0.4);
+  } catch {
+    return `color-mix(in srgb, ${color} 40%, transparent)`;
+  }
 };
 
 export default getTextDecoration;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/49052.
Closes https://github.com/mui/material-ui/pull/49054.

`Link` uses `getTextDecoration` to apply 40% opacity to its underline color. For color formats supported by MUI's JavaScript color parser, this continues to use `alpha()` as before.

Valid CSS colors that the parser cannot decompose, such as named colors, previously caused `alpha()` to throw during render. This change catches that failure and falls back to CSS `color-mix()`:

```css
color-mix(in srgb, <color> 40%, transparent)
```

This prevents the render failure while preserving the existing styling behavior:

- Palette, RGB, hex, and CSS-variable colors keep their existing output.
- Named CSS colors receive the intended transparent underline.
- The underline remains derived from the `color` prop, even when `styleOverrides` or `sx` changes the rendered text color.
- Existing RGBA colors continue to use absolute 40% alpha rather than multiplying their current alpha.

Tests cover:

- Rendering a `Link` with a named CSS color without throwing.
- Applying transparency to a named CSS underline color in a browser.
- Preserving the `color` prop as the source of the underline color.
- The fallback with and without CSS theme variables.
- Existing supported color formats and custom palette colors.