### PR TITLE
[test] Fix flaky DocSearch modal screenshots

### DIFF
--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -324,6 +324,9 @@ async function main() {
         // The modal portals to `document.body`, so it lands outside the
         // testcase element and has to be screenshotted on its own.
         await page.getByRole('button', { name: /search/i }).click();
+        // The click leaves the pointer on the button. Move it to the top-right corner,
+        // outside the modal at both widths, so that no hover state gets into a capture.
+        await page.mouse.move(page.viewportSize().width - 1, 0);
         const modal = await page.waitForSelector('.DocSearch-Modal');
         // `useLazyCSS` fetches the DocSearch stylesheet and injects it as a
         // `<style data-href>`. Without it the modal is unstyled.


### PR DESCRIPTION
The Argos captures of the DocSearch modal sometimes show the hover state of the MUI X "Overview" link on the start screen. The current master baseline of `regression-AppSearch/SearchModalDarkOpen.png` has it, and so does https://app.argos-ci.com/mui/material-ui/builds/51991/454471015.

The test now moves the pointer to the top-right corner right after the click that opens the modal. That point is outside the modal at both capture widths, so no hover state gets into a capture.

- Locally, the 4 AppSearch regression tests pass, and the captures are byte-identical with and without the change.
- The same change ran on #48983. Its Argos build https://app.argos-ci.com/mui/material-ui/builds/52001 shows the "Overview" link without the hover.
- Argos on this PR can show a diff in the Open captures, because the master baseline has the hover. That diff is expected.

Extracted from #48983, so that it can merge before the DocSearch bump.
