### PR TITLE
[material-ui][Pagination] Add tests for zero boundary and sibling counts

### DIFF
--- a/packages/mui-material/src/Pagination/Pagination.test.js
+++ b/packages/mui-material/src/Pagination/Pagination.test.js
@@ -278,4 +278,14 @@ describe('<Pagination />', () => {
 
     expect(resultsRef.current).toHaveFocus();
   });
+
+  it('renders no page button when count is zero', () => {
+    render(<Pagination count={0} boundaryCount={0} siblingCount={0} />);
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).to.have.length(2);
+    buttons.forEach((button) => {
+      expect(button).to.have.attribute('disabled');
+    });
+  });
 });

--- a/packages/mui-material/src/usePagination/usePagination.test.js
+++ b/packages/mui-material/src/usePagination/usePagination.test.js
@@ -178,4 +178,52 @@ describe('usePagination', () => {
       'next',
     ]);
   });
+
+  it('should never render a page item outside of the count range', () => {
+    [0, 1, 2, 3, 4, 5, 11].forEach((count) => {
+      [1, 3, 7].forEach((page) => {
+        const items = renderHook(() =>
+          usePagination({ count, page, boundaryCount: 0, siblingCount: 0 }),
+        ).result.current.items;
+        serialize(items)
+          .filter((item) => typeof item === 'number')
+          .forEach((item) => {
+            expect(item).to.be.within(1, count);
+          });
+      });
+    });
+  });
+
+  it('should keep every page reachable when they all fit', () => {
+    let items;
+
+    items = renderHook(() =>
+      usePagination({ count: 2, page: 1, boundaryCount: 0, siblingCount: 0 }),
+    ).result.current.items;
+    expect(serialize(items)).to.deep.equal(['previous', 1, 2, 'next']);
+
+    items = renderHook(() =>
+      usePagination({ count: 3, page: 2, boundaryCount: 0, siblingCount: 0 }),
+    ).result.current.items;
+    expect(serialize(items)).to.deep.equal(['previous', 1, 2, 3, 'next']);
+
+    items = renderHook(() =>
+      usePagination({ count: 4, page: 1, boundaryCount: 0, siblingCount: 0 }),
+    ).result.current.items;
+    expect(serialize(items)).to.deep.equal(['previous', 1, 2, 'end-ellipsis', 'next']);
+  });
+
+  it('should stay navigable without previous & next buttons', () => {
+    const items = renderHook(() =>
+      usePagination({
+        count: 3,
+        page: 2,
+        boundaryCount: 0,
+        siblingCount: 0,
+        hidePrevButton: true,
+        hideNextButton: true,
+      }),
+    ).result.current.items;
+    expect(serialize(items)).to.deep.equal([1, 2, 3]);
+  });
 });


### PR DESCRIPTION
There's almost no coverage for `boundaryCount={0} siblingCount={0}`. The one test we have uses `count: 11`, and the Pagination test called "boundaryCount is zero" sets `siblingCount={1}`, so it never hits this code path.

These check what the hook does today, not what we might want it to do. #49090 changes this path to show only the current page, which also hides pages that were clickable before when the count is small. Merging these first means that PR has to change a test on purpose.
