### PR TITLE
[Modal] Skip scrollbar compensation when the gutter is stable

### DIFF
--- a/docs/data/material/getting-started/faq/faq.md
+++ b/docs/data/material/getting-started/faq/faq.md
@@ -28,9 +28,10 @@ Scrolling is blocked as soon as a modal is opened.
 This prevents interacting with the background when the modal should be the only interactive content. However, removing the scrollbar can make your **fixed positioned elements** move.
 In this situation, you can apply a global `.mui-fixed` class name to tell Material UI to handle those elements.
 
-Alternatively, set `scrollbar-gutter: stable` on the scroll container—usually the `html` element.
-The scrollbar space then stays reserved while the scroll is blocked, so nothing moves and the compensation is skipped entirely, including for `.mui-fixed` elements.
-This also covers fixed positioned elements that aren't annotated with `.mui-fixed`.
+Alternatively, set `scrollbar-gutter: stable` on the scroll container.
+For page scrolling that is the root `html` element—a gutter on `body` isn't propagated to the viewport, so it reserves nothing.
+The scrollbar space then stays reserved while the scroll is blocked, so nothing moves—fixed positioned elements included, whether or not they carry `.mui-fixed`—and the compensation is skipped.
+The container has to be scrollable already, since a gutter on a non-scrolling element is inert.
 Browsers without support for `scrollbar-gutter` keep the `.mui-fixed` behavior.
 
 ## How can I disable the ripple effect globally?

--- a/docs/data/material/getting-started/faq/faq.md
+++ b/docs/data/material/getting-started/faq/faq.md
@@ -28,6 +28,11 @@ Scrolling is blocked as soon as a modal is opened.
 This prevents interacting with the background when the modal should be the only interactive content. However, removing the scrollbar can make your **fixed positioned elements** move.
 In this situation, you can apply a global `.mui-fixed` class name to tell Material UI to handle those elements.
 
+Alternatively, set `scrollbar-gutter: stable` on the scroll container—usually the `html` element.
+The scrollbar space then stays reserved while the scroll is blocked, so nothing moves and the compensation is skipped entirely, including for `.mui-fixed` elements.
+This also covers fixed positioned elements that aren't annotated with `.mui-fixed`.
+Browsers without support for `scrollbar-gutter` keep the `.mui-fixed` behavior.
+
 ## How can I disable the ripple effect globally?
 
 The ripple effect is exclusively coming from the `BaseButton` component.

