### PR TITLE
[docs] Fix the dead Popper.js documentation links

### DIFF
--- a/docs/data/material/components/popper/popper.md
+++ b/docs/data/material/components/popper/popper.md
@@ -12,7 +12,7 @@ githubSource: packages/mui-material/src/Popper
 
 Some important features of the Popper component:
 
-- 🕷 Popper relies on the 3rd party library ([Popper.js](https://popper.js.org/docs/v2/)) for perfect positioning.
+- 🕷 Popper relies on the 3rd party library ([Popper.js](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/index.md)) for perfect positioning.
 - 💄 It's an alternative API to react-popper. It aims for simplicity.
 - Its child element is a [Portal](/material-ui/react-portal/) on the body of the document to avoid rendering problems.
   You can disable this behavior with `disablePortal`.
@@ -57,7 +57,7 @@ Alternatively, you can use [react-spring](https://github.com/pmndrs/react-spring
 ## Virtual element
 
 The value of the `anchorEl` prop can be a reference to a fake DOM element.
-You need to create an object shaped like the [`VirtualElement`](https://popper.js.org/docs/v2/virtual-elements/).
+You need to create an object shaped like the [`VirtualElement`](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/virtual-elements.md).
 
 Highlight part of the text to see the popper:
 

--- a/docs/data/material/components/tooltips/tooltips.md
+++ b/docs/data/material/components/tooltips/tooltips.md
@@ -60,7 +60,7 @@ You can use the `arrow` prop to give your tooltip an arrow indicating which elem
 
 ## Distance from anchor
 
-To adjust the distance between the tooltip and its anchor, you can use the `slotProps` prop to modify the [offset](https://popper.js.org/docs/v2/modifiers/offset/) of the popper.
+To adjust the distance between the tooltip and its anchor, you can use the `slotProps` prop to modify the [offset](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/modifiers/offset.md) of the popper.
 
 {{"demo": "TooltipOffset.js"}}
 
@@ -185,7 +185,7 @@ You can enable the tooltip to follow the cursor by setting `followCursor={true}`
 
 In the event you need to implement a custom placement, you can use the `anchorEl` prop:
 The value of the `anchorEl` prop can be a reference to a fake DOM element.
-You need to create an object shaped like the [`VirtualElement`](https://popper.js.org/docs/v2/virtual-elements/).
+You need to create an object shaped like the [`VirtualElement`](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/virtual-elements.md).
 
 {{"demo": "AnchorElTooltips.js"}}
 

--- a/docs/data/material/migration/migration-v4/v5-component-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-component-changes.md
@@ -1172,7 +1172,7 @@ The `getContentAnchorEl` prop was removed to simplify the positioning logic.
 
 ### Upgrade from v1 to v2
 
-Upgrade [Popper.js](https://popper.js.org/) from v1 to v2.
+Upgrade [Popper.js](https://github.com/floating-ui/popper-docs) from v1 to v2.
 
 The CSS prefixes have changed:
 
@@ -1197,7 +1197,7 @@ Method names have changed:
 
 The Modifiers API has been changed too significantly to fully cover here.
 
-Read the [Popper.js migration guide](https://popper.js.org/docs/v2/migration-guide/) for complete details.
+Read the [Popper.js migration guide](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/migration-guide.md) for complete details.
 
 ## Portal
 

--- a/docs/translations/api-docs/popper/popper.json
+++ b/docs/translations/api-docs/popper/popper.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "anchorEl": {
-      "description": "An HTML element, <a href=\"https://popper.js.org/docs/v2/virtual-elements/\">virtualElement</a>, or a function that returns either. It&#39;s used to set the position of the popper. The return value will passed as the reference object of the Popper instance."
+      "description": "An HTML element, <a href=\"https://github.com/floating-ui/popper-docs/blob/main/docs/v2/virtual-elements.md\">virtualElement</a>, or a function that returns either. It&#39;s used to set the position of the popper. The return value will passed as the reference object of the Popper instance."
     },
     "children": { "description": "Popper render function or node." },
     "component": {
@@ -18,12 +18,12 @@
       "description": "Always keep the children in the DOM. This prop can be useful in SEO situation or when you want to maximize the responsiveness of the Popper."
     },
     "modifiers": {
-      "description": "Popper.js is based on a &quot;plugin-like&quot; architecture, most of its features are fully encapsulated &quot;modifiers&quot;.<br>A modifier is a function that is called each time Popper.js needs to compute the position of the popper. For this reason, modifiers should be very performant to avoid bottlenecks. To learn how to create a modifier, <a href=\"https://popper.js.org/docs/v2/modifiers/\">read the modifiers documentation</a>."
+      "description": "Popper.js is based on a &quot;plugin-like&quot; architecture, most of its features are fully encapsulated &quot;modifiers&quot;.<br>A modifier is a function that is called each time Popper.js needs to compute the position of the popper. For this reason, modifiers should be very performant to avoid bottlenecks. To learn how to create a modifier, <a href=\"https://github.com/floating-ui/popper-docs/blob/main/docs/v2/modifiers/index.md\">read the modifiers documentation</a>."
     },
     "open": { "description": "If <code>true</code>, the component is shown." },
     "placement": { "description": "Popper placement." },
     "popperOptions": {
-      "description": "Options provided to the <a href=\"https://popper.js.org/docs/v2/constructors/#options\"><code>Popper.js</code></a> instance."
+      "description": "Options provided to the <a href=\"https://github.com/floating-ui/popper-docs/blob/main/docs/v2/constructors.md#options\"><code>Popper.js</code></a> instance."
     },
     "popperRef": { "description": "A ref that points to the used popper instance." },
     "slotProps": { "description": "The props used for each slot inside the Popper." },

--- a/packages/mui-material/src/Popper/BasePopper.tsx
+++ b/packages/mui-material/src/Popper/BasePopper.tsx
@@ -347,7 +347,7 @@ Popper.propTypes /* remove-proptypes */ = {
   // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
   // └─────────────────────────────────────────────────────────────────────┘
   /**
-   * An HTML element, [virtualElement](https://popper.js.org/docs/v2/virtual-elements/),
+   * An HTML element, [virtualElement](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/virtual-elements.md),
    * or a function that returns either.
    * It's used to set the position of the popper.
    * The return value will passed as the reference object of the Popper instance.
@@ -392,7 +392,7 @@ Popper.propTypes /* remove-proptypes */ = {
             [
               'MUI: The `anchorEl` prop provided to the component is invalid.',
               'It should be an HTML element instance or a virtualElement ',
-              '(https://popper.js.org/docs/v2/virtual-elements/).',
+              '(https://github.com/floating-ui/popper-docs/blob/main/docs/v2/virtual-elements.md).',
             ].join('\n'),
           );
         }
@@ -446,7 +446,7 @@ Popper.propTypes /* remove-proptypes */ = {
    * A modifier is a function that is called each time Popper.js needs to
    * compute the position of the popper.
    * For this reason, modifiers should be very performant to avoid bottlenecks.
-   * To learn how to create a modifier, [read the modifiers documentation](https://popper.js.org/docs/v2/modifiers/).
+   * To learn how to create a modifier, [read the modifiers documentation](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/modifiers/index.md).
    */
   modifiers: PropTypes.arrayOf(
     PropTypes.shape({
@@ -497,7 +497,7 @@ Popper.propTypes /* remove-proptypes */ = {
     'top',
   ]),
   /**
-   * Options provided to the [`Popper.js`](https://popper.js.org/docs/v2/constructors/#options) instance.
+   * Options provided to the [`Popper.js`](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/constructors.md#options) instance.
    * @default {}
    */
   popperOptions: PropTypes.shape({

--- a/packages/mui-material/src/Popper/BasePopper.types.ts
+++ b/packages/mui-material/src/Popper/BasePopper.types.ts
@@ -21,7 +21,7 @@ export interface PopperChildrenProps {
 
 export interface PopperOwnProps {
   /**
-   * An HTML element, [virtualElement](https://popper.js.org/docs/v2/virtual-elements/),
+   * An HTML element, [virtualElement](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/virtual-elements.md),
    * or a function that returns either.
    * It's used to set the position of the popper.
    * The return value will passed as the reference object of the Popper instance.
@@ -67,7 +67,7 @@ export interface PopperOwnProps {
    * A modifier is a function that is called each time Popper.js needs to
    * compute the position of the popper.
    * For this reason, modifiers should be very performant to avoid bottlenecks.
-   * To learn how to create a modifier, [read the modifiers documentation](https://popper.js.org/docs/v2/modifiers/).
+   * To learn how to create a modifier, [read the modifiers documentation](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/modifiers/index.md).
    */
   modifiers?: Options['modifiers'] | undefined;
   /**
@@ -80,7 +80,7 @@ export interface PopperOwnProps {
    */
   placement?: PopperPlacementType | undefined;
   /**
-   * Options provided to the [`Popper.js`](https://popper.js.org/docs/v2/constructors/#options) instance.
+   * Options provided to the [`Popper.js`](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/constructors.md#options) instance.
    * @default {}
    */
   popperOptions?: Partial<OptionsGeneric<any>> | undefined;

--- a/packages/mui-material/src/Popper/Popper.tsx
+++ b/packages/mui-material/src/Popper/Popper.tsx
@@ -98,7 +98,7 @@ Popper.propTypes /* remove-proptypes */ = {
   // │ To update them, edit the TypeScript types and run `pnpm proptypes`. │
   // └─────────────────────────────────────────────────────────────────────┘
   /**
-   * An HTML element, [virtualElement](https://popper.js.org/docs/v2/virtual-elements/),
+   * An HTML element, [virtualElement](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/virtual-elements.md),
    * or a function that returns either.
    * It's used to set the position of the popper.
    * The return value will passed as the reference object of the Popper instance.
@@ -153,7 +153,7 @@ Popper.propTypes /* remove-proptypes */ = {
    * A modifier is a function that is called each time Popper.js needs to
    * compute the position of the popper.
    * For this reason, modifiers should be very performant to avoid bottlenecks.
-   * To learn how to create a modifier, [read the modifiers documentation](https://popper.js.org/docs/v2/modifiers/).
+   * To learn how to create a modifier, [read the modifiers documentation](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/modifiers/index.md).
    */
   modifiers: PropTypes.arrayOf(
     PropTypes.shape({
@@ -204,7 +204,7 @@ Popper.propTypes /* remove-proptypes */ = {
     'top',
   ]),
   /**
-   * Options provided to the [`Popper.js`](https://popper.js.org/docs/v2/constructors/#options) instance.
+   * Options provided to the [`Popper.js`](https://github.com/floating-ui/popper-docs/blob/main/docs/v2/constructors.md#options) instance.
    * @default {}
    */
   popperOptions: PropTypes.shape({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #49080

`popper.js.org` has been decommissioned and now serves a JS.ORG placeholder, so every link into it 404s, including the `popperOptions` reference on the Popper API page. Popper became Floating UI along the way, and `popperjs/popper-core` redirects to `floating-ui/floating-ui`.

The maintainers kept the v1 and v2 pages in [floating-ui/popper-docs](https://github.com/floating-ui/popper-docs), laid out so the old URLs map straight onto files, so this repoints each link there. Material UI still ships `@popperjs/core@^2`, which makes the v2 reference the right target; the Floating UI docs describe a different API. `CHANGELOG.old.md` keeps its original link as a historical record.

`pnpm proptypes` and `pnpm docs:api` produce no further changes.
