### PR TITLE
[Tooltip] Close when a scroll moves the trigger away from the cursor

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -219,6 +219,21 @@ export function testReset() {
   hystersisTimer.clear();
 }
 
+function isCursorOver(element, cursorPosition) {
+  if (!element) {
+    return false;
+  }
+
+  const rect = element.getBoundingClientRect();
+
+  return (
+    cursorPosition.x >= rect.left &&
+    cursorPosition.x <= rect.right &&
+    cursorPosition.y >= rect.top &&
+    cursorPosition.y <= rect.bottom
+  );
+}
+
 function composeEventHandler(handler, eventHandler) {
   return (event, ...params) => {
     if (eventHandler) {
@@ -265,6 +280,10 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   const [arrowRef, setArrowRef] = React.useState(null);
   const ignoreNonTouchEvents = React.useRef(false);
   const openedByDisabledTriggerRef = React.useRef(false);
+  const popperNodeRef = React.useRef(null);
+  // Where the cursor was when it last entered the trigger or the tooltip.
+  // `null` when the tooltip was not opened by a cursor, i.e. by focus or by touch.
+  const cursorPositionRef = React.useRef(null);
 
   const disableInteractive = disableInteractiveProp || followCursor;
 
@@ -335,6 +354,9 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     if (ignoreNonTouchEvents.current && event.type !== 'touchstart') {
       return;
     }
+
+    cursorPositionRef.current =
+      event.type === 'mouseover' ? { x: event.clientX, y: event.clientY } : null;
 
     // Remove the title ahead of time.
     // We don't want to wait for the next render commit.
@@ -490,6 +512,42 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     };
   }, [handleClose, open]);
 
+  // Scrolling moves the trigger out from under a motionless cursor without the browser
+  // firing any pointer event, so the tooltip would stay open with nothing hovered.
+  // https://github.com/mui/material-ui/issues/44548
+  const handleScroll = useEventCallback((nativeEvent) => {
+    const cursorPosition = cursorPositionRef.current;
+
+    // A tooltip opened by focus stays open as long as the trigger is focused, and a touch
+    // interaction leaves no cursor behind. Neither is affected by a scroll.
+    if (!cursorPosition) {
+      return;
+    }
+
+    if (
+      isCursorOver(childNode, cursorPosition) ||
+      (!disableInteractive && isCursorOver(popperNodeRef.current, cursorPosition))
+    ) {
+      return;
+    }
+
+    handleMouseLeave(nativeEvent);
+  });
+
+  React.useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    // `scroll` does not bubble, the listener has to run in the capture phase to catch
+    // scrolls happening in any container between the document and the trigger.
+    document.addEventListener('scroll', handleScroll, true);
+
+    return () => {
+      document.removeEventListener('scroll', handleScroll, true);
+    };
+  }, [handleScroll, open]);
+
   const handleRef = useForkRef(getReactElementRef(children), setChildNode, ref);
 
   // There is no point in displaying an empty tooltip.
@@ -639,6 +697,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     externalForwardedProps,
     ownerState,
     className: classes.popper,
+    ref: popperNodeRef,
   });
 
   const [TransitionSlot, transitionSlotProps] = useSlot('transition', {

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -632,6 +632,135 @@ describe('<Tooltip />', () => {
     });
   });
 
