### PR TITLE
[docs-infra] Rate-limit the documentation feedback endpoint

### DIFF
--- a/netlify/functions/feedback-management.mts
+++ b/netlify/functions/feedback-management.mts
@@ -1,6 +1,16 @@
 import querystring from 'node:querystring';
 import { App, AwsLambdaReceiver, BlockAction, ButtonAction } from '@slack/bolt';
-import { Handler } from '@netlify/functions';
+import { Handler, type Config } from '@netlify/functions';
+
+// Rate-limit this public, unauthenticated endpoint so one client can't flood Slack with posts.
+export const config: Config = {
+  path: ['/.netlify/functions/feedback-management', '/.netlify/functions/feedback-management/'],
+  rateLimit: {
+    windowLimit: 6,
+    windowSize: 60,
+    aggregateBy: 'ip',
+  },
+};
 
 const X_FEEBACKS_CHANNEL_ID = 'C04U3R2V9UK';
 const JOY_FEEBACKS_CHANNEL_ID = 'C050VE13HDL';


### PR DESCRIPTION
The docs feedback function is public and unauthenticated — any POST with `callback_id: "send_feedback"` makes the bot post to an internal Slack channel, with no per-client limit. This adds Netlify's built-in rate limiting via the function `config` (enforced by the platform before the handler runs, so throttled requests never reach Slack or spend a function invocation).

Set to 6 requests/minute per IP — enough for genuine feedback while cutting off automated spam.
