### PR TITLE
[code-infra] Compare the nightly React runs with the stable Argos build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,10 +245,10 @@ jobs:
               equal: [stable, << parameters.react-version >>]
           steps:
             - run:
-                name: Use a separate Argos build name
-                # Argos compares only builds with the same name, so this keeps the
-                # react@17/18/next runs out of the baseline that PRs compare against.
-                command: echo 'export ARGOS_BUILD_NAME="$CIRCLE_JOB"' >> "$BASH_ENV"
+                name: Mark the Argos upload as a subset build
+                # Argos never uses subset builds as baselines, and it ignores the
+                # screenshots that the react@17/18/next runs skip.
+                command: echo 'export ARGOS_SUBSET=true' >> "$BASH_ENV"
       - code-infra/argos-push
   test_bundling_prepare:
     <<: *default-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,16 @@ jobs:
           # pnpm-workspace.yaml (overrides) and may touch pnpm-lock.yaml. Exclude those so
           # this check still verifies the a11y results without tripping on the pinned deps.
           command: git add -A -- . ':(exclude)pnpm-*.yaml' && git diff --exit-code --staged
+      - when:
+          condition:
+            not:
+              equal: [stable, << parameters.react-version >>]
+          steps:
+            - run:
+                name: Use a separate Argos build name
+                # Argos compares only builds with the same name, so this keeps the
+                # react@17/18/next runs out of the baseline that PRs compare against.
+                command: echo 'export ARGOS_BUILD_NAME="$CIRCLE_JOB"' >> "$BASH_ENV"
       - code-infra/argos-push
   test_bundling_prepare:
     <<: *default-job


### PR DESCRIPTION
The nightly `test_regressions-react@18` and `test_regressions-react@next` jobs upload to Argos like the normal `test_regressions` run. Master auto-approves every build, and Argos uses the last approved build on the merge-base commit as the baseline. So a nightly run can become the baseline that PRs compare against, and a React-specific difference never fails.

For example, the nightly React 18 build was the last build on `5ce5a0f` (https://app.argos-ci.com/mui/material-ui/builds/52007). The React 18 run skips `CrudDashboard` since #49027, so #49122 showed `CrudDashboard.png` as added (https://app.argos-ci.com/mui/material-ui/builds/52015/456363749).

This PR sets three variables for the non-stable React runs (react@17, react@18, react@next):
- `ARGOS_SUBSET=true`: Argos never uses a subset build as a baseline, and it ignores the screenshots that the run skips (https://argos-ci.com/docs/learn/how-to-guides/ci-pipelines/subset-builds).
- `ARGOS_BRANCH=$CIRCLE_JOB`: the build is not on master, so Argos does not auto-approve it, and a React-specific difference fails.
- `ARGOS_REFERENCE_COMMIT=$CIRCLE_SHA1`: Argos compares the build with the stable run of the same commit. Without it, the SDK can look for a merge base with a branch that does not exist on origin, and then the build has no baseline.

`ARGOS_BRANCH` needs `@mui/internal-code-infra` 0.0.4-canary.115 (https://github.com/mui/mui-public/pull/1853), which master has since #49125. The other two variables worked before.

The nightly build keeps the default build name, so its result replaces the `argos` status of the stable run on that commit. A React-specific difference then shows as a failed check on master. Accepted differences need a skip rule in `test/regressions/demoMeta.ts`, like `minReactMajor` from #49027, because the baseline is always the stable run.

The `test_regressions` job on this PR uses the stable React version, so it skips the new step. To see the new behavior before the merge, trigger the `nightly` workflow on this branch.