+  describe('scroll', () => {
+    // JSDOM has no layout, the rects the component reads have to be provided by the test.
+    function setRect(element, { top, left, bottom, right }) {
+      element.getBoundingClientRect = () => ({
+        top,
+        left,
+        bottom,
+        right,
+        x: left,
+        y: top,
+        width: right - left,
+        height: bottom - top,
+        toJSON() {},
+      });
+    }
+
+    function renderTooltip(props) {
+      const handleClose = spy();
+
+      render(
+        <div data-testid="scroller">
+          <Tooltip
+            title="Hello World"
+            enterDelay={100}
+            leaveDelay={111}
+            onClose={handleClose}
+            slotProps={{ transition: { timeout: 10 } }}
+            {...props}
+          >
+            <button type="submit">Hello World</button>
+          </Tooltip>
+        </div>,
+      );
+
+      const trigger = screen.getByRole('button');
+      setRect(trigger, { top: 0, left: 0, bottom: 20, right: 100 });
+
+      return { handleClose, trigger };
+    }
+
+    it('should close when a scroll moves the trigger away from the cursor', async () => {
+      const { handleClose, trigger } = renderTooltip();
+
+      fireEvent.mouseOver(trigger, { clientX: 50, clientY: 10 });
+      clock.tick(100);
+
+      expect(screen.getByRole('tooltip')).toBeVisible();
+
+      // The container scrolls under a motionless cursor: the trigger is no longer below it.
+      setRect(trigger, { top: -60, left: 0, bottom: -40, right: 100 });
+      fireEvent.scroll(screen.getByTestId('scroller'));
+      // Popper schedules its update in a microtask, flush it before moving on.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      clock.tick(111);
+      clock.tick(10);
+
+      expect(handleClose.callCount).to.equal(1);
+      expect(screen.queryByRole('tooltip')).to.equal(null);
+    });
+
+    it('should stay open when the cursor is still over the trigger after the scroll', async () => {
+      const { handleClose, trigger } = renderTooltip();
+
+      fireEvent.mouseOver(trigger, { clientX: 50, clientY: 10 });
+      clock.tick(100);
+
+      // Scrolled by 5px only, the cursor is still within the trigger.
+      setRect(trigger, { top: -5, left: 0, bottom: 15, right: 100 });
+      fireEvent.scroll(document);
+      // Popper schedules its update in a microtask, flush it before moving on.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      clock.tick(111);
+      clock.tick(10);
+
+      expect(handleClose.callCount).to.equal(0);
+      expect(screen.getByRole('tooltip')).toBeVisible();
+    });
+
+    it('should stay open when the cursor is over an interactive tooltip', async () => {
+      const { handleClose, trigger } = renderTooltip();
+
+      fireEvent.mouseOver(trigger, { clientX: 50, clientY: 10 });
+      clock.tick(100);
+
+      // The cursor moved from the trigger onto the tooltip.
+      const tooltip = screen.getByRole('tooltip');
+      fireEvent.mouseLeave(trigger);
+      fireEvent.mouseOver(tooltip, { clientX: 50, clientY: 60 });
+      setRect(trigger, { top: -40, left: 0, bottom: -20, right: 100 });
+      setRect(tooltip, { top: 50, left: 0, bottom: 80, right: 100 });
+      fireEvent.scroll(document);
+      // Popper schedules its update in a microtask, flush it before moving on.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      clock.tick(111);
+      clock.tick(10);
+
+      expect(handleClose.callCount).to.equal(0);
+      expect(screen.queryByRole('tooltip')).not.to.equal(null);
+    });
+
+    it('should not close a tooltip that was not opened by the cursor', async () => {
+      const enterTouchDelay = 700;
+      const { handleClose, trigger } = renderTooltip({ enterTouchDelay });
+
+      fireEvent.touchStart(trigger);
+      clock.tick(enterTouchDelay + 100);
+
+      expect(screen.getByRole('tooltip')).toBeVisible();
+
+      setRect(trigger, { top: -60, left: 0, bottom: -40, right: 100 });
+      fireEvent.scroll(document);
+      // Popper schedules its update in a microtask, flush it before moving on.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      clock.tick(111);
+      clock.tick(10);
+
+      expect(handleClose.callCount).to.equal(0);
+      expect(screen.queryByRole('tooltip')).not.to.equal(null);
+    });
+  });
+
   describe('mount', () => {
     it('should mount without any issue', () => {
       render(

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -633,7 +633,17 @@ describe('<Tooltip />', () => {
   });
 
   describe('scroll', () => {
-    // JSDOM has no layout, the rects the component reads have to be provided by the test.
+    // The trigger sits away from the viewport origin so that the tooltip is never rendered
+    // under the real pointer of the browser running the test, which would fire a genuine
+    // `mouseover` and overwrite the cursor position the test is simulating.
+    const TRIGGER_RECT = { top: 100, left: 100, bottom: 120, right: 200 };
+    const TOOLTIP_RECT = { top: 130, left: 100, bottom: 160, right: 200 };
+    const SCROLLED_AWAY_RECT = { top: 20, left: 100, bottom: 40, right: 200 };
+    const CURSOR_ON_TRIGGER = { clientX: 150, clientY: 110 };
+    const CURSOR_ON_TOOLTIP = { clientX: 150, clientY: 140 };
+
+    // Neither JSDOM nor a freshly laid out popper gives the test control over the
+    // geometry the component reads, so every rect it looks at is provided here.
     function setRect(element, { top, left, bottom, right }) {
       element.getBoundingClientRect = () => ({
         top,
@@ -667,28 +677,34 @@ describe('<Tooltip />', () => {
       );
 
       const trigger = screen.getByRole('button');
-      setRect(trigger, { top: 0, left: 0, bottom: 20, right: 100 });
+      setRect(trigger, TRIGGER_RECT);
 
       return { handleClose, trigger };
     }
 
-    it('should close when a scroll moves the trigger away from the cursor', async () => {
-      const { handleClose, trigger } = renderTooltip();
-
-      fireEvent.mouseOver(trigger, { clientX: 50, clientY: 10 });
-      clock.tick(100);
-
-      expect(screen.getByRole('tooltip')).toBeVisible();
-
-      // The container scrolls under a motionless cursor: the trigger is no longer below it.
-      setRect(trigger, { top: -60, left: 0, bottom: -40, right: 100 });
-      fireEvent.scroll(screen.getByTestId('scroller'));
+    async function scroll(element) {
+      fireEvent.scroll(element);
       // Popper schedules its update in a microtask, flush it before moving on.
       await act(async () => {
         await Promise.resolve();
       });
       clock.tick(111);
       clock.tick(10);
+    }
+
+    it('should close when a scroll moves the trigger away from the cursor', async () => {
+      const { handleClose, trigger } = renderTooltip();
+
+      fireEvent.mouseOver(trigger, CURSOR_ON_TRIGGER);
+      clock.tick(100);
+
+      const tooltip = screen.getByRole('tooltip');
+      expect(tooltip).toBeVisible();
+      setRect(tooltip, TOOLTIP_RECT);
+
+      // The container scrolls under a motionless cursor: nothing is below it anymore.
+      setRect(trigger, SCROLLED_AWAY_RECT);
+      await scroll(screen.getByTestId('scroller'));
 
       expect(handleClose.callCount).to.equal(1);
       expect(screen.queryByRole('tooltip')).to.equal(null);
@@ -697,42 +713,32 @@ describe('<Tooltip />', () => {
     it('should stay open when the cursor is still over the trigger after the scroll', async () => {
       const { handleClose, trigger } = renderTooltip();
 
-      fireEvent.mouseOver(trigger, { clientX: 50, clientY: 10 });
+      fireEvent.mouseOver(trigger, CURSOR_ON_TRIGGER);
       clock.tick(100);
+      setRect(screen.getByRole('tooltip'), TOOLTIP_RECT);
 
       // Scrolled by 5px only, the cursor is still within the trigger.
-      setRect(trigger, { top: -5, left: 0, bottom: 15, right: 100 });
-      fireEvent.scroll(document);
-      // Popper schedules its update in a microtask, flush it before moving on.
-      await act(async () => {
-        await Promise.resolve();
-      });
-      clock.tick(111);
-      clock.tick(10);
+      setRect(trigger, { ...TRIGGER_RECT, top: 95, bottom: 115 });
+      await scroll(document);
 
       expect(handleClose.callCount).to.equal(0);
-      expect(screen.getByRole('tooltip')).toBeVisible();
+      expect(screen.queryByRole('tooltip')).not.to.equal(null);
     });
 
     it('should stay open when the cursor is over an interactive tooltip', async () => {
       const { handleClose, trigger } = renderTooltip();
 
-      fireEvent.mouseOver(trigger, { clientX: 50, clientY: 10 });
+      fireEvent.mouseOver(trigger, CURSOR_ON_TRIGGER);
       clock.tick(100);
 
       // The cursor moved from the trigger onto the tooltip.
       const tooltip = screen.getByRole('tooltip');
+      setRect(tooltip, TOOLTIP_RECT);
       fireEvent.mouseLeave(trigger);
-      fireEvent.mouseOver(tooltip, { clientX: 50, clientY: 60 });
-      setRect(trigger, { top: -40, left: 0, bottom: -20, right: 100 });
-      setRect(tooltip, { top: 50, left: 0, bottom: 80, right: 100 });
-      fireEvent.scroll(document);
-      // Popper schedules its update in a microtask, flush it before moving on.
-      await act(async () => {
-        await Promise.resolve();
-      });
-      clock.tick(111);
-      clock.tick(10);
+      fireEvent.mouseOver(tooltip, CURSOR_ON_TOOLTIP);
+
+      setRect(trigger, SCROLLED_AWAY_RECT);
+      await scroll(document);
 
       expect(handleClose.callCount).to.equal(0);
       expect(screen.queryByRole('tooltip')).not.to.equal(null);
@@ -745,16 +751,12 @@ describe('<Tooltip />', () => {
       fireEvent.touchStart(trigger);
       clock.tick(enterTouchDelay + 100);
 
-      expect(screen.getByRole('tooltip')).toBeVisible();
+      const tooltip = screen.getByRole('tooltip');
+      expect(tooltip).toBeVisible();
+      setRect(tooltip, TOOLTIP_RECT);
 
-      setRect(trigger, { top: -60, left: 0, bottom: -40, right: 100 });
-      fireEvent.scroll(document);
-      // Popper schedules its update in a microtask, flush it before moving on.
-      await act(async () => {
-        await Promise.resolve();
-      });
-      clock.tick(111);
-      clock.tick(10);
+      setRect(trigger, SCROLLED_AWAY_RECT);
+      await scroll(document);
 
       expect(handleClose.callCount).to.equal(0);
       expect(screen.queryByRole('tooltip')).not.to.equal(null);


### PR DESCRIPTION
Closes #44548

## Problem

Hover a tooltip trigger, then scroll without moving the mouse: the trigger slides out from under the cursor, but the browser fires no pointer event, so `onMouseLeave` never runs and the tooltip stays open over unrelated content.

[Repro from the issue](https://stackblitz.com/edit/react-44fyjx?file=LastName.js) — hover a tooltip, scroll away, the tooltip is still there.

This matches what was agreed in the issue thread:

> Closing when the cursor leaves the trigger no matter the reason (scroll, actual cursor move) feels more correct to me. — @mj12albert

> I agree, closing the Tooltip when scrolling away seems a better default. — @aarongarciah

and the ARIA pattern quoted there: the tooltip *"remains open as long as the cursor is over the trigger or the tooltip"*. React Aria and Radix already behave this way.

## Solution

`handleMouseOver` already funnels every open path, so it records where the cursor was — and records `null` when the event was not a `mouseover`, which is exactly the focus and touch cases.

While the tooltip is open, a capture-phase `scroll` listener on the document (mirroring the existing `Escape` listener right above it) closes the tooltip when that remembered point is no longer over the trigger nor over the tooltip. It goes through `handleMouseLeave`, so `leaveDelay` and `onClose` behave exactly as they do when the cursor physically leaves.

Deliberately unchanged:

- **Opened by focus** — the tooltip stays as long as the trigger is focused, per the ARIA pattern.
- **Opened by touch** — there is no cursor to leave behind.
- **Cursor still on the trigger** — a small scroll that keeps the pointer inside the trigger does not close it.
- **Cursor on the tooltip** — an interactive tooltip under the pointer stays open.

The listener only exists while a tooltip is open, and in practice the first scroll event removes it again.

## Testing

Four tests in a new `scroll` block. The first one fails on `master` (`expected +0 to equal 1` — `onClose` is never called) and passes with the fix; the other three lock in the cases that must *not* change.

```
Test Files  1 passed (1)
     Tests  86 passed | 18 skipped (104)
```

The whole `@mui/material` suite is unchanged: `4687 passed` on this branch vs `4683 passed` on `master` (the 4 new tests), with the same single pre-existing `Select` failure — `does not select an option when the opening mouseup lands on it before the drag delay` — present on both, and passing in isolation either way.

`pnpm eslint`, `pnpm typescript` and `prettier --check` are clean on the touched files.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
