### PR TITLE
[material-ui][Pagination] Add tests for page links near the edges

### DIFF
--- a/packages/mui-material/src/Pagination/Pagination.test.js
+++ b/packages/mui-material/src/Pagination/Pagination.test.js
@@ -279,6 +279,23 @@ describe('<Pagination />', () => {
     expect(resultsRef.current).toHaveFocus();
   });
 
+  it('keeps a page reachable when both navigation buttons are hidden', () => {
+    render(
+      <Pagination
+        count={4}
+        page={3}
+        boundaryCount={0}
+        siblingCount={0}
+        hidePrevButton
+        hideNextButton
+      />,
+    );
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).to.have.length(2);
+    expect(buttons.map((button) => button.textContent)).to.deep.equal(['3', '4']);
+  });
+
   it('renders no page button when count is zero', () => {
     render(<Pagination count={0} boundaryCount={0} siblingCount={0} />);
 

--- a/packages/mui-material/src/usePagination/usePagination.test.js
+++ b/packages/mui-material/src/usePagination/usePagination.test.js
@@ -226,4 +226,73 @@ describe('usePagination', () => {
     ).result.current.items;
     expect(serialize(items)).to.deep.equal([1, 2, 3]);
   });
+
+  it('should link a neighbouring page when the current page is near an edge', () => {
+    [4, 5, 8, 11].forEach((count) => {
+      [1, 2, count - 1, count].forEach((page) => {
+        const items = renderHook(() =>
+          usePagination({ count, page, boundaryCount: 0, siblingCount: 0 }),
+        ).result.current.items;
+        const pages = serialize(items).filter((item) => typeof item === 'number');
+        expect(pages.length, `count=${count} page=${page}`).to.be.at.least(2);
+      });
+    });
+  });
+
+  it('should keep the neighbouring page linked when count is 4', () => {
+    let items;
+
+    items = renderHook(() =>
+      usePagination({ count: 4, page: 2, boundaryCount: 0, siblingCount: 0 }),
+    ).result.current.items;
+    expect(serialize(items)).to.deep.equal(['previous', 1, 2, 'end-ellipsis', 'next']);
+
+    items = renderHook(() =>
+      usePagination({ count: 4, page: 3, boundaryCount: 0, siblingCount: 0 }),
+    ).result.current.items;
+    expect(serialize(items)).to.deep.equal(['previous', 'start-ellipsis', 3, 4, 'next']);
+
+    items = renderHook(() =>
+      usePagination({ count: 4, page: 4, boundaryCount: 0, siblingCount: 0 }),
+    ).result.current.items;
+    expect(serialize(items)).to.deep.equal(['previous', 'start-ellipsis', 3, 4, 'next']);
+  });
+
+  it('should keep the neighbouring page linked on the first & last pages', () => {
+    let items;
+
+    items = renderHook(() =>
+      usePagination({ count: 11, page: 1, boundaryCount: 0, siblingCount: 0 }),
+    ).result.current.items;
+    expect(serialize(items)).to.deep.equal(['previous', 1, 2, 'end-ellipsis', 'next']);
+
+    items = renderHook(() =>
+      usePagination({ count: 11, page: 2, boundaryCount: 0, siblingCount: 0 }),
+    ).result.current.items;
+    expect(serialize(items)).to.deep.equal(['previous', 1, 2, 'end-ellipsis', 'next']);
+
+    items = renderHook(() =>
+      usePagination({ count: 11, page: 10, boundaryCount: 0, siblingCount: 0 }),
+    ).result.current.items;
+    expect(serialize(items)).to.deep.equal(['previous', 'start-ellipsis', 10, 11, 'next']);
+
+    items = renderHook(() =>
+      usePagination({ count: 11, page: 11, boundaryCount: 0, siblingCount: 0 }),
+    ).result.current.items;
+    expect(serialize(items)).to.deep.equal(['previous', 'start-ellipsis', 10, 11, 'next']);
+  });
+
+  it('should stay navigable without previous & next buttons when count is 4', () => {
+    const items = renderHook(() =>
+      usePagination({
+        count: 4,
+        page: 3,
+        boundaryCount: 0,
+        siblingCount: 0,
+        hidePrevButton: true,
+        hideNextButton: true,
+      }),
+    ).result.current.items;
+    expect(serialize(items)).to.deep.equal(['start-ellipsis', 3, 4]);
+  });
 });


### PR DESCRIPTION
With `boundaryCount={0} siblingCount={0}` we lose a page link when the current page is one of the first two or last two. On an 11-page pagination, page 1 loses the link to page 2. It happens at every count from 4 up. These tests pass on master and fail on #49090.

Two of them matter most: the edge invariant here and the button-count test in `Pagination.test.js`. They also pass under a fix that just strips the ellipses and keeps the links, so they don't assume one implementation. The three deep-equal tests pin the ellipses too, so any version of this feature will need to update them.

Draft because it may be easier to fold these into #49090.