--- a/packages-internal/core-docs/src/AppLayout/components/AppSearch.tsx
+++ b/packages-internal/core-docs/src/AppLayout/components/AppSearch.tsx
@@ -453,6 +453,13 @@ export function AppSearch(props: AppSearchProps) {
             },
           },
           body: {
+            // DocSearch unconditionally sets `margin-right: <scrollbar width>` on the body to
+            // compensate for the scrollbar it expects to hide. It only hides the one on <body>,
+            // while the docs keep the scrollbar on <html> (overflow-y: scroll), so nothing
+            // disappears and the compensation shifts the whole page to the left instead.
+            '&.DocSearch--active': {
+              marginRight: '0 !important',
+            },
             '.DocSearch-Container': {
               transition: `opacity ${FADE_DURATION}ms`,
               opacity: 0,

--- a/packages-internal/core-docs/src/AppLayout/components/AppSearch.tsx
+++ b/packages-internal/core-docs/src/AppLayout/components/AppSearch.tsx
@@ -454,9 +454,9 @@ export function AppSearch(props: AppSearchProps) {
           },
           body: {
             // DocSearch unconditionally sets `margin-right: <scrollbar width>` on the body to
-            // compensate for the scrollbar it expects to hide. It only hides the one on <body>,
-            // while the docs keep the scrollbar on <html> (overflow-y: scroll), so nothing
-            // disappears and the compensation shifts the whole page sideways instead.
+            // compensate for the scrollbar it expects to hide. The docs reserve that space on
+            // <html> and only ever hide the overflow of <body>, so nothing disappears and the
+            // compensation shifts the whole page sideways instead.
             // It sets `margin-inline-end`, so overriding `margin-right` would miss it in RTL.
             '&.DocSearch--active': {
               marginInlineEnd: '0 !important',

--- a/packages-internal/core-docs/src/AppLayout/components/AppSearch.tsx
+++ b/packages-internal/core-docs/src/AppLayout/components/AppSearch.tsx
@@ -456,9 +456,10 @@ export function AppSearch(props: AppSearchProps) {
             // DocSearch unconditionally sets `margin-right: <scrollbar width>` on the body to
             // compensate for the scrollbar it expects to hide. It only hides the one on <body>,
             // while the docs keep the scrollbar on <html> (overflow-y: scroll), so nothing
-            // disappears and the compensation shifts the whole page to the left instead.
+            // disappears and the compensation shifts the whole page sideways instead.
+            // It sets `margin-inline-end`, so overriding `margin-right` would miss it in RTL.
             '&.DocSearch--active': {
-              marginRight: '0 !important',
+              marginInlineEnd: '0 !important',
             },
             '.DocSearch-Container': {
               transition: `opacity ${FADE_DURATION}ms`,

--- a/packages-internal/core-docs/src/branding/brandingTheme.ts
+++ b/packages-internal/core-docs/src/branding/brandingTheme.ts
@@ -1555,9 +1555,7 @@ export function getThemedComponents(): ThemeOptions {
         styleOverrides: {
           html: {
             overflowY: 'scroll',
-            // TODO add support for it,
-            // https://github.com/mui/material-ui/issues/40748
-            // scrollbarGutter: 'stable',
+            scrollbarGutter: 'stable',
           },
         },
       },

--- a/packages-internal/core-docs/src/branding/brandingTheme.ts
+++ b/packages-internal/core-docs/src/branding/brandingTheme.ts
@@ -1554,9 +1554,10 @@ export function getThemedComponents(): ThemeOptions {
         },
         styleOverrides: {
           html: {
-            // Keep both: the scroll lock only locks <html> instead of <body> when the
-            // computed overflow-y is `scroll`, and the gutter is what stops the page from
-            // shifting while it is locked.
+            // Forcing the scrollbar keeps the page from shifting between short and long
+            // pages, and is the fallback where `scrollbar-gutter` isn't supported. The
+            // gutter supersedes it elsewhere, and also holds the space while a modal
+            // blocks the scroll.
             overflowY: 'scroll',
             scrollbarGutter: 'stable',
           },

--- a/packages-internal/core-docs/src/branding/brandingTheme.ts
+++ b/packages-internal/core-docs/src/branding/brandingTheme.ts
@@ -1554,6 +1554,9 @@ export function getThemedComponents(): ThemeOptions {
         },
         styleOverrides: {
           html: {
+            // Keep both: the scroll lock only locks <html> instead of <body> when the
+            // computed overflow-y is `scroll`, and the gutter is what stops the page from
+            // shifting while it is locked.
             overflowY: 'scroll',
             scrollbarGutter: 'stable',
           },

--- a/packages/mui-material/src/Modal/ModalManager.test.ts
+++ b/packages/mui-material/src/Modal/ModalManager.test.ts
@@ -150,8 +150,7 @@ describe('ModalManager', () => {
     it.skipIf(isJsdom())(
       'should not compensate the scrollbar when the scroll container has a stable gutter',
       () => {
-        // Asserted rather than skipped: every browser in the test matrix supports the
-        // property, so losing it should fail instead of silently voiding this test.
+        // This test is useless without support.
         expect(CSS.supports('scrollbar-gutter', 'stable')).to.equal(true);
 
         fixedNode.style.paddingRight = '14.4px';

--- a/packages/mui-material/src/Modal/ModalManager.test.ts
+++ b/packages/mui-material/src/Modal/ModalManager.test.ts
@@ -1,5 +1,6 @@
 import { describe, beforeAll, afterAll, it, expect, beforeEach, afterEach } from 'vitest';
 import getScrollbarSize from '@mui/utils/getScrollbarSize';
+import { isJsdom } from '@mui/internal-test-utils';
 import { ModalManager } from './ModalManager';
 
 interface Modal {
@@ -125,6 +126,7 @@ describe('ModalManager', () => {
 
     afterEach(() => {
       document.body.removeChild(fixedNode);
+      container1.style.removeProperty('scrollbar-gutter');
       window.innerWidth -= 1;
     });
 
@@ -142,6 +144,31 @@ describe('ModalManager', () => {
       expect(container1.style.paddingRight).to.equal('20px');
       expect(fixedNode.style.paddingRight).to.equal('14.4px');
     });
+
+    // A stable scrollbar gutter keeps the scrollbar space reserved while the scroll is locked,
+    // so compensating for it would shift the content instead of keeping it in place.
+    it.skipIf(isJsdom())(
+      'should not compensate the scrollbar when the scroll container has a stable gutter',
+      (ctx) => {
+        if (!CSS.supports('scrollbar-gutter', 'stable')) {
+          ctx.skip();
+        }
+
+        fixedNode.style.paddingRight = '14.4px';
+        container1.style.setProperty('scrollbar-gutter', 'stable');
+
+        const modal = getDummyModal();
+        modalManager.add(modal, container1);
+        modalManager.mount(modal, {});
+        expect(container1.style.overflow).to.equal('hidden');
+        expect(container1.style.paddingRight).to.equal('20px');
+        expect(fixedNode.style.paddingRight).to.equal('14.4px');
+        modalManager.remove(modal);
+        expect(container1.style.overflow).to.equal('');
+        expect(container1.style.paddingRight).to.equal('20px');
+        expect(fixedNode.style.paddingRight).to.equal('14.4px');
+      },
+    );
 
     it('should disable the scroll even when not overflowing', () => {
       // simulate non-overflowing container

--- a/packages/mui-material/src/Modal/ModalManager.test.ts
+++ b/packages/mui-material/src/Modal/ModalManager.test.ts
@@ -149,10 +149,10 @@ describe('ModalManager', () => {
     // so compensating for it would shift the content instead of keeping it in place.
     it.skipIf(isJsdom())(
       'should not compensate the scrollbar when the scroll container has a stable gutter',
-      (ctx) => {
-        if (!CSS.supports('scrollbar-gutter', 'stable')) {
-          ctx.skip();
-        }
+      () => {
+        // Asserted rather than skipped: every browser in the test matrix supports the
+        // property, so losing it should fail instead of silently voiding this test.
+        expect(CSS.supports('scrollbar-gutter', 'stable')).to.equal(true);
 
         fixedNode.style.paddingRight = '14.4px';
         container1.style.setProperty('scrollbar-gutter', 'stable');

--- a/packages/mui-material/src/Modal/ModalManager.test.ts
+++ b/packages/mui-material/src/Modal/ModalManager.test.ts
@@ -169,6 +169,48 @@ describe('ModalManager', () => {
       },
     );
 
+    // Locking <body> is the default: the scroll container only resolves to <html> when its
+    // overflow-y computes to `scroll`.
+    describe.skipIf(isJsdom())('when locking the body', () => {
+      // A dedicated manager per test, so the document-wide styles these mutate can't leak
+      // into the shared one when an assertion fails before the modal is removed.
+      let bodyModalManager: ModalManager;
+
+      beforeEach(() => {
+        bodyModalManager = new ModalManager();
+      });
+
+      afterEach(() => {
+        document.documentElement.style.removeProperty('scrollbar-gutter');
+        document.body.style.removeProperty('scrollbar-gutter');
+        document.body.style.removeProperty('padding-right');
+        document.body.style.removeProperty('overflow');
+      });
+
+      it('should not compensate the scrollbar when the root element has a stable gutter', () => {
+        document.documentElement.style.setProperty('scrollbar-gutter', 'stable');
+
+        const modal = getDummyModal();
+        bodyModalManager.add(modal, document.body);
+        bodyModalManager.mount(modal, {});
+        expect(document.body.style.paddingRight).to.equal('');
+        bodyModalManager.remove(modal);
+      });
+
+      // scrollbar-gutter propagates to the viewport from the root element only, so a gutter
+      // on <body> reserves nothing and the compensation is still needed.
+      it('should compensate the scrollbar when only the body has a stable gutter', () => {
+        document.body.style.setProperty('scrollbar-gutter', 'stable');
+
+        const modal = getDummyModal();
+        bodyModalManager.add(modal, document.body);
+        bodyModalManager.mount(modal, {});
+        expect(document.body.style.paddingRight).to.equal(`${getScrollbarSize(window)}px`);
+        bodyModalManager.remove(modal);
+        expect(document.body.style.paddingRight).to.equal('');
+      });
+    });
+
     it('should disable the scroll even when not overflowing', () => {
       // simulate non-overflowing container
       const container2 = document.createElement('div');

--- a/packages/mui-material/src/Modal/ModalManager.test.ts
+++ b/packages/mui-material/src/Modal/ModalManager.test.ts
@@ -8,11 +8,6 @@ interface Modal {
   modalRef: Element;
 }
 
-// The gutter tests are useless without support, so fail loudly rather than pass vacuously.
-function expectStableGutterSupport() {
-  expect(CSS.supports('scrollbar-gutter', 'stable')).to.equal(true);
-}
-
 function getDummyModal(): Modal {
   return {
     mount: document.createElement('div'),
@@ -131,7 +126,6 @@ describe('ModalManager', () => {
 
     afterEach(() => {
       document.body.removeChild(fixedNode);
-      container1.style.removeProperty('scrollbar-gutter');
       window.innerWidth -= 1;
     });
 
@@ -150,101 +144,101 @@ describe('ModalManager', () => {
       expect(fixedNode.style.paddingRight).to.equal('14.4px');
     });
 
-    // A stable scrollbar gutter keeps the scrollbar space reserved while the scroll is locked,
-    // so compensating for it would shift the content instead of keeping it in place.
     describe.skipIf(isJsdom())('with a stable scrollbar gutter', () => {
       beforeEach(() => {
-        expectStableGutterSupport();
+        // These tests are useless without support, so fail loudly rather than pass vacuously.
+        if (!CSS.supports('scrollbar-gutter', 'stable')) {
+          throw new Error('This browser does not support scrollbar-gutter.');
+        }
         fixedNode.style.paddingRight = '14.4px';
       });
 
-      afterEach(() => {
-        container1.style.removeProperty('overflow');
+      describe('on the scroll container', () => {
+        afterEach(() => {
+          container1.style.removeProperty('overflow');
+          container1.style.removeProperty('scrollbar-gutter');
+        });
+
+        it('should not compensate the scrollbar when the scroll container has a stable gutter', () => {
+          container1.style.overflow = 'auto';
+          container1.style.setProperty('scrollbar-gutter', 'stable');
+
+          const modal = getDummyModal();
+          modalManager.add(modal, container1);
+          modalManager.mount(modal, {});
+          expect(container1.style.overflow).to.equal('hidden');
+          expect(container1.style.paddingRight).to.equal('20px');
+          expect(fixedNode.style.paddingRight).to.equal('14.4px');
+          modalManager.remove(modal);
+          expect(container1.style.overflow).to.equal('auto');
+          expect(container1.style.paddingRight).to.equal('20px');
+          expect(fixedNode.style.paddingRight).to.equal('14.4px');
+        });
+
+        // The gutter is inert until the element is a scroll container, and blocking the scroll
+        // is what turns it into one, so the space it then reserves still has to be compensated.
+        it('should compensate the scrollbar when the container is not a scroll container', () => {
+          const scrollbarSize = getScrollbarSize(window);
+          container1.style.setProperty('scrollbar-gutter', 'stable');
+
+          const modal = getDummyModal();
+          modalManager.add(modal, container1);
+          modalManager.mount(modal, {});
+          expect(container1.style.overflow).to.equal('hidden');
+          expect(container1.style.paddingRight).to.equal(`${20 + scrollbarSize}px`);
+          expect(fixedNode.style.paddingRight).to.equal(`${14.4 + scrollbarSize}px`);
+          modalManager.remove(modal);
+          expect(container1.style.paddingRight).to.equal('20px');
+          expect(fixedNode.style.paddingRight).to.equal('14.4px');
+        });
       });
 
-      it('should not compensate the scrollbar when the scroll container has a stable gutter', () => {
-        container1.style.overflow = 'auto';
-        container1.style.setProperty('scrollbar-gutter', 'stable');
+      describe('when locking the body', () => {
+        // A dedicated manager per test, so the document-wide styles these mutate can't leak
+        // into the shared one when an assertion fails before the modal is removed.
+        let bodyModalManager: ModalManager;
 
-        const modal = getDummyModal();
-        modalManager.add(modal, container1);
-        modalManager.mount(modal, {});
-        expect(container1.style.overflow).to.equal('hidden');
-        expect(container1.style.paddingRight).to.equal('20px');
-        expect(fixedNode.style.paddingRight).to.equal('14.4px');
-        modalManager.remove(modal);
-        expect(container1.style.overflow).to.equal('auto');
-        expect(container1.style.paddingRight).to.equal('20px');
-        expect(fixedNode.style.paddingRight).to.equal('14.4px');
-      });
+        beforeEach(() => {
+          bodyModalManager = new ModalManager();
+        });
 
-      // The gutter is inert until the element is a scroll container, and blocking the scroll
-      // is what turns it into one, so the space it then reserves still has to be compensated.
-      it('should compensate the scrollbar when the container is not a scroll container', () => {
-        const scrollbarSize = getScrollbarSize(window);
-        container1.style.setProperty('scrollbar-gutter', 'stable');
+        afterEach(() => {
+          document.documentElement.style.removeProperty('scrollbar-gutter');
+          document.body.style.removeProperty('scrollbar-gutter');
+          document.body.style.removeProperty('padding-right');
+          document.body.style.removeProperty('overflow');
+        });
 
-        const modal = getDummyModal();
-        modalManager.add(modal, container1);
-        modalManager.mount(modal, {});
-        expect(container1.style.overflow).to.equal('hidden');
-        expect(container1.style.paddingRight).to.equal(`${20 + scrollbarSize}px`);
-        expect(fixedNode.style.paddingRight).to.equal(`${14.4 + scrollbarSize}px`);
-        modalManager.remove(modal);
-        expect(container1.style.paddingRight).to.equal('20px');
-        expect(fixedNode.style.paddingRight).to.equal('14.4px');
-      });
-    });
+        it('should not compensate the scrollbar when the root element has a stable gutter', () => {
+          document.documentElement.style.setProperty('scrollbar-gutter', 'stable');
 
-    // Locking <body> is the default: the scroll container only resolves to <html> when its
-    // overflow-y computes to `scroll`.
-    describe.skipIf(isJsdom())('when locking the body', () => {
-      // A dedicated manager per test, so the document-wide styles these mutate can't leak
-      // into the shared one when an assertion fails before the modal is removed.
-      let bodyModalManager: ModalManager;
+          const modal = getDummyModal();
+          bodyModalManager.add(modal, document.body);
+          bodyModalManager.mount(modal, {});
+          expect(document.body.style.overflow).to.equal('hidden');
+          expect(document.body.style.paddingRight).to.equal('');
+          expect(fixedNode.style.paddingRight).to.equal('14.4px');
+          bodyModalManager.remove(modal);
+          expect(document.body.style.overflow).to.equal('');
+        });
 
-      beforeEach(() => {
-        expectStableGutterSupport();
-        bodyModalManager = new ModalManager();
-        fixedNode.style.paddingRight = '14.4px';
-      });
+        // scrollbar-gutter propagates to the viewport from the root element only, so a gutter
+        // on <body> reserves nothing and the compensation is still needed.
+        it('should compensate the scrollbar when only the body has a stable gutter', () => {
+          // Read before mounting: locking <body> propagates to the viewport, so the scrollbar
+          // is gone by the time the assertions run.
+          const scrollbarSize = getScrollbarSize(window);
+          document.body.style.setProperty('scrollbar-gutter', 'stable');
 
-      afterEach(() => {
-        document.documentElement.style.removeProperty('scrollbar-gutter');
-        document.body.style.removeProperty('scrollbar-gutter');
-        document.body.style.removeProperty('padding-right');
-        document.body.style.removeProperty('overflow');
-      });
-
-      it('should not compensate the scrollbar when the root element has a stable gutter', () => {
-        document.documentElement.style.setProperty('scrollbar-gutter', 'stable');
-
-        const modal = getDummyModal();
-        bodyModalManager.add(modal, document.body);
-        bodyModalManager.mount(modal, {});
-        expect(document.body.style.overflow).to.equal('hidden');
-        expect(document.body.style.paddingRight).to.equal('');
-        expect(fixedNode.style.paddingRight).to.equal('14.4px');
-        bodyModalManager.remove(modal);
-        expect(document.body.style.overflow).to.equal('');
-      });
-
-      // scrollbar-gutter propagates to the viewport from the root element only, so a gutter
-      // on <body> reserves nothing and the compensation is still needed.
-      it('should compensate the scrollbar when only the body has a stable gutter', () => {
-        // Read before mounting: locking <body> propagates to the viewport, so the scrollbar
-        // is gone by the time the assertions run.
-        const scrollbarSize = getScrollbarSize(window);
-        document.body.style.setProperty('scrollbar-gutter', 'stable');
-
-        const modal = getDummyModal();
-        bodyModalManager.add(modal, document.body);
-        bodyModalManager.mount(modal, {});
-        expect(document.body.style.overflow).to.equal('hidden');
-        expect(document.body.style.paddingRight).to.equal(`${scrollbarSize}px`);
-        expect(fixedNode.style.paddingRight).to.equal(`${14.4 + scrollbarSize}px`);
-        bodyModalManager.remove(modal);
-        expect(document.body.style.paddingRight).to.equal('');
+          const modal = getDummyModal();
+          bodyModalManager.add(modal, document.body);
+          bodyModalManager.mount(modal, {});
+          expect(document.body.style.overflow).to.equal('hidden');
+          expect(document.body.style.paddingRight).to.equal(`${scrollbarSize}px`);
+          expect(fixedNode.style.paddingRight).to.equal(`${14.4 + scrollbarSize}px`);
+          bodyModalManager.remove(modal);
+          expect(document.body.style.paddingRight).to.equal('');
+        });
       });
     });
 

--- a/packages/mui-material/src/Modal/ModalManager.test.ts
+++ b/packages/mui-material/src/Modal/ModalManager.test.ts
@@ -8,6 +8,11 @@ interface Modal {
   modalRef: Element;
 }
 
+// The gutter tests are useless without support, so fail loudly rather than pass vacuously.
+function expectStableGutterSupport() {
+  expect(CSS.supports('scrollbar-gutter', 'stable')).to.equal(true);
+}
+
 function getDummyModal(): Modal {
   return {
     mount: document.createElement('div'),
@@ -147,13 +152,18 @@ describe('ModalManager', () => {
 
     // A stable scrollbar gutter keeps the scrollbar space reserved while the scroll is locked,
     // so compensating for it would shift the content instead of keeping it in place.
-    it.skipIf(isJsdom())(
-      'should not compensate the scrollbar when the scroll container has a stable gutter',
-      () => {
-        // This test is useless without support.
-        expect(CSS.supports('scrollbar-gutter', 'stable')).to.equal(true);
-
+    describe.skipIf(isJsdom())('with a stable scrollbar gutter', () => {
+      beforeEach(() => {
+        expectStableGutterSupport();
         fixedNode.style.paddingRight = '14.4px';
+      });
+
+      afterEach(() => {
+        container1.style.removeProperty('overflow');
+      });
+
+      it('should not compensate the scrollbar when the scroll container has a stable gutter', () => {
+        container1.style.overflow = 'auto';
         container1.style.setProperty('scrollbar-gutter', 'stable');
 
         const modal = getDummyModal();
@@ -163,11 +173,28 @@ describe('ModalManager', () => {
         expect(container1.style.paddingRight).to.equal('20px');
         expect(fixedNode.style.paddingRight).to.equal('14.4px');
         modalManager.remove(modal);
-        expect(container1.style.overflow).to.equal('');
+        expect(container1.style.overflow).to.equal('auto');
         expect(container1.style.paddingRight).to.equal('20px');
         expect(fixedNode.style.paddingRight).to.equal('14.4px');
-      },
-    );
+      });
+
+      // The gutter is inert until the element is a scroll container, and blocking the scroll
+      // is what turns it into one, so the space it then reserves still has to be compensated.
+      it('should compensate the scrollbar when the container is not a scroll container', () => {
+        const scrollbarSize = getScrollbarSize(window);
+        container1.style.setProperty('scrollbar-gutter', 'stable');
+
+        const modal = getDummyModal();
+        modalManager.add(modal, container1);
+        modalManager.mount(modal, {});
+        expect(container1.style.overflow).to.equal('hidden');
+        expect(container1.style.paddingRight).to.equal(`${20 + scrollbarSize}px`);
+        expect(fixedNode.style.paddingRight).to.equal(`${14.4 + scrollbarSize}px`);
+        modalManager.remove(modal);
+        expect(container1.style.paddingRight).to.equal('20px');
+        expect(fixedNode.style.paddingRight).to.equal('14.4px');
+      });
+    });
 
     // Locking <body> is the default: the scroll container only resolves to <html> when its
     // overflow-y computes to `scroll`.
@@ -177,7 +204,9 @@ describe('ModalManager', () => {
       let bodyModalManager: ModalManager;
 
       beforeEach(() => {
+        expectStableGutterSupport();
         bodyModalManager = new ModalManager();
+        fixedNode.style.paddingRight = '14.4px';
       });
 
       afterEach(() => {
@@ -193,19 +222,27 @@ describe('ModalManager', () => {
         const modal = getDummyModal();
         bodyModalManager.add(modal, document.body);
         bodyModalManager.mount(modal, {});
+        expect(document.body.style.overflow).to.equal('hidden');
         expect(document.body.style.paddingRight).to.equal('');
+        expect(fixedNode.style.paddingRight).to.equal('14.4px');
         bodyModalManager.remove(modal);
+        expect(document.body.style.overflow).to.equal('');
       });
 
       // scrollbar-gutter propagates to the viewport from the root element only, so a gutter
       // on <body> reserves nothing and the compensation is still needed.
       it('should compensate the scrollbar when only the body has a stable gutter', () => {
+        // Read before mounting: locking <body> propagates to the viewport, so the scrollbar
+        // is gone by the time the assertions run.
+        const scrollbarSize = getScrollbarSize(window);
         document.body.style.setProperty('scrollbar-gutter', 'stable');
 
         const modal = getDummyModal();
         bodyModalManager.add(modal, document.body);
         bodyModalManager.mount(modal, {});
-        expect(document.body.style.paddingRight).to.equal(`${getScrollbarSize(window)}px`);
+        expect(document.body.style.overflow).to.equal('hidden');
+        expect(document.body.style.paddingRight).to.equal(`${scrollbarSize}px`);
+        expect(fixedNode.style.paddingRight).to.equal(`${14.4 + scrollbarSize}px`);
         bodyModalManager.remove(modal);
         expect(document.body.style.paddingRight).to.equal('');
       });

--- a/packages/mui-material/src/Modal/ModalManager.test.ts
+++ b/packages/mui-material/src/Modal/ModalManager.test.ts
@@ -153,92 +153,109 @@ describe('ModalManager', () => {
         fixedNode.style.paddingRight = '14.4px';
       });
 
-      describe('on the scroll container', () => {
-        afterEach(() => {
-          container1.style.removeProperty('overflow');
-          container1.style.removeProperty('scrollbar-gutter');
-        });
-
-        it('should not compensate the scrollbar when the scroll container has a stable gutter', () => {
-          container1.style.overflow = 'auto';
-          container1.style.setProperty('scrollbar-gutter', 'stable');
-
-          const modal = getDummyModal();
-          modalManager.add(modal, container1);
-          modalManager.mount(modal, {});
-          expect(container1.style.overflow).to.equal('hidden');
-          expect(container1.style.paddingRight).to.equal('20px');
-          expect(fixedNode.style.paddingRight).to.equal('14.4px');
-          modalManager.remove(modal);
-          expect(container1.style.overflow).to.equal('auto');
-          expect(container1.style.paddingRight).to.equal('20px');
-          expect(fixedNode.style.paddingRight).to.equal('14.4px');
-        });
-
-        // The gutter is inert until the element is a scroll container, and blocking the scroll
-        // is what turns it into one, so the space it then reserves still has to be compensated.
-        it('should compensate the scrollbar when the container is not a scroll container', () => {
-          const scrollbarSize = getScrollbarSize(window);
-          container1.style.setProperty('scrollbar-gutter', 'stable');
-
-          const modal = getDummyModal();
-          modalManager.add(modal, container1);
-          modalManager.mount(modal, {});
-          expect(container1.style.overflow).to.equal('hidden');
-          expect(container1.style.paddingRight).to.equal(`${20 + scrollbarSize}px`);
-          expect(fixedNode.style.paddingRight).to.equal(`${14.4 + scrollbarSize}px`);
-          modalManager.remove(modal);
-          expect(container1.style.paddingRight).to.equal('20px');
-          expect(fixedNode.style.paddingRight).to.equal('14.4px');
-        });
+      afterEach(() => {
+        container1.style.removeProperty('overflow');
+        container1.style.removeProperty('scrollbar-gutter');
+        document.documentElement.style.removeProperty('scrollbar-gutter');
+        document.body.style.removeProperty('scrollbar-gutter');
+        document.body.style.removeProperty('padding-right');
+        document.body.style.removeProperty('overflow');
       });
 
-      describe('when locking the body', () => {
-        // A dedicated manager per test, so the document-wide styles these mutate can't leak
-        // into the shared one when an assertion fails before the modal is removed.
-        let bodyModalManager: ModalManager;
+      it('should not compensate the scrollbar when the scroll container has a stable gutter', () => {
+        container1.style.overflow = 'auto';
+        container1.style.setProperty('scrollbar-gutter', 'stable');
 
-        beforeEach(() => {
-          bodyModalManager = new ModalManager();
-        });
+        const modal = getDummyModal();
+        modalManager.add(modal, container1);
+        modalManager.mount(modal, {});
+        expect(container1.style.overflow).to.equal('hidden');
+        expect(container1.style.paddingRight).to.equal('20px');
+        expect(fixedNode.style.paddingRight).to.equal('14.4px');
+        modalManager.remove(modal);
+        expect(container1.style.overflow).to.equal('auto');
+        expect(container1.style.paddingRight).to.equal('20px');
+        expect(fixedNode.style.paddingRight).to.equal('14.4px');
+      });
 
-        afterEach(() => {
-          document.documentElement.style.removeProperty('scrollbar-gutter');
-          document.body.style.removeProperty('scrollbar-gutter');
-          document.body.style.removeProperty('padding-right');
-          document.body.style.removeProperty('overflow');
-        });
+      // The gutter is inert until the element is a scroll container, and blocking the scroll
+      // is what turns it into one, so the space it then reserves still has to be compensated.
+      it('should compensate the scrollbar when the container is not a scroll container', () => {
+        const scrollbarSize = getScrollbarSize(window);
+        container1.style.setProperty('scrollbar-gutter', 'stable');
 
-        it('should not compensate the scrollbar when the root element has a stable gutter', () => {
-          document.documentElement.style.setProperty('scrollbar-gutter', 'stable');
+        const modal = getDummyModal();
+        modalManager.add(modal, container1);
+        modalManager.mount(modal, {});
+        expect(container1.style.overflow).to.equal('hidden');
+        expect(container1.style.paddingRight).to.equal(`${20 + scrollbarSize}px`);
+        expect(fixedNode.style.paddingRight).to.equal(`${14.4 + scrollbarSize}px`);
+        modalManager.remove(modal);
+        expect(container1.style.paddingRight).to.equal('20px');
+        expect(fixedNode.style.paddingRight).to.equal('14.4px');
+      });
 
-          const modal = getDummyModal();
-          bodyModalManager.add(modal, document.body);
-          bodyModalManager.mount(modal, {});
-          expect(document.body.style.overflow).to.equal('hidden');
-          expect(document.body.style.paddingRight).to.equal('');
-          expect(fixedNode.style.paddingRight).to.equal('14.4px');
-          bodyModalManager.remove(modal);
-          expect(document.body.style.overflow).to.equal('');
-        });
+      it('should not compensate the scrollbar when the root element has a stable gutter', () => {
+        // A dedicated manager, so the document-wide styles this mutates can't leak into the
+        // shared one when an assertion fails before the modal is removed.
+        const bodyModalManager = new ModalManager();
+        document.documentElement.style.setProperty('scrollbar-gutter', 'stable');
 
-        // scrollbar-gutter propagates to the viewport from the root element only, so a gutter
-        // on <body> reserves nothing and the compensation is still needed.
-        it('should compensate the scrollbar when only the body has a stable gutter', () => {
-          // Read before mounting: locking <body> propagates to the viewport, so the scrollbar
-          // is gone by the time the assertions run.
-          const scrollbarSize = getScrollbarSize(window);
-          document.body.style.setProperty('scrollbar-gutter', 'stable');
+        const modal = getDummyModal();
+        bodyModalManager.add(modal, document.body);
+        bodyModalManager.mount(modal, {});
+        expect(document.body.style.overflow).to.equal('hidden');
+        expect(document.body.style.paddingRight).to.equal('');
+        expect(fixedNode.style.paddingRight).to.equal('14.4px');
+        bodyModalManager.remove(modal);
+        expect(document.body.style.overflow).to.equal('');
+      });
 
-          const modal = getDummyModal();
-          bodyModalManager.add(modal, document.body);
-          bodyModalManager.mount(modal, {});
-          expect(document.body.style.overflow).to.equal('hidden');
-          expect(document.body.style.paddingRight).to.equal(`${scrollbarSize}px`);
-          expect(fixedNode.style.paddingRight).to.equal(`${14.4 + scrollbarSize}px`);
-          bodyModalManager.remove(modal);
-          expect(document.body.style.paddingRight).to.equal('');
-        });
+      // scrollbar-gutter propagates to the viewport from the root element only, so a gutter
+      // on <body> reserves nothing and the compensation is still needed.
+      it('should compensate the scrollbar when only the body has a stable gutter', () => {
+        const bodyModalManager = new ModalManager();
+        // Read before mounting: locking <body> propagates to the viewport, so the scrollbar
+        // is gone by the time the assertions run.
+        const scrollbarSize = getScrollbarSize(window);
+        document.body.style.setProperty('scrollbar-gutter', 'stable');
+
+        const modal = getDummyModal();
+        bodyModalManager.add(modal, document.body);
+        bodyModalManager.mount(modal, {});
+        expect(document.body.style.overflow).to.equal('hidden');
+        expect(document.body.style.paddingRight).to.equal(`${scrollbarSize}px`);
+        expect(fixedNode.style.paddingRight).to.equal(`${14.4 + scrollbarSize}px`);
+        bodyModalManager.remove(modal);
+        expect(document.body.style.paddingRight).to.equal('');
+      });
+    });
+
+    // jsdom reports a clientWidth of 0, which makes every scrollbar look wide, so a zero-width
+    // one only exists in a browser.
+    describe.skipIf(isJsdom())('with a zero-width scrollbar', () => {
+      beforeEach(() => {
+        window.innerWidth -= 1; // undo the simulated scrollbar
+        // Leave the padding to the stylesheet, so that writing it at all is observable.
+        container1.style.removeProperty('padding-right');
+      });
+
+      afterEach(() => {
+        window.innerWidth += 1;
+      });
+
+      // Overlay scrollbars (macOS, Windows 11) take no width, so there is nothing to
+      // compensate and writing the padding would only freeze what the theme had set.
+      it('should not compensate the scrollbar when it has no width', () => {
+        expect(getScrollbarSize(window)).to.equal(0);
+
+        const modal = getDummyModal();
+        modalManager.add(modal, container1);
+        modalManager.mount(modal, {});
+        expect(container1.style.overflow).to.equal('hidden');
+        expect(container1.style.paddingRight).to.equal('');
+        expect(fixedNode.style.paddingRight).to.equal('');
+        modalManager.remove(modal);
       });
     });
 

--- a/packages/mui-material/src/Modal/ModalManager.test.ts
+++ b/packages/mui-material/src/Modal/ModalManager.test.ts
@@ -165,11 +165,15 @@ describe('ModalManager', () => {
       it('should not compensate the scrollbar when the scroll container has a stable gutter', () => {
         container1.style.overflow = 'auto';
         container1.style.setProperty('scrollbar-gutter', 'stable');
+        // The premise of skipping the compensation: the gutter holds the width across the
+        // lock. Assert it rather than only asserting the decision it leads to.
+        const widthBefore = container1.clientWidth;
 
         const modal = getDummyModal();
         modalManager.add(modal, container1);
         modalManager.mount(modal, {});
         expect(container1.style.overflow).to.equal('hidden');
+        expect(container1.clientWidth).to.equal(widthBefore);
         expect(container1.style.paddingRight).to.equal('20px');
         expect(fixedNode.style.paddingRight).to.equal('14.4px');
         modalManager.remove(modal);
@@ -200,11 +204,13 @@ describe('ModalManager', () => {
         // shared one when an assertion fails before the modal is removed.
         const bodyModalManager = new ModalManager();
         document.documentElement.style.setProperty('scrollbar-gutter', 'stable');
+        const widthBefore = document.documentElement.clientWidth;
 
         const modal = getDummyModal();
         bodyModalManager.add(modal, document.body);
         bodyModalManager.mount(modal, {});
         expect(document.body.style.overflow).to.equal('hidden');
+        expect(document.documentElement.clientWidth).to.equal(widthBefore);
         expect(document.body.style.paddingRight).to.equal('');
         expect(fixedNode.style.paddingRight).to.equal('14.4px');
         bodyModalManager.remove(modal);
@@ -231,33 +237,37 @@ describe('ModalManager', () => {
       });
     });
 
-    // jsdom reports a clientWidth of 0, which makes every scrollbar look wide, so a zero-width
-    // one only exists in a browser.
-    describe.skipIf(isJsdom())('with a zero-width scrollbar', () => {
-      beforeEach(() => {
-        window.innerWidth -= 1; // undo the simulated scrollbar
-        // Leave the padding to the stylesheet, so that writing it at all is observable.
-        container1.style.removeProperty('padding-right');
-      });
+    // jsdom reports a clientWidth of 0, which makes every scrollbar look wide, and an engine
+    // rendering a classic scrollbar has no zero-width case to exercise. Measured before the
+    // hooks below adjust `innerWidth`, so this is the ambient width either way.
+    describe.skipIf(isJsdom() || getScrollbarSize(window) !== 0)(
+      'with a zero-width scrollbar',
+      () => {
+        beforeEach(() => {
+          window.innerWidth -= 1; // undo the simulated scrollbar
+          // Leave the padding to the stylesheet, so that writing it at all is observable.
+          container1.style.removeProperty('padding-right');
+        });
 
-      afterEach(() => {
-        window.innerWidth += 1;
-      });
+        afterEach(() => {
+          window.innerWidth += 1;
+        });
 
-      // Overlay scrollbars (macOS, Windows 11) take no width, so there is nothing to
-      // compensate and writing the padding would only freeze what the theme had set.
-      it('should not compensate the scrollbar when it has no width', () => {
-        expect(getScrollbarSize(window)).to.equal(0);
+        // Overlay scrollbars (macOS, Windows 11) take no width, so there is nothing to
+        // compensate and writing the padding would only freeze what the theme had set.
+        it('should not compensate the scrollbar when it has no width', () => {
+          expect(getScrollbarSize(window)).to.equal(0);
 
-        const modal = getDummyModal();
-        modalManager.add(modal, container1);
-        modalManager.mount(modal, {});
-        expect(container1.style.overflow).to.equal('hidden');
-        expect(container1.style.paddingRight).to.equal('');
-        expect(fixedNode.style.paddingRight).to.equal('');
-        modalManager.remove(modal);
-      });
-    });
+          const modal = getDummyModal();
+          modalManager.add(modal, container1);
+          modalManager.mount(modal, {});
+          expect(container1.style.overflow).to.equal('hidden');
+          expect(container1.style.paddingRight).to.equal('');
+          expect(fixedNode.style.paddingRight).to.equal('');
+          modalManager.remove(modal);
+        });
+      },
+    );
 
     it('should disable the scroll even when not overflowing', () => {
       // simulate non-overflowing container

--- a/packages/mui-material/src/Modal/ModalManager.ts
+++ b/packages/mui-material/src/Modal/ModalManager.ts
@@ -72,6 +72,25 @@ function ariaHiddenSiblings(
   });
 }
 
+// A stable scrollbar gutter keeps the scrollbar space reserved while the scroll is locked,
+// so there is no layout shift to compensate for.
+// Reading the computed value doubles as a feature detection: browsers that don't support
+// scrollbar-gutter resolve it to an empty string.
+function hasStableScrollbarGutter(scrollContainer: HTMLElement): boolean {
+  const win = ownerWindow(scrollContainer);
+  const doc = ownerDocument(scrollContainer);
+  // scrollbar-gutter isn't inherited, but the one set on the root element propagates to the
+  // viewport, so check <html> as well when locking the document scroller.
+  const elements =
+    scrollContainer === doc.body || scrollContainer === doc.documentElement
+      ? [scrollContainer, doc.documentElement]
+      : [scrollContainer];
+
+  return elements.some((element) =>
+    win.getComputedStyle(element).getPropertyValue('scrollbar-gutter').includes('stable'),
+  );
+}
+
 function handleContainer(containerInfo: Container, props: ManagedModalProps) {
   const restoreStyle: Array<{
     /**
@@ -100,7 +119,7 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
           : container;
     }
 
-    if (isOverflowing(scrollContainer)) {
+    if (isOverflowing(scrollContainer) && !hasStableScrollbarGutter(scrollContainer)) {
       // Compute the size before applying overflow hidden to avoid any scroll jumps.
       const scrollbarSize = getScrollbarSize(ownerWindow(scrollContainer));
 

--- a/packages/mui-material/src/Modal/ModalManager.ts
+++ b/packages/mui-material/src/Modal/ModalManager.ts
@@ -16,7 +16,8 @@ function isOverflowing(container: Element): boolean {
   const doc = ownerDocument(container);
 
   if (isDocumentScroller(container, doc)) {
-    return ownerWindow(container).innerWidth > doc.documentElement.clientWidth;
+    // The viewport scrollbar is visible exactly when it takes up width.
+    return getScrollbarSize(ownerWindow(container)) > 0;
   }
 
   return container.scrollHeight > container.clientHeight;
@@ -96,10 +97,11 @@ function hasStableScrollbarGutter(scrollContainer: HTMLElement): boolean {
   }
 
   const containerStyle = win.getComputedStyle(scrollContainer);
+  const { overflowY } = containerStyle;
   // The gutter only takes effect on a scroll container, so on a `visible` or `clip` container
   // the declaration is inert. Blocking the scroll below turns it into a scroll container,
   // which would create the gutter and shrink the content instead of leaving it in place.
-  if (containerStyle.overflowY === 'visible' || containerStyle.overflowY === 'clip') {
+  if (overflowY === 'visible' || overflowY === 'clip') {
     return false;
   }
 
@@ -123,7 +125,7 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
     if (container.parentNode instanceof DocumentFragment) {
       scrollContainer = ownerDocument(container).body;
     } else {
-      // Support html overflow-y: auto for scroll stability between pages
+      // Support html overflow-y: scroll for scroll stability between pages
       // https://css-tricks.com/snippets/css/force-vertical-scrollbar/
       const parent = container.parentElement;
       const containerWindow = ownerWindow(container);
@@ -134,7 +136,8 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
           : container;
     }
 
-    // Compute the size before applying overflow hidden to avoid any scroll jumps.
+    // Read the size while the scrollbar is still there, so applying overflow hidden below
+    // can't jump the scroll position.
     const scrollbarSize = getScrollbarSize(ownerWindow(scrollContainer));
 
     // Overlay scrollbars (e.g. macOS, Windows 11) have zero width — there is nothing to

--- a/packages/mui-material/src/Modal/ModalManager.ts
+++ b/packages/mui-material/src/Modal/ModalManager.ts
@@ -78,14 +78,27 @@ function ariaHiddenSiblings(
 // scrollbar-gutter resolve it to an empty string.
 function hasStableScrollbarGutter(scrollContainer: HTMLElement): boolean {
   const doc = ownerDocument(scrollContainer);
-  // Locking <body> means locking the viewport scrollbar, and only the root element's gutter
-  // propagates to the viewport — unlike overflow, which propagates from <body> too.
-  const gutterElement = scrollContainer === doc.body ? doc.documentElement : scrollContainer;
+  const win = ownerWindow(scrollContainer);
 
-  return ownerWindow(scrollContainer)
-    .getComputedStyle(gutterElement)
-    .getPropertyValue('scrollbar-gutter')
-    .includes('stable');
+  if (scrollContainer === doc.body || scrollContainer === doc.documentElement) {
+    // Locking the document scroller locks the viewport scrollbar. The viewport is always a
+    // scroll container, and only the root element's gutter propagates to it — unlike
+    // overflow, which propagates from <body> too.
+    return win
+      .getComputedStyle(doc.documentElement)
+      .getPropertyValue('scrollbar-gutter')
+      .includes('stable');
+  }
+
+  const containerStyle = win.getComputedStyle(scrollContainer);
+  // The gutter only takes effect on a scroll container, so on a `visible` or `clip` container
+  // the declaration is inert. Blocking the scroll below turns it into a scroll container,
+  // which would create the gutter and shrink the content instead of leaving it in place.
+  if (containerStyle.overflowY === 'visible' || containerStyle.overflowY === 'clip') {
+    return false;
+  }
+
+  return containerStyle.getPropertyValue('scrollbar-gutter').includes('stable');
 }
 
 function handleContainer(containerInfo: Container, props: ManagedModalProps) {
@@ -116,10 +129,17 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
           : container;
     }
 
-    if (isOverflowing(scrollContainer) && !hasStableScrollbarGutter(scrollContainer)) {
-      // Compute the size before applying overflow hidden to avoid any scroll jumps.
-      const scrollbarSize = getScrollbarSize(ownerWindow(scrollContainer));
+    // Compute the size before applying overflow hidden to avoid any scroll jumps.
+    const scrollbarSize = getScrollbarSize(ownerWindow(scrollContainer));
 
+    // Overlay scrollbars (e.g. macOS, Windows 11) have zero width — there is nothing to
+    // compensate for, and writing the inline styles anyway would freeze the current padding,
+    // overriding later theme/CSS changes.
+    if (
+      scrollbarSize > 0 &&
+      isOverflowing(scrollContainer) &&
+      !hasStableScrollbarGutter(scrollContainer)
+    ) {
       restoreStyle.push({
         value: scrollContainer.style.paddingRight,
         property: 'padding-right',

--- a/packages/mui-material/src/Modal/ModalManager.ts
+++ b/packages/mui-material/src/Modal/ModalManager.ts
@@ -77,18 +77,15 @@ function ariaHiddenSiblings(
 // Reading the computed value doubles as a feature detection: browsers that don't support
 // scrollbar-gutter resolve it to an empty string.
 function hasStableScrollbarGutter(scrollContainer: HTMLElement): boolean {
-  const win = ownerWindow(scrollContainer);
   const doc = ownerDocument(scrollContainer);
-  // scrollbar-gutter isn't inherited, but the one set on the root element propagates to the
-  // viewport, so check <html> as well when locking the document scroller.
-  const elements =
-    scrollContainer === doc.body || scrollContainer === doc.documentElement
-      ? [scrollContainer, doc.documentElement]
-      : [scrollContainer];
+  // Unlike overflow, scrollbar-gutter only propagates to the viewport from the root element,
+  // never from <body>, so a gutter declared on <body> reserves no space for the page scrollbar.
+  const gutterElement = scrollContainer === doc.body ? doc.documentElement : scrollContainer;
 
-  return elements.some((element) =>
-    win.getComputedStyle(element).getPropertyValue('scrollbar-gutter').includes('stable'),
-  );
+  return ownerWindow(scrollContainer)
+    .getComputedStyle(gutterElement)
+    .getPropertyValue('scrollbar-gutter')
+    .includes('stable');
 }
 
 function handleContainer(containerInfo: Container, props: ManagedModalProps) {

--- a/packages/mui-material/src/Modal/ModalManager.ts
+++ b/packages/mui-material/src/Modal/ModalManager.ts
@@ -6,11 +6,16 @@ export interface ManagedModalProps {
   disableScrollLock?: boolean | undefined;
 }
 
+// Both <body> and <html> scroll the viewport rather than themselves.
+function isDocumentScroller(element: Element, doc: Document): boolean {
+  return element === doc.body || element === doc.documentElement;
+}
+
 // Is a vertical scrollbar displayed?
 function isOverflowing(container: Element): boolean {
   const doc = ownerDocument(container);
 
-  if (container === doc.body || container === doc.documentElement) {
+  if (isDocumentScroller(container, doc)) {
     return ownerWindow(container).innerWidth > doc.documentElement.clientWidth;
   }
 
@@ -80,7 +85,7 @@ function hasStableScrollbarGutter(scrollContainer: HTMLElement): boolean {
   const doc = ownerDocument(scrollContainer);
   const win = ownerWindow(scrollContainer);
 
-  if (scrollContainer === doc.body || scrollContainer === doc.documentElement) {
+  if (isDocumentScroller(scrollContainer, doc)) {
     // Locking the document scroller locks the viewport scrollbar. The viewport is always a
     // scroll container, and only the root element's gutter propagates to it — unlike
     // overflow, which propagates from <body> too.

--- a/packages/mui-material/src/Modal/ModalManager.ts
+++ b/packages/mui-material/src/Modal/ModalManager.ts
@@ -78,8 +78,8 @@ function ariaHiddenSiblings(
 // scrollbar-gutter resolve it to an empty string.
 function hasStableScrollbarGutter(scrollContainer: HTMLElement): boolean {
   const doc = ownerDocument(scrollContainer);
-  // Unlike overflow, scrollbar-gutter only propagates to the viewport from the root element,
-  // never from <body>, so a gutter declared on <body> reserves no space for the page scrollbar.
+  // Locking <body> means locking the viewport scrollbar, and only the root element's gutter
+  // propagates to the viewport — unlike overflow, which propagates from <body> too.
   const gutterElement = scrollContainer === doc.body ? doc.documentElement : scrollContainer;
 
   return ownerWindow(scrollContainer)


### PR DESCRIPTION
The docs set `html { overflow-y: scroll }`. Opening a Select sets `overflow: hidden` on `<html>`, so the scrollbar vanishes and right-anchored fixed elements jump — most visibly the cookie banner.

`scrollbar-gutter: stable` fixes that, but enabling it alone shifted the page the other way: `isOverflowing()` is still true while a gutter is reserved, so the scroll container got a `padding-right` nothing cancelled out. `ModalManager` now skips the compensation when the computed gutter is stable. Unsupported browsers resolve it to `''` and keep today's behaviour. Docs opt in.

Separately, the search box shifted left because `@docsearch/react` sets `margin-right: <scrollbar width>` on the body to compensate for a scrollbar that never disappears here.

Closes #40748 (was moved to base ui before)

try it out on https://deploy-preview-49079--material-ui.netlify.app/material-ui/react-select/