### PR TITLE
[code-infra] Pin the only-allow version in the preinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "9.4.0",
   "private": true,
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
+    "preinstall": "npx only-allow@1.2.2 pnpm",
     "proptypes": "tsx ./scripts/generateProptypes.ts",
     "deduplicate": "pnpm dedupe",
     "build": "lerna run build --ignore docs",


### PR DESCRIPTION
The root `preinstall` hook ran `npx only-allow pnpm`. Because the version is unpinned, `npx` resolves and executes whatever the registry currently serves for `only-allow`, so a future release could change what runs during install with no review here.

Pin it to `only-allow@1.2.2`. Kept as a one-line `npx` call (rather than a committed script) so the same change propagates trivially to the other repos that use this preinstall hook.
